### PR TITLE
【front】Recommendページを追加し、Home/Recommendテンプレートを共通化

### DIFF
--- a/frontend/src/api/internal/media/list.ts
+++ b/frontend/src/api/internal/media/list.ts
@@ -3,10 +3,14 @@ import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
 import { SearchParms, MediaHome, Video, Music, Comic, Picture, Blog, Chat } from 'types/internal/media'
-import { apiHome, apiVideos, apiMusics, apiComics, apiPictures, apiBlogs, apiChats } from 'api/uri'
+import { apiHome, apiRecommend, apiVideos, apiMusics, apiComics, apiPictures, apiBlogs, apiChats } from 'api/uri'
 
 export const getHome = async (params: SearchParms, req?: Req): Promise<ApiOut<MediaHome>> => {
   return await apiOut(apiClient('json').get(apiHome, cookieHeader(req, params)))
+}
+
+export const getRecommend = async (params: SearchParms, req?: Req): Promise<ApiOut<MediaHome>> => {
+  return await apiOut(apiClient('json').get(apiRecommend, cookieHeader(req, params)))
 }
 
 export const getVideos = async (params: SearchParms, req?: Req): Promise<ApiOut<Video[]>> => {

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -32,7 +32,8 @@ export const apiChannelSubscribe = base + '/channel/subscribe'
 export const apiChannel = (ulid: string) => base + `/channel/${ulid}`
 
 // Media
-export const apiHome = base + '/home'
+export const apiHome = base + '/media/home'
+export const apiRecommend = base + '/media/recommend'
 
 export const apiVideos = base + '/media/video'
 export const apiVideo = (ulid: string) => base + `/media/video/${ulid}`

--- a/frontend/src/components/templates/media/home/list.tsx
+++ b/frontend/src/components/templates/media/home/list.tsx
@@ -11,17 +11,18 @@ import PictureCard from 'components/widgets/Card/Media/Picture'
 import VideoCard from 'components/widgets/Card/Media/Video'
 
 interface Props {
+  title: string
   mediaHome: MediaHome
 }
 
 export default function Homes(props: Props): React.JSX.Element {
-  const { mediaHome } = props
+  const { title, mediaHome } = props
   const { videos, musics, comics, pictures, blogs, chats } = mediaHome
 
   const search = useSearch([videos, musics, comics, pictures, blogs, chats])
 
   return (
-    <Main title="Home" search={search}>
+    <Main title={title} search={search}>
       <Divide />
       <CardIndexList title="Video">
         {videos?.map((media) => (

--- a/frontend/src/pages/recommend.tsx
+++ b/frontend/src/pages/recommend.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { MediaHome } from 'types/internal/media'
-import { getHome } from 'api/internal/media/list'
+import { getRecommend } from 'api/internal/media/list'
 import { searchParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Homes from 'components/templates/media/home/list'
@@ -9,7 +9,7 @@ import Homes from 'components/templates/media/home/list'
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const params = searchParams(query)
-  const ret = await getHome(params)
+  const ret = await getRecommend(params)
   if (ret.isErr()) return { props: { status: ret.error.status } }
   const mediaHome = ret.value
   return { props: { ...translations, mediaHome } }
@@ -20,10 +20,10 @@ interface Props {
   mediaHome: MediaHome
 }
 
-export default function HomesPage(props: Props): React.JSX.Element {
+export default function RecommendPage(props: Props): React.JSX.Element {
   return (
     <ErrorCheck status={props.status}>
-      <Homes title="Home" {...props} />
+      <Homes title="Recommend" {...props} />
     </ErrorCheck>
   )
 }


### PR DESCRIPTION
## Summary
- Recommend（急上昇）ページを`/recommend`に新規追加
- HomeとRecommendのテンプレートを`title` propsで共通化
- `apiHome`のURLパスを`/home`から`/media/home`に修正

## 変更内容

### 新規: pages/recommend.tsx
- `getRecommend` APIを呼び出し、`Homes`コンポーネントに`title="Recommend"`で表示
- バックエンドのPR #674（`/media/recommend` API）と対応

### テンプレート共通化
- `templates/media/home/list.tsx` — `title: string` propsを追加、`<Main title={title}>`で動的に
- `pages/index.tsx` — `title="Home"`を明示的に渡す

### API追加
- `api/uri.ts` — `apiRecommend`（`/media/recommend`）を追加
- `api/internal/media/list.ts` — `getRecommend`関数を追加

### バグ修正
- `apiHome`のURLパスを`/home`から`/media/home`に修正（バックエンドのルーティングと一致）