### PR TITLE
【back】動画管理APIの追加(一覧/詳細/更新/削除)

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,0 +1,69 @@
+from django.http import HttpRequest
+from ninja import Router
+from api.modules.logger import log
+from api.src.adapter.media import convert_videos
+from api.src.types.schema.common import ErrorOut
+from api.src.types.schema.media import VideoOut, VideoUpdateIn
+from api.src.usecase.auth import auth_check
+from api.src.usecase.manage.media import delete_manage_video, get_manage_video, get_manage_videos, update_manage_video
+
+
+class ManageVideoAPI:
+    """ManageVideoAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[VideoOut], 401: ErrorOut})
+    def list(request: HttpRequest, search: str = ""):
+        log.info("ManageVideoAPI list", search=search)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs = get_manage_videos(user_id, search)
+        return 200, convert_videos(objs)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: VideoOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManageVideoAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_video(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Video not found")
+
+        return 200, convert_videos([obj])[0]
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: VideoUpdateIn):
+        log.info("ManageVideoAPI put", ulid=ulid, input=input)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_video(user_id, ulid, input):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, ulid: str):
+        log.info("ManageVideoAPI delete", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_video(user_id, ulid):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -22,6 +22,8 @@ class VideoRepository(VideoInterface):
             q_list.append(Q(ulid=filter.ulid))
         if filter.publish is not None:
             q_list.append(Q(publish=filter.publish))
+        if filter.owner_id:
+            q_list.append(Q(channel__owner_id=filter.owner_id))
         if filter.channel_id:
             q_list.append(Q(channel_id=filter.channel_id))
         if filter.category_id:
@@ -67,3 +69,6 @@ class VideoRepository(VideoInterface):
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Video.objects.filter(id=media_id, like__id=user_id).exists()
+
+    def delete(self, id: int) -> None:
+        Video.objects.filter(id=id).delete()

--- a/myus/api/src/domain/interface/media/index.py
+++ b/myus/api/src/domain/interface/media/index.py
@@ -16,6 +16,7 @@ class SortType(Enum):
 class FilterOption:
     ulid: str = ""
     publish: bool | None = None
+    owner_id: int = 0
     channel_id: int = 0
     category_id: int = 0
     is_recommend: bool = False

--- a/myus/api/src/domain/interface/media/video/interface.py
+++ b/myus/api/src/domain/interface/media/video/interface.py
@@ -19,3 +19,7 @@ class VideoInterface(ABC):
     @abstractmethod
     def is_liked(self, media_id: int, user_id: int) -> bool:
         ...
+
+    @abstractmethod
+    def delete(self, id: int) -> None:
+        ...

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,6 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
+from api.src.adapter.manage import ManageVideoAPI
 from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -16,6 +17,8 @@ api.add_router("/user", UserAPI().router, tags=["user"])
 api.add_router("/setting/profile", SettingProfileAPI().router, tags=["Setting"])
 api.add_router("/setting/mypage", SettingMyPageAPI().router, tags=["Setting"])
 api.add_router("/setting/notification", SettingNotificationAPI().router, tags=["Setting"])
+
+api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Video"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/media.py
+++ b/myus/api/src/types/schema/media.py
@@ -54,6 +54,12 @@ class ChatIn(BaseModel):
     period: str
 
 
+class VideoUpdateIn(BaseModel):
+    title: str
+    content: str
+    publish: bool
+
+
 # Outputs
 
 class MediaCreateOut(BaseModel):

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -1,0 +1,79 @@
+from dataclasses import replace
+from api.modules.logger import log
+from api.src.domain.interface.media.video.data import VideoData
+from api.src.domain.interface.media.video.interface import VideoInterface
+from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
+from api.src.injectors.container import injector
+from api.src.types.schema.media import VideoUpdateIn
+from api.utils.functions.index import create_url
+
+
+def get_manage_videos(user_id: int, search: str) -> list[VideoData]:
+    repository = injector.get(VideoInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    objs = repository.bulk_get(ids=ids)
+
+    data = [replace(o,
+        image=create_url(o.image),
+        video=create_url(o.video),
+        convert=create_url(o.convert),
+    ) for o in objs]
+
+    return data
+
+
+def get_manage_video(user_id: int, ulid: str) -> VideoData | None:
+    repository = injector.get(VideoInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.info("Video not found", ulid=ulid, user_id=user_id)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    return replace(obj,
+        image=create_url(obj.image),
+        video=create_url(obj.video),
+        convert=create_url(obj.convert),
+    )
+
+
+def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn) -> bool:
+    repository = injector.get(VideoInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Video not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Video owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    update_data = replace(obj, title=input.title, content=input.content, publish=input.publish)
+    try:
+        repository.bulk_save([update_data])
+        return True
+    except Exception as e:
+        log.error("update_manage_video error", exc=e)
+        return False
+
+
+def delete_manage_video(user_id: int, ulid: str) -> bool:
+    repository = injector.get(VideoInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Video not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Video owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    try:
+        repository.delete(obj.id)
+        return True
+    except Exception as e:
+        log.error("delete_manage_video error", exc=e)
+        return False


### PR DESCRIPTION
## Summary
- 動画管理用のCRUD APIエンドポイント(`/manage/media/video`)を新設
- adapter / usecase / repository / interface の各層に管理機能を追加
- 認証チェック・オーナー権限チェックを実装

## 変更内容

### 新規ファイル
- `adapter/manage.py`: ManageVideoAPI（list/get/put/delete）エンドポイント定義
- `usecase/manage/media.py`: 管理用ビジネスロジック（一覧取得/詳細取得/更新/削除）

### 既存ファイル変更
- `routers.py`: `/manage/media/video` ルーティング追加
- `types/schema/media.py`: `VideoUpdateIn` スキーマ追加
- `domain/interface/media/index.py`: `FilterOption` に `owner_id` フィールド追加
- `domain/interface/media/video/interface.py`: `delete` メソッド追加
- `domain/entity/media/video/repository.py`: `owner_id` フィルタ・`delete` 実装追加