### PR TITLE
【front】動画管理API用クライアント・URI・型定義を追加

### DIFF
--- a/frontend/src/api/internal/manage/video.ts
+++ b/frontend/src/api/internal/manage/video.ts
@@ -1,0 +1,24 @@
+import { apiClient } from 'lib/axios/internal'
+import { cookieHeader } from 'lib/config'
+import { ApiOut, apiOut } from 'lib/error'
+import { Req } from 'types/global'
+import { SearchParms, Video, VideoUpdateIn } from 'types/internal/media'
+import { ErrorOut } from 'types/internal/other'
+import { apiManageVideo, apiManageVideos } from 'api/uri'
+import { camelSnake } from 'utils/functions/convertCase'
+
+export const getManageVideos = async (params: SearchParms, req?: Req): Promise<ApiOut<Video[]>> => {
+  return await apiOut(apiClient('json').get(apiManageVideos, cookieHeader(req, params)))
+}
+
+export const getManageVideo = async (ulid: string, req?: Req): Promise<ApiOut<Video>> => {
+  return await apiOut(apiClient('json').get(apiManageVideo(ulid), cookieHeader(req)))
+}
+
+export const putManageVideo = async (ulid: string, request: VideoUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').put(apiManageVideo(ulid), camelSnake(request)))
+}
+
+export const deleteManageVideo = async (ulid: string): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').delete(apiManageVideo(ulid)))
+}

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -60,5 +60,9 @@ export const apiComment = (ulid: string) => base + `/media/comment/${ulid}`
 export const apiMessages = base + '/media/message'
 export const apiMessage = (ulid: string) => base + `/media/message/${ulid}`
 
+// Manage
+export const apiManageVideos = base + '/manage/media/video'
+export const apiManageVideo = (ulid: string) => base + `/manage/media/video/${ulid}`
+
 // 外部API
 export const apiAddress = base + '/search'

--- a/frontend/src/types/internal/media/index.d.ts
+++ b/frontend/src/types/internal/media/index.d.ts
@@ -121,3 +121,9 @@ export interface ChatIn {
   content: string
   period: string
 }
+
+export interface VideoUpdateIn {
+  title: string
+  content: string
+  publish: boolean
+}


### PR DESCRIPTION
## Summary
- `/manage/media/video` 配下を呼び出すフロントエンドAPIクライアントを新設
- URI定義に管理用エンドポイントを追加
- 更新リクエスト用の `VideoUpdateIn` 型を追加

## 変更内容
### frontend/src/api/internal/manage/video.ts (新規)
- `getManageVideos` / `getManageVideo` / `putManageVideo` / `deleteManageVideo` を実装
- 一覧・単体取得・更新・削除を網羅し、所有動画のCRUDを完結させる

### frontend/src/api/uri.ts
- `apiManageVideos` (一覧) と `apiManageVideo(ulid)` (単体) を追加
- 既存の閲覧用 `/media/video` とは別名前空間 `/manage/media/video` を採用

### frontend/src/types/internal/media/index.d.ts
- 動画更新APIに渡すリクエストボディ型 `VideoUpdateIn` を追加 (title / content / publish)

閲覧用APIと管理用APIを意図的に分離することで、フィルタやスコープの取り違えによる権限事故（他人の未公開動画の漏洩等）を防ぐ設計。