### PR TITLE
【front】mypageのチャンネル選択横にチャンネル作成ボタンを配置

### DIFF
--- a/frontend/src/components/templates/setting/mypage/index.tsx
+++ b/frontend/src/components/templates/setting/mypage/index.tsx
@@ -28,6 +28,7 @@ export default function SettingMyPage(props: Props): React.JSX.Element {
 
   const handleEdit = () => router.push('/setting/mypage/edit')
   const handleUserPage = () => router.push(`/userpage/${mypage.ulid}`)
+  const handleCreateChannel = () => router.push('/setting/mypage/channel/create')
   const handleSelectChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
 
   const channel = channels.find((c) => c.ulid === channelUlid)
@@ -80,7 +81,10 @@ export default function SettingMyPage(props: Props): React.JSX.Element {
         </TableRow>
       </Table>
 
-      <SelectBox value={channelUlid} options={channelOptions} onChange={handleSelectChannel} className={style.channel} />
+      <HStack gap="8" justify="between" className={style.channel_area}>
+        <SelectBox value={channelUlid} options={channelOptions} onChange={handleSelectChannel} className={style.channel} />
+        <Button color="green" size="s" name="チャンネル作成" onClick={handleCreateChannel} />
+      </HStack>
 
       <Table>
         {channel && (


### PR DESCRIPTION
## Summary
- mypage設定ページのチャンネル選択SelectBoxの横に「チャンネル作成」ボタンを配置
- ボタンクリックで `/setting/mypage/channel/create` へ遷移

## 変更内容
### `frontend/src/components/templates/setting/mypage/index.tsx`
- `handleCreateChannel` ハンドラを追加し、チャンネル作成ページへ遷移するよう実装
- 既存のSelectBoxを `HStack`（gap="8", justify="between"）でラップし、右側に `Button`（color="green", size="s"）を配置

## 備考
- 遷移先ページ `/setting/mypage/channel/create` および作成API は未実装のため、別PRで対応が必要