### PR TITLE
【front】動画管理ページ(一覧/編集)をmanage配下で実装

### DIFF
--- a/frontend/src/components/parts/DataTable/DataTable.module.scss
+++ b/frontend/src/components/parts/DataTable/DataTable.module.scss
@@ -1,65 +1,66 @@
 .data_table {
-  overflow-x: auto;
   border: 1px solid rgb(220, 220, 220);
-  border-radius: 6px;
+  border-radius: 5px;
+  overflow-x: auto;
 
   .table {
-    table-layout: fixed;
     border-collapse: collapse;
     width: 100%;
     font-size: 13px;
 
-    thead {
+    .thead {
       background: rgb(245, 245, 245);
-
-      th {
-        padding: 8px 12px;
-        text-align: left;
-        font-weight: 500;
-        border-bottom: 1px solid rgb(220, 220, 220);
-        white-space: nowrap;
-
-        .sort_button {
-          display: inline-flex;
-          align-items: center;
-          gap: 4px;
-          padding: 0;
-          border: none;
-          background: none;
-          color: inherit;
-          font: inherit;
-          cursor: pointer;
-
-          &:hover {
-            color: rgb(50, 110, 200);
-          }
-
-          .sort_mark {
-            font-size: 11px;
-            color: rgb(130, 130, 130);
-          }
-        }
-      }
-    }
-
-    tbody {
-      tr {
-        border-bottom: 1px solid rgb(235, 235, 235);
-
-        &:hover {
-          background: rgb(250, 250, 250);
-        }
-      }
-
-      td {
-        padding: 8px;
-        vertical-align: middle;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        overflow: hidden;
-      }
     }
   }
+}
+
+.th {
+  padding: 4px;
+  text-align: left;
+  font-weight: 500;
+  border-bottom: 1px solid rgb(220, 220, 220);
+  white-space: nowrap;
+
+  &:first-child {
+    padding-left: 8px;
+  }
+
+  .sort_button {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+
+    &:hover {
+      color: rgb(50, 110, 200);
+    }
+
+    .sort_mark {
+      font-size: 11px;
+      color: rgb(130, 130, 130);
+    }
+  }
+}
+
+.tr {
+  border-bottom: 1px solid rgb(235, 235, 235);
+
+  &:hover {
+    background: rgb(250, 250, 250);
+  }
+}
+
+.td {
+  padding: 4px;
+  vertical-align: middle;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .empty {

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -11,7 +11,8 @@ export interface Column<T> {
   sortValue?: (row: T) => string | number
   render: (row: T) => React.ReactNode
   className?: string
-  cellClassName?: string
+  headerClass?: string
+  cellClass?: string
 }
 
 interface Props<T> {
@@ -59,10 +60,10 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
   return (
     <div className={style.data_table}>
       <table className={style.table}>
-        <thead>
+        <thead className={style.thead}>
           <tr>
             {columns.map((column) => (
-              <th key={column.key} className={column.className}>
+              <th key={column.key} className={cx(style.th, column.className, column.headerClass)}>
                 {column.sortable ? (
                   <button type="button" className={style.sort_button} onClick={() => handleSort(column.key)}>
                     {column.header}
@@ -77,9 +78,9 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
         </thead>
         <tbody>
           {sortedDatas.map((row) => (
-            <tr key={rowKey(row)}>
+            <tr key={rowKey(row)} className={style.tr}>
               {columns.map((column) => (
-                <td key={column.key} className={cx(column.className, column.cellClassName)}>
+                <td key={column.key} className={cx(style.td, column.className, column.cellClass)}>
                   {column.render(row)}
                 </td>
               ))}

--- a/frontend/src/components/templates/manage/media/video/Video.module.scss
+++ b/frontend/src/components/templates/manage/media/video/Video.module.scss
@@ -1,0 +1,60 @@
+.manage {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.filter {
+  width: 240px;
+}
+
+.thumbnail {
+  width: 120px;
+
+  img {
+    width: 96px;
+    height: 54px;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+}
+
+.title {
+  max-width: 240px;
+}
+
+.content {
+  max-width: 280px;
+  color: rgb(90, 90, 90);
+}
+
+.datetime {
+  width: 140px;
+  color: rgb(90, 90, 90);
+}
+
+.narrow {
+  width: 56px;
+  text-align: center;
+}
+
+.number {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.publish {
+  display: flex;
+  justify-content: center;
+}
+
+.actions {
+  width: 116px;
+  text-align: center;
+}
+
+.actions_inner {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+}

--- a/frontend/src/components/templates/manage/media/video/Video.module.scss
+++ b/frontend/src/components/templates/manage/media/video/Video.module.scss
@@ -10,6 +10,8 @@
 
 .thumbnail {
   width: 120px;
+  min-width: 120px;
+  max-width: 120px;
 
   img {
     width: 96px;
@@ -20,21 +22,24 @@
 }
 
 .title {
+  min-width: 160px;
   max-width: 240px;
 }
 
 .content {
+  min-width: 200px;
   max-width: 280px;
-  color: rgb(90, 90, 90);
 }
 
 .datetime {
-  width: 140px;
-  color: rgb(90, 90, 90);
+  width: 100px;
 }
 
 .narrow {
   width: 56px;
+}
+
+.center {
   text-align: center;
 }
 
@@ -44,8 +49,12 @@
 }
 
 .publish {
-  display: flex;
-  justify-content: center;
+  text-align: center;
+}
+
+.publish_inner {
+  display: inline-flex;
+  align-items: center;
 }
 
 .actions {

--- a/frontend/src/components/templates/manage/media/video/edit.tsx
+++ b/frontend/src/components/templates/manage/media/video/edit.tsx
@@ -35,7 +35,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<VideoUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
 
-  const handleBack = () => router.push('/setting/manage/media/data')
+  const handleBack = () => router.push('/manage/media/video')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })

--- a/frontend/src/components/templates/manage/media/video/index.tsx
+++ b/frontend/src/components/templates/manage/media/video/index.tsx
@@ -1,0 +1,146 @@
+import { ChangeEvent, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { Video } from 'types/internal/media'
+import { Option } from 'types/internal/other'
+import { deleteManageVideo } from 'api/internal/manage/video'
+import { FetchError } from 'utils/constants/enum'
+import { formatDatetime } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import DataTable, { Column } from 'components/parts/DataTable'
+import ExImage from 'components/parts/ExImage'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Toggle from 'components/parts/Input/Toggle'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from './Video.module.scss'
+
+interface Props {
+  datas: Video[]
+  channels: Channel[]
+}
+
+export default function ManageVideos(props: Props): React.JSX.Element {
+  const { datas, channels } = props
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [deleteTarget, setDeleteTarget] = useState<Video | null>(null)
+  const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+
+  const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
+  const handleEdit = (video: Video) => router.push(`/manage/media/video/edit/${video.ulid}`)
+  const handleDeleteOpen = (video: Video) => setDeleteTarget(video)
+  const handleDeleteClose = () => setDeleteTarget(null)
+
+  const handleDeleteSubmit = async () => {
+    if (!deleteTarget) return
+    handleLoading(true)
+    const ret = await deleteManageVideo(deleteTarget.ulid)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Delete, ret.error.message)
+      return
+    }
+    handleDeleteClose()
+    router.replace(router.asPath)
+  }
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const channelDatas = useMemo(() => {
+    return datas.filter((v) => v.channel.ulid === channelUlid)
+  }, [datas, channelUlid])
+
+  const columns: Column<Video>[] = [
+    {
+      key: 'thumbnail',
+      header: 'サムネイル',
+      className: style.thumbnail,
+      render: (v) => v.image && <ExImage src={v.image} width="96" height="54" />,
+    },
+    {
+      key: 'title',
+      header: 'タイトル',
+      sortable: true,
+      sortValue: (v) => v.title,
+      className: style.title,
+      render: (v) => v.title,
+    },
+    {
+      key: 'content',
+      header: '内容',
+      sortable: true,
+      sortValue: (v) => v.content,
+      className: style.content,
+      render: (v) => v.content,
+    },
+    {
+      key: 'created',
+      header: '投稿日時',
+      sortable: true,
+      sortValue: (v) => new Date(v.created).getTime(),
+      className: style.datetime,
+      render: (v) => formatDatetime(v.created),
+    },
+    {
+      key: 'read',
+      header: '再生',
+      sortable: true,
+      sortValue: (v) => v.read,
+      className: style.narrow,
+      cellClassName: style.number,
+      render: (v) => v.read,
+    },
+    {
+      key: 'like',
+      header: 'いいね',
+      sortable: true,
+      sortValue: (v) => v.like,
+      className: style.narrow,
+      cellClassName: style.number,
+      render: (v) => v.like,
+    },
+    {
+      key: 'publish',
+      header: '公開',
+      sortable: true,
+      sortValue: (v) => (v.publish ? 1 : 0),
+      className: style.narrow,
+      cellClassName: style.publish,
+      render: (v) => <Toggle isActive={v.publish} disable />,
+    },
+    {
+      key: 'actions',
+      header: '操作',
+      className: style.actions,
+      render: (v) => (
+        <div className={style.actions_inner}>
+          <Button color="blue" size="s" name="編集" onClick={() => handleEdit(v)} />
+          <Button color="red" size="s" name="削除" onClick={() => handleDeleteOpen(v)} />
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <Main title="動画管理" type="table" toast={toast} button={<SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />}>
+      <div className={style.manage}>
+        <DataTable datas={channelDatas} columns={columns} rowKey={(v) => v.ulid} />
+      </div>
+      <DeleteModal
+        open={deleteTarget !== null}
+        title="動画の削除"
+        content={`「${deleteTarget?.title ?? ''}」を削除しますか？`}
+        loading={isLoading}
+        onClose={handleDeleteClose}
+        onAction={handleDeleteSubmit}
+      />
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/media/video/index.tsx
+++ b/frontend/src/components/templates/manage/media/video/index.tsx
@@ -94,7 +94,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => v.read,
       className: style.narrow,
-      cellClassName: style.number,
+      cellClass: style.number,
       render: (v) => v.read,
     },
     {
@@ -103,7 +103,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => v.like,
       className: style.narrow,
-      cellClassName: style.number,
+      cellClass: style.number,
       render: (v) => v.like,
     },
     {
@@ -112,8 +112,13 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => (v.publish ? 1 : 0),
       className: style.narrow,
-      cellClassName: style.publish,
-      render: (v) => <Toggle isActive={v.publish} disable />,
+      headerClass: style.center,
+      cellClass: style.publish,
+      render: (v) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={v.publish} disable />
+        </div>
+      ),
     },
     {
       key: 'actions',

--- a/frontend/src/pages/manage/media/video.tsx
+++ b/frontend/src/pages/manage/media/video.tsx
@@ -6,6 +6,7 @@ import { getChannels } from 'api/internal/channel'
 import { getManageVideos } from 'api/internal/manage/video'
 import { searchParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
+import ManageVideos from 'components/templates/manage/media/video'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
@@ -27,8 +28,7 @@ interface Props {
 export default function ManageVideosPage(props: Props): React.JSX.Element {
   return (
     <ErrorCheck status={props.status}>
-      <></>
-      {/* <ManageVideos {...props} /> */}
+      <ManageVideos {...props} />
     </ErrorCheck>
   )
 }

--- a/frontend/src/pages/manage/media/video/edit/[ulid].tsx
+++ b/frontend/src/pages/manage/media/video/edit/[ulid].tsx
@@ -5,7 +5,7 @@ import { Video } from 'types/internal/media'
 import { getChannels } from 'api/internal/channel'
 import { getManageVideo } from 'api/internal/manage/video'
 import ErrorCheck from 'components/widgets/Error/Check'
-import ManageVideoEdit from 'components/templates/setting/manage/media/video/edit'
+import ManageVideoEdit from 'components/templates/manage/media/video/edit'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])


### PR DESCRIPTION
## Summary
- \`/manage/media/video\` 一覧ページを実装（チャンネル切替フィルタ + DataTable + 削除モーダル）
- \`/manage/media/video/edit/[ulid]\` 編集ページを実装（タイトル / 内容 / 公開フラグ）
- URLパスを \`/setting/manage/...\` から \`/manage/...\` に移行し、テンプレート配置も \`templates/manage/media/video/\` に集約

## 変更内容
### 一覧ページ
- \`components/templates/manage/media/video/index.tsx\` (新規)
  - チャンネル切替 SelectBox (Mainの title 横、space-between 右配置)
  - 汎用 \`DataTable\` に \`Column<Video>[]\` を渡して描画（サムネイル / タイトル / 内容 / 投稿日時 / 再生 / いいね / 公開 / 操作）
  - 固定幅: サムネイル 120px / 投稿日時 140px / 再生・いいね・公開 56px / 操作 116px
  - 削除は共通 \`widgets/Modal/Delete\` を使用
- \`components/templates/manage/media/video/Video.module.scss\` (新規)
  - video固有の列スタイル（thumbnail/title/content/datetime/narrow/number/publish/actions）
- \`pages/manage/media/video.tsx\` (rename+更新): 旧 setting/manage 配下から移動し、テンプレート結線

### 編集ページ
- \`components/templates/manage/media/video/edit.tsx\` (rename): 旧 setting/manage 配下から移動
  - チャンネルは表示のみ（disabled）
  - 保存ボタン + 戻るボタン(\`/manage/media/video\`)を横並びで配置
- \`pages/manage/media/video/edit/[ulid].tsx\` (rename): SSRで \`getManageVideo(ulid)\` と \`getChannels()\` を並列取得