### PR TITLE
【front】汎用DataTableコンポーネントを追加

### DIFF
--- a/frontend/src/components/parts/DataTable/DataTable.module.scss
+++ b/frontend/src/components/parts/DataTable/DataTable.module.scss
@@ -1,0 +1,69 @@
+.table_wrap {
+  overflow-x: auto;
+  border: 1px solid rgb(220, 220, 220);
+  border-radius: 6px;
+
+  .table {
+    table-layout: fixed;
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 13px;
+
+    thead {
+      background: rgb(245, 245, 245);
+
+      th {
+        padding: 8px 12px;
+        text-align: left;
+        font-weight: 500;
+        border-bottom: 1px solid rgb(220, 220, 220);
+        white-space: nowrap;
+
+        .sort_button {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          padding: 0;
+          border: none;
+          background: none;
+          color: inherit;
+          font: inherit;
+          cursor: pointer;
+
+          &:hover {
+            color: rgb(50, 110, 200);
+          }
+
+          .sort_mark {
+            font-size: 11px;
+            color: rgb(130, 130, 130);
+          }
+        }
+      }
+    }
+
+    tbody {
+      tr {
+        border-bottom: 1px solid rgb(235, 235, 235);
+
+        &:hover {
+          background: rgb(250, 250, 250);
+        }
+      }
+
+      td {
+        padding: 8px;
+        vertical-align: middle;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+    }
+  }
+}
+
+.empty {
+  padding: 40px;
+  text-align: center;
+  color: rgb(150, 150, 150);
+}

--- a/frontend/src/components/parts/DataTable/DataTable.module.scss
+++ b/frontend/src/components/parts/DataTable/DataTable.module.scss
@@ -1,4 +1,4 @@
-.table_wrap {
+.data_table {
   overflow-x: auto;
   border: 1px solid rgb(220, 220, 220);
   border-radius: 6px;

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react'
+import cx from 'utils/functions/cx'
+import style from './DataTable.module.scss'
+
+export interface Column<T> {
+  key: string
+  header: string
+  sortable?: boolean
+  sortValue?: (row: T) => string | number
+  render: (row: T) => React.ReactNode
+  className?: string
+  cellClassName?: string
+}
+
+interface Props<T> {
+  datas: T[]
+  columns: Column<T>[]
+  rowKey: (row: T) => string
+}
+
+type SortOrder = 'asc' | 'desc'
+
+export default function DataTable<T>(props: Props<T>): React.JSX.Element {
+  const { datas, columns, rowKey } = props
+
+  const [sortKey, setSortKey] = useState<string | null>(null)
+  const [sortOrder, setSortOrder] = useState<SortOrder>('asc')
+
+  const handleSort = (key: string) => {
+    if (sortKey === key) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
+      return
+    }
+    setSortKey(key)
+    setSortOrder('desc')
+  }
+
+  const sortedDatas = useMemo(() => {
+    if (sortKey === null) return datas
+    const column = columns.find((c) => c.key === sortKey)
+    if (!column || !column.sortValue) return datas
+    const sortValue = column.sortValue
+    const copied = [...datas]
+    copied.sort((a, b) => {
+      const va = sortValue(a)
+      const vb = sortValue(b)
+      if (va < vb) return sortOrder === 'asc' ? -1 : 1
+      if (va > vb) return sortOrder === 'asc' ? 1 : -1
+      return 0
+    })
+    return copied
+  }, [datas, columns, sortKey, sortOrder])
+
+  const sortMark = (key: string): string => {
+    if (sortKey !== key) return ''
+    return sortOrder === 'asc' ? '↑' : '↓'
+  }
+
+  return (
+    <div className={style.table_wrap}>
+      <table className={style.table}>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th key={column.key} className={column.className}>
+                {column.sortable ? (
+                  <button type="button" className={style.sort_button} onClick={() => handleSort(column.key)}>
+                    {column.header}
+                    <span className={style.sort_mark}>{sortMark(column.key)}</span>
+                  </button>
+                ) : (
+                  column.header
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedDatas.map((row) => (
+            <tr key={rowKey(row)}>
+              {columns.map((column) => (
+                <td key={column.key} className={cx(column.className, column.cellClassName)}>
+                  {column.render(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {datas.length === 0 && <div className={style.empty}>データがありません</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react'
 import cx from 'utils/functions/cx'
 import style from './DataTable.module.scss'
 
+type SortOrder = 'asc' | 'desc'
+
 export interface Column<T> {
   key: string
   header: string
@@ -17,8 +19,6 @@ interface Props<T> {
   columns: Column<T>[]
   rowKey: (row: T) => string
 }
-
-type SortOrder = 'asc' | 'desc'
 
 export default function DataTable<T>(props: Props<T>): React.JSX.Element {
   const { datas, columns, rowKey } = props

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -57,7 +57,7 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
   }
 
   return (
-    <div className={style.table_wrap}>
+    <div className={style.data_table}>
       <table className={style.table}>
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- 列設定(\`Column<T>\`)とソート状態を内包したジェネリックな \`DataTable\` コンポーネントを追加
- video管理以外のリソースからも再利用できるよう \`components/parts/DataTable/\` 配下に配置

## 変更内容
### components/parts/DataTable/index.tsx (新規)
- \`Column<T>\`: \`key\` / \`header\` / \`sortable\` / \`sortValue\` / \`render\` / \`className\` / \`cellClassName\`
- \`DataTable<T>\` コンポーネント: datas + columns + rowKey を受け取り、th/td/ソート/空状態を描画
- 初期ソート順 \`asc\`、初回クリックで \`desc\` に切り替わる挙動をハードコード
- データ0件時は「データがありません」を固定表示
- 列の幅・alignなどのスタイルはconsumerの CSS Modules class を \`className\` / \`cellClassName\` で注入する設計（インラインstyleは使用しない）

### components/parts/DataTable/DataTable.module.scss (新規)
- \`table_wrap\` / \`table\` (table-layout: fixed) / \`sort_button\` / \`sort_mark\` / \`empty\` の基本スタイル
- セル内の\`overflow:hidden; text-overflow:ellipsis; white-space:nowrap\` で1行省略をデフォルト動作に