### PR TITLE
【back】ChannelのPOST APIを追加し、ユーザチャンネル取得をID順に整列

### DIFF
--- a/myus/api/src/adapter/channel.py
+++ b/myus/api/src/adapter/channel.py
@@ -1,11 +1,11 @@
 from django.http import HttpRequest
 from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
-from api.src.types.schema.channel import ChannelIn, ChannelOut
+from api.src.types.schema.channel import ChannelCreateOut, ChannelIn, ChannelOut
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.subscribe import SubscribeIn, SubscribeOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.channel import get_user_channels, update_user_channel
+from api.src.usecase.channel import create_user_channel, get_user_channels, update_user_channel
 from api.src.usecase.subscribe import get_subscribe_channels, upsert_subscribe
 from api.utils.functions.index import create_url
 
@@ -80,6 +80,21 @@ class ChannelAPI:
 
         data = SubscribeOut(is_subscribe=subscribe.is_subscribe, count=subscribe.count)
         return 200, data
+
+    @staticmethod
+    @router.post("", response={201: ChannelCreateOut, 400: ErrorOut, 401: ErrorOut})
+    def post(request: HttpRequest, input: ChannelIn = Form(...), avatar_file: UploadedFile = File(None)):
+        log.info("ChannelAPI post", input=input)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        new_ulid = create_user_channel(user_id, input, avatar_file)
+        if new_ulid is None:
+            return 400, ErrorOut(message="作成に失敗しました!")
+
+        return 201, ChannelCreateOut(ulid=new_ulid)
 
     @staticmethod
     @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})

--- a/myus/api/src/domain/interface/channel/interface.py
+++ b/myus/api/src/domain/interface/channel/interface.py
@@ -5,8 +5,7 @@ from api.src.domain.interface.channel.data import ChannelData
 
 
 class SortType(Enum):
-    CREATED = auto()
-    UPDATED = auto()
+    ID = auto()
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,8 +17,8 @@ class FilterOption:
 
 @dataclass(frozen=True, slots=True)
 class SortOption:
-    is_asc: bool = False
-    sort_type: SortType = SortType.CREATED
+    is_asc: bool = True
+    sort_type: SortType = SortType.ID
 
 
 class ChannelInterface(ABC):

--- a/myus/api/src/types/schema/channel.py
+++ b/myus/api/src/types/schema/channel.py
@@ -14,3 +14,7 @@ class ChannelOut(BaseModel):
     is_default: bool
     description: str
     count: int
+
+
+class ChannelCreateOut(BaseModel):
+    ulid: str

--- a/myus/api/src/usecase/channel.py
+++ b/myus/api/src/usecase/channel.py
@@ -1,8 +1,9 @@
 from dataclasses import replace
+from django_ulid.models import ulid
 from ninja import UploadedFile
 from api.modules.logger import log
 from api.src.domain.interface.channel.data import ChannelData
-from api.src.domain.interface.channel.interface import ChannelInterface, FilterOption, SortOption
+from api.src.domain.interface.channel.interface import ChannelInterface, FilterOption, SortOption, SortType
 from api.src.injectors.container import injector
 from api.src.types.schema.channel import ChannelIn
 from api.utils.enum.index import ImageUpload
@@ -37,8 +38,32 @@ def get_user_channels(owner_id: int) -> list[ChannelData]:
         log.warning("Channel not found", owner_id=owner_id)
         return []
 
-    data = repository.bulk_get(ids)
-    return data
+    return repository.bulk_get(ids)
+
+
+def create_user_channel(user_id: int, input: ChannelIn, avatar_file: UploadedFile) -> str | None:
+    repository = injector.get(ChannelInterface)
+    new_ulid = str(ulid.new())
+    avatar = save_upload(avatar_file, ImageUpload.CHANNEL, new_ulid) if avatar_file else ""
+
+    data = ChannelData(
+        id=0,
+        ulid=new_ulid,
+        owner_id=user_id,
+        owner_ulid="",
+        avatar=avatar,
+        name=input.name,
+        description=input.description,
+        is_default=False,
+        count=0,
+    )
+
+    try:
+        repository.bulk_save([data])
+        return new_ulid
+    except Exception as e:
+        log.error("create_user_channel error", exc=e)
+        return None
 
 
 def update_user_channel(user_id: int, ulid: str, input: ChannelIn, avatar_file: UploadedFile) -> bool:


### PR DESCRIPTION
## Summary
- `POST /channel` エンドポイントを追加（avatar画像対応）
- mypageなどのチャンネル選択でユーザチャンネルをID昇順で返すよう変更

## 変更内容

### API
- `api/src/adapter/channel.py`: `post` エンドポイントを追加（`Form` + `File`、成功時 `201` で `ChannelCreateOut { ulid }` を返却）
- `api/src/types/schema/channel.py`: `ChannelCreateOut` スキーマを追加

### Usecase
- `api/src/usecase/channel.py`:
  - `create_user_channel(user_id, input, avatar_file)` を追加。新規ULID発行 → avatar保存 → `bulk_save` → 成功時に `ulid` を返却
  - `get_user_channels` は `SortOption()`（デフォルトで ID 昇順）で取得するよう変更

### Domain
- `api/src/domain/interface/channel/interface.py`:
  - `SortType` を `ID` に変更（`CREATED` / `UPDATED` を削除）
  - `SortOption` のデフォルトを `is_asc=True` / `sort_type=SortType.ID` に変更

## 関連
- PR #677 （フロントエンドのチャンネル作成画面）と対になります