### PR TITLE
【front】dev起動時のhostnameを127.0.0.1に固定

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6686,7 +6686,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --hostname 127.0.0.1",
     "build": "next build",
     "start": "next start",
     "test": "jest",


### PR DESCRIPTION
## Summary
- `next dev`の起動オプションに`--hostname 127.0.0.1`を追加
- 127.0.0.1経由でアクセスした際にHMR WebSocketが接続できずホットリロードがブラウザに反映されない問題を解消

## 変更内容
### frontend/package.json
- `dev`スクリプトを `next dev --turbopack` から `next dev --turbopack --hostname 127.0.0.1` へ変更

Next.jsのdevサーバはデフォルトで`localhost`にバインドするため、`http://127.0.0.1:3000`でアクセスしているとHMR用WebSocket(`ws://127.0.0.1:3000/_next/webpack-hmr`)へのupgradeが失敗し、コンパイル済みの差分がブラウザに通知されない状態になっていた。バックエンドのCORS設定が`127.0.0.1`前提のためアクセス側を`localhost`に切り替えることはできず、devサーバ側を`127.0.0.1`に明示的にバインドして揃えることで解決。