### PR TITLE
【front】動画管理のタイトルクリックで編集遷移・編集ボタン削除

### DIFF
--- a/frontend/src/components/templates/manage/media/video/Video.module.scss
+++ b/frontend/src/components/templates/manage/media/video/Video.module.scss
@@ -24,6 +24,15 @@
 .title {
   min-width: 160px;
   max-width: 240px;
+
+  .title_link {
+    color: rgb(50, 110, 200);
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .content {
@@ -58,12 +67,6 @@
 }
 
 .actions {
-  width: 116px;
+  width: 64px;
   text-align: center;
-}
-
-.actions_inner {
-  display: flex;
-  justify-content: center;
-  gap: 4px;
 }

--- a/frontend/src/components/templates/manage/media/video/index.tsx
+++ b/frontend/src/components/templates/manage/media/video/index.tsx
@@ -71,7 +71,11 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => v.title,
       className: style.title,
-      render: (v) => v.title,
+      render: (v) => (
+        <a className={style.title_link} onClick={() => handleEdit(v)}>
+          {v.title}
+        </a>
+      ),
     },
     {
       key: 'content',
@@ -125,12 +129,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       key: 'actions',
       header: '操作',
       className: style.actions,
-      render: (v) => (
-        <div className={style.actions_inner}>
-          <Button color="blue" size="s" name="編集" onClick={() => handleEdit(v)} />
-          <Button color="red" size="s" name="削除" onClick={() => handleDeleteOpen(v)} />
-        </div>
-      ),
+      render: (v) => <Button color="red" size="s" name="削除" onClick={() => handleDeleteOpen(v)} />,
     },
   ]
 


### PR DESCRIPTION
## Summary
- タイトル列をクリックで編集ページに遷移するリンクに変更
- 操作列から編集ボタンを削除し削除ボタンのみに簡略化

## 変更内容

### `index.tsx`
- タイトル列の`render`をリンク(`<a>`)に変更し、クリックで編集ページへ遷移
- 操作列から編集ボタンを削除、削除ボタンのみに変更
- `actions_inner`ラッパーdivを削除

### `Video.module.scss`
- `.title_link`: 青色テキスト・ホバーで下線のリンクスタイルを追加
- `.actions`: 幅を116px→64pxに縮小（削除ボタンのみのため）
- `.actions_inner`: 未使用のため削除