### PR TITLE
【front】signup画面を参考にチャンネル作成画面を実装

### DIFF
--- a/frontend/src/api/internal/channel.ts
+++ b/frontend/src/api/internal/channel.ts
@@ -2,13 +2,17 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { Channel, ChannelIn, SubscribeIn, SubscribeOut } from 'types/internal/channel'
+import { Channel, ChannelCreateOut, ChannelIn, SubscribeIn, SubscribeOut } from 'types/internal/channel'
 import { ErrorOut } from 'types/internal/other'
-import { apiChannel, apiChannelUser, apiChannelSubscribe } from 'api/uri'
+import { apiChannel, apiChannelCreate, apiChannelUser, apiChannelSubscribe } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const getChannels = async (req?: Req): Promise<ApiOut<Channel[]>> => {
   return await apiOut(apiClient('json').get(apiChannelUser, cookieHeader(req)))
+}
+
+export const postChannel = async (request: ChannelIn): Promise<ApiOut<ChannelCreateOut>> => {
+  return await apiOut(apiClient('form').post(apiChannelCreate, camelSnake(request)))
 }
 
 export const putChannel = async (ulid: string, request: ChannelIn): Promise<ApiOut<ErrorOut>> => {

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -27,6 +27,7 @@ export const apiSettingMypage = base + '/setting/mypage'
 export const apiSettingNotification = base + '/setting/notification'
 
 // Channel
+export const apiChannelCreate = base + '/channel'
 export const apiChannelUser = base + '/channel/user'
 export const apiChannelSubscribe = base + '/channel/subscribe'
 export const apiChannel = (ulid: string) => base + `/channel/${ulid}`

--- a/frontend/src/components/templates/setting/mypage/channel/create.tsx
+++ b/frontend/src/components/templates/setting/mypage/channel/create.tsx
@@ -1,0 +1,102 @@
+import { ChangeEvent, useState } from 'react'
+import { useRouter } from 'next/router'
+import { ChannelIn } from 'types/internal/channel'
+import { postChannel } from 'api/internal/channel'
+import { FetchError } from 'utils/constants/enum'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Footer from 'components/layout/Footer'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import ExImage from 'components/parts/ExImage'
+import IconPerson from 'components/parts/Icon/Person'
+import Input from 'components/parts/Input'
+import InputImage from 'components/parts/Input/Image'
+import Textarea from 'components/parts/Input/Textarea'
+import VStack from 'components/parts/Stack/Vertical'
+import style from '../../Setting.module.scss'
+
+const initChannel: ChannelIn = {
+  name: '',
+  description: '',
+}
+
+export default function ChannelCreate(): React.JSX.Element {
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { message, handleError } = useApiError({ handleToast })
+  const [avatarFile, setAvatarFile] = useState<File>()
+  const [values, setValues] = useState<ChannelIn>(initChannel)
+
+  const avatarUrl = avatarFile ? URL.createObjectURL(avatarFile) : ''
+
+  const handleBack = () => router.push('/setting/mypage')
+  const handleAvatar = (files: File | File[]) => Array.isArray(files) || setAvatarFile(files)
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleSubmit = async () => {
+    const { name } = values
+    if (!isRequiredCheck({ name })) return
+    handleLoading(true)
+    const ret = await postChannel({ ...values, avatarFile })
+    handleLoading(false)
+    if (ret.isErr()) {
+      const message = ret.error.message
+      handleError(FetchError.Post, message)
+      return
+    }
+    handleBack()
+  }
+
+  return (
+    <Main metaTitle="チャンネル作成" toast={toast}>
+      <article className="article_registration">
+        <form method="POST" action="" className="form_account">
+          <h1 className="signup_h1">チャンネル作成</h1>
+
+          {message && (
+            <ul className="messages_signup">
+              <li>{message}</li>
+            </ul>
+          )}
+
+          <VStack gap="8">
+            <VStack gap="4" align="center">
+              <p>アバター画像</p>
+              <InputImage
+                id="avatar"
+                className={style.account_image_edit}
+                icon={
+                  avatarUrl ? (
+                    <div className={style.account_image}>
+                      <ExImage src={avatarUrl} size="56" />
+                    </div>
+                  ) : (
+                    <div className={style.account_image_edit}>
+                      <IconPerson size="56" type="square" />
+                    </div>
+                  )
+                }
+                onChange={handleAvatar}
+              />
+            </VStack>
+
+            <Input name="name" placeholder="チャンネル名" maxLength={50} required={isRequired} onChange={handleInput} />
+            <Textarea name="description" placeholder="説明" onChange={handleText} />
+          </VStack>
+
+          <VStack gap="12" className="mv_40">
+            <Button color="green" size="l" name="作成" type="submit" loading={isLoading} onClick={handleSubmit} />
+            <Button color="blue" size="l" name="戻る" onClick={handleBack} />
+          </VStack>
+        </form>
+      </article>
+      <Footer />
+    </Main>
+  )
+}

--- a/frontend/src/pages/setting/mypage/channel/create.tsx
+++ b/frontend/src/pages/setting/mypage/channel/create.tsx
@@ -1,0 +1,21 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ChannelCreate from 'components/templates/setting/mypage/channel/create'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  return { props: { ...translations } }
+}
+
+interface Props {
+  status: number
+}
+
+export default function ChannelCreatePage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ChannelCreate />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/types/internal/channel.d.ts
+++ b/frontend/src/types/internal/channel.d.ts
@@ -14,6 +14,10 @@ export interface ChannelIn {
   description: string
 }
 
+export interface ChannelCreateOut {
+  ulid: string
+}
+
 export interface SubscribeIn {
   channelUlid: string
   isSubscribe: boolean


### PR DESCRIPTION
## Summary
- signup画面のレイアウトを踏襲したチャンネル作成画面を新規追加
- mypageから `/setting/mypage/channel/create` に遷移してチャンネルを作成できるように

## 変更内容

### 画面・ルーティング
- `pages/setting/mypage/channel/create.tsx`: 認証チェック付きのページエントリ（`getSettingMypage` で認可確認 → `ErrorCheck` でラップ）
- `components/templates/setting/mypage/channel/create.tsx`: signup画面のクラス（`article_registration` / `form_account` / `signup_h1` / `messages_signup`）と `VStack` 構造を踏襲したテンプレート
  - アバター画像アップロード（`InputImage` + `ExImage` プレビュー）
  - チャンネル名（必須・`useRequired`）
  - 説明（`Textarea`）
  - green「作成」/ blue「戻る」ボタン

### API / 型
- `api/uri.ts`: `apiChannelCreate = base + '/channel'` を追加
- `api/internal/channel.ts`: `postChannel(request)` を追加（`form` クライアント + `camelSnake`）
- `types/internal/channel.d.ts`: `ChannelCreateOut { ulid }` を追加

## 備考
- バックエンドの `POST /channel` エンドポイントは本PRには含まれていません（別途実装が必要）。エンドポイントが未実装の状態では作成ボタン押下時にエラーになります