### PR TITLE
【front】DataTableにチェックボックス選択機能を追加

### DIFF
--- a/frontend/src/components/parts/DataTable/DataTable.module.scss
+++ b/frontend/src/components/parts/DataTable/DataTable.module.scss
@@ -14,16 +14,25 @@
   }
 }
 
+.checkbox {
+  width: 32px;
+  max-width: 32px;
+  text-align: center;
+  vertical-align: middle;
+  padding: 4px 0;
+}
+
+.th,
+.td {
+  padding: 4px 8px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 .th {
-  padding: 4px;
   text-align: left;
   font-weight: 500;
   border-bottom: 1px solid rgb(220, 220, 220);
-  white-space: nowrap;
-
-  &:first-child {
-    padding-left: 8px;
-  }
 
   .sort_button {
     display: inline-flex;
@@ -47,20 +56,17 @@
   }
 }
 
+.td {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 .tr {
   border-bottom: 1px solid rgb(235, 235, 235);
 
   &:hover {
     background: rgb(250, 250, 250);
   }
-}
-
-.td {
-  padding: 4px;
-  vertical-align: middle;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
 }
 
 .empty {

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import cx from 'utils/functions/cx'
 import style from './DataTable.module.scss'
 
@@ -19,10 +19,13 @@ interface Props<T> {
   datas: T[]
   columns: Column<T>[]
   rowKey: (row: T) => string
+  selectable?: boolean
+  selectedKeys?: Set<string>
+  onSelection?: (selectedKeys: Set<string>) => void
 }
 
 export default function DataTable<T>(props: Props<T>): React.JSX.Element {
-  const { datas, columns, rowKey } = props
+  const { datas, columns, rowKey, selectable, selectedKeys, onSelection } = props
 
   const [sortKey, setSortKey] = useState<string | null>(null)
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc')
@@ -36,7 +39,7 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
     setSortOrder('desc')
   }
 
-  const sortedDatas = useMemo(() => {
+  const sortedDatas = (() => {
     if (sortKey === null) return datas
     const column = columns.find((c) => c.key === sortKey)
     if (!column || !column.sortValue) return datas
@@ -50,11 +53,33 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
       return 0
     })
     return copied
-  }, [datas, columns, sortKey, sortOrder])
+  })()
 
   const sortMark = (key: string): string => {
     if (sortKey !== key) return ''
     return sortOrder === 'asc' ? '↑' : '↓'
+  }
+
+  const isAllSelected = datas.length > 0 && selectedKeys?.size === datas.length
+
+  const handleSelectAll = () => {
+    if (!onSelection) return
+    if (isAllSelected) {
+      onSelection(new Set())
+      return
+    }
+    onSelection(new Set(datas.map((row) => rowKey(row))))
+  }
+
+  const handleSelectRow = (key: string) => {
+    if (!onSelection || !selectedKeys) return
+    const next = new Set(selectedKeys)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    onSelection(next)
   }
 
   return (
@@ -62,6 +87,11 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
       <table className={style.table}>
         <thead className={style.thead}>
           <tr>
+            {selectable && (
+              <th className={cx(style.th, style.checkbox)}>
+                <input type="checkbox" checked={isAllSelected} onChange={handleSelectAll} />
+              </th>
+            )}
             {columns.map((column) => (
               <th key={column.key} className={cx(style.th, column.className, column.headerClass)}>
                 {column.sortable ? (
@@ -77,15 +107,23 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
           </tr>
         </thead>
         <tbody>
-          {sortedDatas.map((row) => (
-            <tr key={rowKey(row)} className={style.tr}>
-              {columns.map((column) => (
-                <td key={column.key} className={cx(style.td, column.className, column.cellClass)}>
-                  {column.render(row)}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {sortedDatas.map((row) => {
+            const key = rowKey(row)
+            return (
+              <tr key={key} className={style.tr}>
+                {selectable && (
+                  <td className={cx(style.td, style.checkbox)}>
+                    <input type="checkbox" checked={selectedKeys?.has(key) ?? false} onChange={() => handleSelectRow(key)} />
+                  </td>
+                )}
+                {columns.map((column) => (
+                  <td key={column.key} className={cx(style.td, column.className, column.cellClass)}>
+                    {column.render(row)}
+                  </td>
+                ))}
+              </tr>
+            )
+          })}
         </tbody>
       </table>
       {datas.length === 0 && <div className={style.empty}>データがありません</div>}

--- a/frontend/src/components/templates/manage/media/video/index.tsx
+++ b/frontend/src/components/templates/manage/media/video/index.tsx
@@ -32,6 +32,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
   const { handleError } = useApiError({ handleToast })
   const [deleteTarget, setDeleteTarget] = useState<Video | null>(null)
   const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
   const handleEdit = (video: Video) => router.push(`/manage/media/video/edit/${video.ulid}`)
@@ -134,9 +135,15 @@ export default function ManageVideos(props: Props): React.JSX.Element {
   ]
 
   return (
-    <Main title="動画管理" type="table" toast={toast} button={<SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />}>
+    <Main
+      title="動画管理"
+      type="table"
+      toast={toast}
+      isFooter={false}
+      button={<SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />}
+    >
       <div className={style.manage}>
-        <DataTable datas={channelDatas} columns={columns} rowKey={(v) => v.ulid} />
+        <DataTable datas={channelDatas} columns={columns} rowKey={(v) => v.ulid} selectable selectedKeys={selectedKeys} onSelection={setSelectedKeys} />
       </div>
       <DeleteModal
         open={deleteTarget !== null}


### PR DESCRIPTION
## Summary
- DataTableコンポーネントにチェックボックスによる行選択機能を追加
- React Compiler対応でuseMemo/useCallbackを除去
- 動画管理ページでチェックボックスを有効化、フッターを非表示に変更

## 変更内容

### DataTable (`components/parts/DataTable/`)
- `index.tsx`: `selectable`/`selectedKeys`/`onSelection` プロパティを追加。ヘッダーに全選択、各行に個別選択チェックボックスを表示
- `index.tsx`: `useMemo`/`useCallback`を除去（React Compiler環境のため不要）
- `DataTable.module.scss`: `.checkbox`クラスを追加、`.th`と`.td`のパディングを`4px 8px`に統一してセル位置を整列

### 動画管理ページ (`templates/manage/media/video/`)
- `index.tsx`: DataTableに`selectable`/`selectedKeys`/`onSelection`を渡してチェックボックスを有効化
- `index.tsx`: `isFooter={false}`を追加してフッターを非表示に変更