### PR TITLE
【back】動画管理APIの削除を一括削除(bulk_delete)に変更

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -3,7 +3,7 @@ from ninja import Router
 from api.modules.logger import log
 from api.src.adapter.media import convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media import VideoOut, VideoUpdateIn
+from api.src.types.schema.media import BulkDeleteIn, VideoOut, VideoUpdateIn
 from api.src.usecase.auth import auth_check
 from api.src.usecase.manage.media import delete_manage_video, get_manage_video, get_manage_videos, update_manage_video
 
@@ -55,15 +55,15 @@ class ManageVideoAPI:
         return 204, ErrorOut(message="保存しました!")
 
     @staticmethod
-    @router.delete("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
-    def delete(request: HttpRequest, ulid: str):
-        log.info("ManageVideoAPI delete", ulid=ulid)
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManageVideoAPI delete", ulids=input.ulids)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        if not delete_manage_video(user_id, ulid):
+        if not delete_manage_video(user_id, input.ulids):
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -70,5 +70,5 @@ class VideoRepository(VideoInterface):
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Video.objects.filter(id=media_id, like__id=user_id).exists()
 
-    def delete(self, id: int) -> None:
-        Video.objects.filter(id=id).delete()
+    def bulk_delete(self, ids: list[int]) -> None:
+        Video.objects.filter(id__in=ids).delete()

--- a/myus/api/src/domain/interface/media/video/interface.py
+++ b/myus/api/src/domain/interface/media/video/interface.py
@@ -21,5 +21,5 @@ class VideoInterface(ABC):
         ...
 
     @abstractmethod
-    def delete(self, id: int) -> None:
+    def bulk_delete(self, ids: list[int]) -> None:
         ...

--- a/myus/api/src/types/schema/media.py
+++ b/myus/api/src/types/schema/media.py
@@ -60,6 +60,10 @@ class VideoUpdateIn(BaseModel):
     publish: bool
 
 
+class BulkDeleteIn(BaseModel):
+    ulids: list[str]
+
+
 # Outputs
 
 class MediaCreateOut(BaseModel):

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -59,20 +59,19 @@ def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn) -> bool:
         return False
 
 
-def delete_manage_video(user_id: int, ulid: str) -> bool:
+def delete_manage_video(user_id: int, ulids: list[str]) -> bool:
     repository = injector.get(VideoInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
-    if len(ids) == 0:
-        log.error("Video not found", ulid=ulid)
-        return False
+    delete_ids: list[int] = []
 
-    obj = repository.bulk_get(ids)[0]
-    if obj.channel.owner_id != user_id:
-        log.error("Video owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
-        return False
+    for ulid in ulids:
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        if len(ids) == 0:
+            log.error("Video not found or owner mismatch", ulid=ulid, user_id=user_id)
+            return False
+        delete_ids.append(ids[0])
 
     try:
-        repository.delete(obj.id)
+        repository.bulk_delete(delete_ids)
         return True
     except Exception as e:
         log.error("delete_manage_video error", exc=e)


### PR DESCRIPTION
## Summary
- 動画管理APIの削除を単体削除から一括削除(bulk_delete)に変更
- DELETEエンドポイントをulidsリストのボディ受け取りに変更
- owner_idフィルタによる権限チェックを維持

## 変更内容

### Interface / Repository
- `VideoInterface`: `delete(id: int)` → `bulk_delete(ids: list[int])`
- `VideoRepository`: `filter(id=id).delete()` → `filter(id__in=ids).delete()`

### Usecase
- `delete_manage_video(user_id, ulid)` → `delete_manage_video(user_id, ulids: list[str])`
- 各ulidに対してowner_idフィルタで権限チェックし、全て通過後にbulk_deleteを実行

### Adapter / Schema
- DELETEエンドポイント: `/{ulid}` → `""` (ボディで`BulkDeleteIn`を受け取り)
- `BulkDeleteIn(ulids: list[str])` スキーマを新設