### PR TITLE
【front】動画管理の編集ページとSelectBox onChangeオプショナル化

### DIFF
--- a/frontend/src/components/parts/Input/SelectBox/index.tsx
+++ b/frontend/src/components/parts/Input/SelectBox/index.tsx
@@ -9,8 +9,9 @@ interface Props {
   value: string
   options: Option[]
   placeholder?: string
+  disabled?: boolean
   className?: string
-  onChange: (e: ChangeEvent<HTMLSelectElement>) => void
+  onChange?: (e: ChangeEvent<HTMLSelectElement>) => void
 }
 
 export default function SelectBox(props: Props): React.JSX.Element {

--- a/frontend/src/components/parts/Select/index.tsx
+++ b/frontend/src/components/parts/Select/index.tsx
@@ -7,8 +7,9 @@ interface Props {
   value: string
   options: Option[]
   placeholder?: string
+  disabled?: boolean
   className?: string
-  onChange: (e: ChangeEvent<HTMLSelectElement>) => void
+  onChange?: (e: ChangeEvent<HTMLSelectElement>) => void
 }
 
 export default function Select(props: Props): React.JSX.Element {

--- a/frontend/src/components/templates/setting/manage/media/video/edit.tsx
+++ b/frontend/src/components/templates/setting/manage/media/video/edit.tsx
@@ -1,0 +1,75 @@
+import { useState, ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { Video, VideoUpdateIn } from 'types/internal/media'
+import { Option } from 'types/internal/other'
+import { putManageVideo } from 'api/internal/manage/video'
+import { FetchError } from 'utils/constants/enum'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+
+interface Props {
+  data: Video
+  channels: Channel[]
+}
+
+export default function ManageVideoEdit(props: Props): React.JSX.Element {
+  const { data, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [values, setValues] = useState<VideoUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
+
+  const handleBack = () => router.push('/setting/manage/media/data')
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleForm = async () => {
+    const { title, content } = values
+    if (!isRequiredCheck({ title, content })) return
+    handleLoading(true)
+    const ret = await putManageVideo(data.ulid, values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Put, ret.error.message)
+      return
+    }
+    handleToast('保存しました', false)
+  }
+
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="保存する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
+  return (
+    <Main title="動画編集" type="table" toast={toast} isFooter={false} button={button}>
+      <form method="POST" action="" encType="multipart/form-data">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/pages/setting/manage/media/video.tsx
+++ b/frontend/src/pages/setting/manage/media/video.tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Video } from 'types/internal/media'
+import { getChannels } from 'api/internal/channel'
+import { getManageVideos } from 'api/internal/manage/video'
+import { searchParams } from 'utils/functions/common'
+import ErrorCheck from 'components/widgets/Error/Check'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const params = searchParams(query)
+  const [videosRet, channelsRet] = await Promise.all([getManageVideos(params, req), getChannels(req)])
+  if (videosRet.isErr()) return { props: { status: videosRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const datas = videosRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, datas, channels } }
+}
+
+interface Props {
+  status: number
+  datas: Video[]
+  channels: Channel[]
+}
+
+export default function ManageVideosPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <></>
+      {/* <ManageVideos {...props} /> */}
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/pages/setting/manage/media/video/edit/[ulid].tsx
+++ b/frontend/src/pages/setting/manage/media/video/edit/[ulid].tsx
@@ -1,0 +1,33 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Video } from 'types/internal/media'
+import { getChannels } from 'api/internal/channel'
+import { getManageVideo } from 'api/internal/manage/video'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageVideoEdit from 'components/templates/setting/manage/media/video/edit'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ulid = String(params?.ulid ?? '')
+  const [videoRet, channelsRet] = await Promise.all([getManageVideo(ulid, req), getChannels(req)])
+  if (videoRet.isErr()) return { props: { status: videoRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const data = videoRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, data, channels } }
+}
+
+interface Props {
+  status: number
+  data: Video
+  channels: Channel[]
+}
+
+export default function ManageVideoEditPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageVideoEdit {...props} />
+    </ErrorCheck>
+  )
+}


### PR DESCRIPTION
## Summary
- 動画管理の編集ページ（テンプレート＋ルーティング）を追加
- 一覧ページの土台を追加（テンプレート結線は別PRで実施）
- `SelectBox`/`Select` の `onChange` をオプショナル化（disabled時にハンドラ不要にするため）

## 変更内容
### 編集ページ
- `components/templates/setting/manage/media/video/edit.tsx`: タイトル/内容/公開フラグの編集フォーム。チャンネルは表示のみで変更不可（disabled）。
- `pages/setting/manage/media/video/edit/[ulid].tsx`: SSRで `getManageVideo(ulid)` と `getChannels()` を並列取得し、編集テンプレートに渡す。

### 一覧ページ
- `pages/setting/manage/media/video.tsx`: SSRで動画一覧とチャンネル一覧を取得（テンプレート結線は別PRで対応）

### コンポーネント
- `components/parts/Input/SelectBox/index.tsx`, `components/parts/Select/index.tsx`: `onChange` をオプショナルに変更し、`disabled` 利用時にダミーハンドラを書かなくて済むよう改善。