### PR TITLE
【docs】BE/FE/CSSコーディングルールを簡潔に再構成

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,99 +1,30 @@
-# Claude Code バックエンド開発ルール
+# バックエンド開発ルール
 
-## 基本原則
+## 型ヒント
 
-### 1. 型ヒント
-- **Python 3.12+の型構文を使用**
-  - `List[str]` → `list[str]`
-  - `Dict[str, int]` → `dict[str, int]`
-  - `Optional[str]` → `str | None`
-  - `Union[str, int]` → `str | int`
-  - 型エイリアスは `type` 文を使用: `type MediaModelType = Video | Music | Comic`
-- `collections.abc`から`Callable`をインポート
-- 型ヒントは可能な限りすべての関数・メソッドに付与
+- Python 3.12+の型構文を使用（`list[str]`, `str | None`, `type`文）
+- `Callable`は`collections.abc`からインポート
+- すべての関数・メソッドに型ヒントを付与
 
-### 2. ロギング
-- **必ず`api.modules.logger`を使用**（`print()`禁止）
-  ```python
-  from api.modules.logger import log
-  ```
-- **ログレベルの使い分け**
-  | レベル | 用途 |
-  |--------|------|
-  | `log.debug()` | デバッグ情報 |
-  | `log.info()` | 重要な処理の開始・完了 |
-  | `log.warning()` | 警告（フォールバック処理など） |
-  | `log.error()` | エラー情報（スタックトレース付き） |
-  | `log.critical()` | 致命的エラー |
+## ロギング
 
-- **ログ出力形式**: 値は必ずキーワード引数で構造化して渡す
-  ```python
-  # Good - 値をキーワード引数で構造化
-  log.info("処理完了", user_id=123, duration=5.2)
-  log.error("Channel not found", ulid=ulid)
-  log.error("変換エラー", exc=e, file_path=input_path)
+- `print()`禁止、`api.modules.logger`の`log`を使用
+- 値はキーワード引数で構造化: `log.info("処理完了", user_id=123)`
+- エラーログには`exc=e`を渡す
 
-  # Bad - f-stringで値を埋め込む
-  log.info(f"処理完了: user_id={user_id}")
-  log.error(f"Channel not found: {ulid}")
-  ```
+| レベル | 用途 |
+|--------|------|
+| `log.info()` | 処理の開始・完了、正常系ガード節 |
+| `log.warning()` | 警告、軽度の異常系ガード節 |
+| `log.error()` | エラー、危険度が高いガード節 |
 
-### 3. エラーハンドリング
-- 例外は適切にキャッチして処理
-- エラーログには`exc=e`を渡してスタックトレースを含める
-- ユーザーへのエラーメッセージは具体的かつ分かりやすく
+## インポート
 
-### 4. Django規約
-- Django固有の書き方は、domain modelとDBモデルの範囲内に限定する
-- QuerySetの型ヒントを適切に使用
+- ファイルの先頭で行う（ローカルインポート禁止、`TYPE_CHECKING`禁止）
+- 順序: 標準ライブラリ → サードパーティ → Django → プロジェクト内
 
-### 5. リンターチェック（必須）
-- **Pythonコードを修正したら、必ずmypyでリンターチェックを実行する**
-- 修正したファイルに関連するエラーがあれば修正してから完了とする
+## 命名規則
 
-```bash
-# myusディレクトリで実行
-uv run mypy api/src/path/to/file.py
-
-# 修正したファイルのエラーのみフィルタする場合
-uv run mypy api/src/path/to/file.py 2>&1 | grep "^api/src/path/to/file.py"
-```
-
----
-
-## コーディング規約
-
-### インポート
-- **インポートは必ずファイルの先頭で行う**（関数内でのローカルインポート禁止、`TYPE_CHECKING`禁止）
-- 型ヒントで使用する型も通常通りインポートする
-
-```python
-# Good - ファイル先頭でインポート
-from api.db.models.media import Video, Music
-
-def process(obj: Video | Music) -> str:
-    return obj.title
-
-# Bad - 関数内でのローカルインポート
-def process(obj):
-    from api.db.models.media import Video
-    ...
-
-# Bad - TYPE_CHECKINGは使用しない
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from api.db.models.media import Video
-```
-
-**インポート順序:**
-```python
-1. 標準ライブラリ
-2. サードパーティライブラリ
-3. Django関連
-4. プロジェクト内モジュール
-```
-
-### 命名規則
 | 対象 | 規則 | 例 |
 |------|------|-----|
 | 変数・関数 | snake_case | `user_name`, `get_user()` |
@@ -102,426 +33,100 @@ if TYPE_CHECKING:
 | プライベート | 先頭に`_` | `_internal_method()` |
 | Django Model | 単数形 | `User`, `Video` |
 
-### 条件判定
+## 条件判定
 
-#### リスト/辞書/文字列の空チェック: `len()`を使用
-```python
-# Good
-if len(items) > 0:
-    process(items)
-if len(items) == 0:
-    return []
+- 空チェック: `len(items) == 0`（truthy判定は使わない）
+- None判定: `is None` / `is not None`
+- ブール値: 直接評価（`if enabled:`）
+- 存在チェック: `in`演算子
+- 型チェック: `isinstance()`
 
-# Bad
-if items:
-    process(items)
-```
+## return文
 
-#### Noneの判定: `is None` / `is not None`
-```python
-# Good
-if value is None:
-    return default
+- 戻り値を変数として利用する場合: `return None`を明示
+- ガード節・ループ脱出: `return`のみ
+- 関数末尾: 戻り値を利用しない場合は省略
 
-# Bad
-if value == None:
-    return default
-```
+## enum変換
 
-#### ブール値の判定: 直接評価
-```python
-# Good
-if enabled:
-    run()
-
-# Bad
-if enabled == True:
-    run()
-```
-
-#### 存在チェック: `in` 演算子
-```python
-# Good
-if key in data:
-    value = data[key]
-
-# Bad
-if data.get(key) is not None:
-    value = data[key]
-```
-
-#### 型チェック: `isinstance()`
-```python
-# Good
-if isinstance(obj, str):
-    process_string(obj)
-
-# Bad
-if type(obj) == str:
-    process_string(obj)
-```
-
-### リスト内包表記
-シンプルな場合のみ使用、複雑ならfor文
-```python
-# Good - シンプルな変換
-names = [user.name for user in users]
-active_ids = [u.id for u in users if u.is_active]
-
-# Bad - 複雑すぎる
-result = [process(x) for x in items if x.is_valid and x.status == Status.ACTIVE and x.created_at > threshold]
-
-# Good - 複雑な場合はfor文
-result = []
-for x in items:
-    if not x.is_valid:
-        continue
-    if x.status != Status.ACTIVE:
-        continue
-    result.append(process(x))
-```
-
-### 早期リターン
-ガード節でログを出力する
-| 状況 | ログレベル |
-|------|-----------|
-| 正常系 | `log.info` |
-| 軽度の異常系 | `log.warning` |
-| 危険度が高い | `log.error` |
-
-```python
-def process_video(video_id: int) -> Video | None:
-    video = Video.objects.filter(id=video_id).first()
-
-    if video is None:
-        log.info("動画が見つかりません", video_id=video_id)
-        return None
-
-    if video.status == VideoStatus.PROCESSING:
-        log.warning("動画は処理中です", video_id=video_id)
-        return None
-
-    if video.is_deleted:
-        log.error("削除済み動画へのアクセス", video_id=video_id)
-        return None
-
-    return video
-```
-
-### return文
-- **戻り値を変数として利用する場合**: `return None` を明示的に記述
-- **ガード節・ループ脱出など変数として利用しない場合**: `return` のみ
-- **関数末尾のreturn**: 戻り値を変数として利用しない場合は不要（省略する）
-
-```python
-# 戻り値を変数として利用する場合 → return None
-def find_user(self, id: int) -> UserData | None:
-    if id == 0:
-        return None  # 呼び出し元で result = find_user(id) のように使う
-    ...
-
-# ガード節で抜ける場合 → return
-def bulk_save(self, objs: list[UserData]) -> None:
-    if len(objs) == 0:
-        return  # 戻り値は使わない、処理を抜けるだけ
-    ...
-    # 関数末尾のreturnは不要
-```
-
-### enum変換
 - `match-case`を使用
-- 最後に網羅性チェックを追加（`assert_never`推奨、使えない場合は`assert False`）
+- 網羅性チェック: `assert_never`推奨
 
-```python
-from enum import Enum
-from typing import assert_never
+## リスト内包表記
 
-class MediaType(Enum):
-    VIDEO = "video"
-    MUSIC = "music"
-    COMIC = "comic"
+- シンプルな変換のみ使用、複雑ならfor文
 
-def get_media_label(media_type: MediaType) -> str:
-    match media_type:
-        case MediaType.VIDEO:
-            return "動画"
-        case MediaType.MUSIC:
-            return "音楽"
-        case MediaType.COMIC:
-            return "漫画"
-        case _:
-            assert_never(media_type)  # または assert False, f"不正な値: {media_type}"
-```
+## 例外処理
 
-### 非同期処理
-- 可能な限り`async/await`を活用
-- `asyncio`を使用した並列処理で高速化
-- セマフォを使用してリソース制限
+- 素の`except:`や`except Exception:`でのキャッチは禁止（想定する例外型を明示する）
+- やむを得ず広くキャッチする場合は`log.error`でスタックトレースを残す
+- adapter層でのみユーザー向けエラーメッセージを返す（usecase/domain層はbool or 例外で伝搬）
 
-```python
-import asyncio
-from collections.abc import Callable, Awaitable
+## 文字列
 
-async def process_parallel(
-    items: list[str],
-    processor: Callable[[str], Awaitable[dict]]
-) -> list[dict]:
-    tasks = [processor(item) for item in items]
-    return await asyncio.gather(*tasks)
-```
-
----
+- f-stringを使用（`.format()`や`%`は使わない）
+- ただしログ出力ではf-stringを使わず、キーワード引数で渡す（ロギングセクション参照）
 
 ## 型定義
 
 ### アダプター（API）: Pydantic BaseModel
-- APIリクエスト/レスポンスのバリデーション用
-- サフィックス: 入力に`In`、出力に`Out`
-
-```python
-from pydantic import BaseModel
-
-class LoginIn(BaseModel):
-    username: str
-    password: str
-
-class LoginOut(BaseModel):
-    access: str
-    refresh: str
-```
+- サフィックス: 入力`In`、出力`Out`
 
 ### 内部データ構造: dataclass
-- ドメイン層、ユースケース層などで使用
+- `@dataclass(frozen=True, slots=True)`
 - サフィックス: `Data`
-- **domain interface の dataclass にはフィールドの初期値を設定しない**（すべての値を明示的に渡す）
+- domain interfaceのdataclassにはフィールドの初期値を設定しない
 
-```python
-from dataclasses import dataclass
+## アーキテクチャ
 
-@dataclass(frozen=True, slots=True)
-class UserData:
-    id: int
-    username: str
-    email: str
-
-# Bad - domain interfaceのdataclassに初期値を設定
-@dataclass(frozen=True, slots=True)
-class UserData:
-    id: int
-    username: str = ""  # NG
-    tags: list[str] = field(default_factory=list)  # NG
-```
-
----
-
-## Repository層
-
-### インターフェースの入出力
-- **Repositoryの入出力にはdataclassを使用**（Django ORMモデルを直接返さない）
-- 入力: `list[UserData]`などのdataclass
-- 出力: `list[UserData]`などのdataclass
-
-```python
-# Good - dataclassを使用
-class UserInterface(ABC):
-    @abstractmethod
-    def bulk_get(self, ids: list[int]) -> list[UserData]:
-        ...
-
-    @abstractmethod
-    def bulk_save(self, objs: list[UserData]) -> list[int]:
-        ...
-
-# Bad - Django ORMモデルを直接返す
-class UserInterface(ABC):
-    @abstractmethod
-    def bulk_get(self, ids: list[int]) -> list[User]:  # NG
-        ...
-```
-
-### Usecase層のRepository取得
-- usecase層ではentity（Repository実装）を直接インポートしない
-- injector経由でinterfaceを取得して使用する
-
-```python
-# Good - injector経由でinterfaceを使用
-from api.src.injectors.container import injector
-from api.src.domain.interface.user.interface import UserInterface
-
-def get_user(id: int) -> UserData | None:
-    repository = injector.get(UserInterface)
-    ...
-
-# Bad - entity(Repository実装)を直接インポート
-from api.src.domain.entity.user.repository import UserRepository
-
-def get_user(id: int) -> UserData | None:
-    repository = UserRepository()
-    ...
-```
+### Repository層
+- 入出力はdataclass（Django ORMモデルを直接返さない）
+- usecase層ではinjector経由でinterfaceを取得（entityを直接インポートしない）
 
 ### Converterパターン
-- Repository実装では、`_convert.py`にdataclass ↔ Django ORMモデル間の変換関数を定義
-- `convert_data`: Django ORMモデル → dataclass（読み取り時）
-- `marshal_data`: dataclass → Django ORMモデル（書き込み時）
-
-```python
-# entity/user/_convert.py
-
-# Convert (Django model -> dataclass)
-def convert_data(user: User) -> UserData:
-    return UserData(
-        id=user.id,
-        username=user.username,
-        ...
-    )
-
-# Marshal (dataclass -> Django model)
-def marshal_data(data: UserData) -> User:
-    return User(
-        id=data.id if data.id != 0 else None,
-        username=data.username,
-        email=data.email,
-        ...
-    )
-```
+- `_convert.py`に変換関数を定義
+- `convert_data`: Django ORM → dataclass
+- `marshal_data`: dataclass → Django ORM
 
 ### bulk操作
-- `bulk_save`: 新規作成・更新を一括で行う（upsert）
-- `get_new_ids`でid未設定のオブジェクトに新規IDを割り当て
-- `bulk_create(update_conflicts=True)`で一括insert/update
+- `bulk_save`: upsert（`bulk_create(update_conflicts=True)`）
+- `get_new_ids`でid未設定オブジェクトに新規ID割り当て
 
----
+## 層の責務
 
-## DBモデル
+| 層 | 責務 | 依存してよいもの |
+|------|------|------|
+| adapter | HTTPリクエスト/レスポンス変換、認証チェック | usecase, schema |
+| usecase | ビジネスロジック、複数repositoryの協調 | interface（injector経由） |
+| domain/interface | 抽象定義（ABC, dataclass） | なし |
+| domain/entity | Repository実装、DBアクセス | Django ORM, interface |
 
-```python
-class Video(models.Model, MediaModel):
-    """Video"""
-    id      = models.BigAutoField(primary_key=True)
-    ulid    = models.CharField(max_length=26, unique=True, editable=False, default=ulid.new)
-    channel = models.ForeignKey(Channel, on_delete=models.CASCADE)
-    title   = models.CharField(max_length=100)
-    content = models.TextField()
-    created = models.DateTimeField(auto_now_add=True)
-```
-
----
+- adapter → usecase → interface の方向にのみ依存する
+- usecase層からadapter層の型（`HttpRequest`等）をインポートしない
+- domain/interface層は他の層に依存しない（純粋なPython）
 
 ## パフォーマンス
 
-### データベース
-- `select_related()`と`prefetch_related()`でN+1問題を回避
+- `select_related()`/`prefetch_related()`でN+1回避
 - 必要なフィールドのみ`only()`で取得
-- インデックスを適切に設定
-
-### キャッシング
-- `@lru_cache`でメソッドの結果をキャッシュ
-- Redisを使用したキャッシュ戦略
-
----
+- QuerySetは遅延評価されるため、評価タイミングを意識する
 
 ## テスト
 
-**必ずpytestを使用**（Django標準のTestCaseは使わない）
+- pytestを使用（Django TestCase不可）
+- `@pytest.mark.django_db`でDB接続
 
-### 基本構成
-```python
-import pytest
-from api.db.models import Video
+## リンターチェック（必須）
 
-@pytest.mark.django_db
-class TestVideoModel:
-    def test_create_video(self):
-        video = Video.objects.create(title="Test")
-        assert video.title == "Test"
-```
+コードを書いた後、必ず実行:
 
-### フィクスチャ
-```python
-# conftest.py
-import pytest
-from django.contrib.auth import get_user_model
-
-User = get_user_model()
-
-@pytest.fixture
-def user():
-    return User.objects.create_user(
-        email="test@example.com",
-        username="testuser",
-        nickname="Test User",
-        password="testpassword"
-    )
-```
-
-### 実行コマンド
 ```bash
-pytest                      # すべて実行
-pytest -v                   # 詳細出力
-pytest --cov=api            # カバレッジ付き
-pytest -n auto              # 並列実行
-pytest -m "not slow"        # slowマーカー以外
+uv run mypy api/src/path/to/file.py
 ```
-
----
-
-## セキュリティ
-
-- CSRF保護はJWT使用時は不要
-- Pydantic BaseModelで入力を検証
-- SQLインジェクション対策（ORMを使用）
-- ファイルタイプの検証
-
----
-
-## プロジェクト固有
-
-### 動画処理
-- `VideoConverter`クラスを使用
-- ハードウェアアクセラレーションを活用
-- 複数解像度の並列生成
-
-### 通知システム
-- WebSocketを使用したリアルタイム通知
-- `channels`フレームワークを活用
-
-### メディアファイル
-- `MEDIA_ROOT`配下に適切に整理
-- サムネイル自動生成
-
-### タイムアウト
-- フロントエンド: 60秒
-- バックエンド: 処理に応じて適切に設定
-
----
-
-## 運用
-
-### マイグレーション
-```bash
-python manage.py makemigrations --name descriptive_name
-python manage.py showmigrations
-python manage.py sqlmigrate app_name 0001
-```
-
-### デプロイメント
-- `.env`ファイルで環境変数管理
-- シークレットキーは絶対にコミットしない
-```bash
-python manage.py collectstatic --noinput
-python manage.py migrate --noinput
-```
-
----
 
 ## 更新履歴
-- 2026-02-22: 全体整備（Converter命名・bulk操作・DBモデル例・セキュリティを実装に合わせて修正）
-- 2026-02-22: domain interfaceのdataclassに初期値を設定しないルールを追加
-- 2026-02-21: return文のルールを追加（明示的return None / ガード節のreturn / 末尾return省略）
-- 2026-02-05: bulk操作をbulk_saveに統一（upsertパターン）
-- 2026-02-04: Repository層のルールを追加（dataclass入出力、Converterパターン、bulk操作の分離）
-- 2026-01-21: コーディング規約を大幅に整理・追加（条件判定、早期リターン、リスト内包表記）
-- 2026-01-21: 型定義ルールを変更（アダプターはPydantic BaseModel、それ以外はdataclass）
-- 2025-10-15: Django Ninjaの型定義ルールを追加
 - 2025-09-29: 初版作成
+- 2026-01-21: コーディング規約整理、型定義ルール変更
+- 2026-02-04: Repository層ルール追加
+- 2026-02-22: 全体整備、domain interface初期値禁止ルール追加
+- 2026-04-16: docs/に一元化、構成整理

--- a/docs/css.md
+++ b/docs/css.md
@@ -1,122 +1,20 @@
-# CSS/SCSS コーディングルール
+# SCSS コーディングルール
 
 ## 基本原則
 
-- **必ずCSS Modulesを使用**（`.module.scss`）
-- **インラインスタイルは絶対に使用しない**
-- **すべてのスタイルはクラスを定義してSCSSファイルに記載**
-- 既存のクラスを優先的に使用
-- 動的なスタイルが必要な場合も、可能な限りクラスの切り替えで対応
-
----
+- ファイル形式は必ずSCSSを使用
+- `parts/`、`widgets/`はCSS Modules（`.module.scss`）を使用
+- `templates/`ではグローバルCSS（`styles/`配下）を利用してよい
+- ネスト構文で記述する（子要素は親クラスの中にネスト、3階層まで）
+- インラインスタイルは使用しない
+- 動的スタイルはクラスの切り替え（`cx()`）で対応
 
 ## 命名規則
 
-### クラス名
-- **snake_case**を使用（camelCaseやkebab-caseは使用しない）
-
-```scss
-// ❌ 悪い例
-.videoContainer {}
-.video-container {}
-
-// ✅ 良い例
-.video_container {}
-```
-
-### ファイル名
-- コンポーネント名に合わせたPascalCase: `ComponentName.module.scss`
-
----
-
-## 構造
-
-### ネスト
-- **子要素のクラスは親クラスの中にネストして定義する**
-- ネストは3階層までを目安とする
-
-```scss
-// ❌ 悪い例（フラットに定義）
-.container {
-  min-height: 94px;
-}
-
-.heading {
-  font-size: 16px;
-}
-
-.article {
-  display: block;
-}
-
-// ✅ 良い例（親クラスの中にネスト）
-.container {
-  min-height: 94px;
-
-  .heading {
-    font-size: 16px;
-  }
-
-  .article {
-    display: block;
-  }
-}
-```
-
-### 共通スタイルのグループ化
-- 複数セレクタに共通するプロパティはカンマ区切りでまとめる
-
-```scss
-// ❌ 悪い例
-.th {
-  padding: 4px 8px;
-  vertical-align: middle;
-}
-
-.td {
-  padding: 4px 8px;
-  vertical-align: middle;
-}
-
-// ✅ 良い例
-.th,
-.td {
-  padding: 4px 8px;
-  vertical-align: middle;
-}
-```
-
----
-
-## 詳細度
-
-### `!important`は使用しない
-- 詳細度の問題はセレクタの構造で解決する
-
-### 詳細度を上げる場合
-- 同じクラスを重ねて詳細度を上げる（`.class.class`パターン）
-
-```scss
-// 通常の定義
-.th {
-  text-align: left;
-}
-
-// 上書きが必要な場合（詳細度を上げる）
-.align_right.align_right {
-  text-align: right;
-}
-```
-
-### CSS Modulesの読み込み順に依存しない
-- 外部コンポーネントのクラスを上書きする場合、読み込み順で負けることがある
-- 汎用コンポーネント側にalignやサイズ用のクラスを用意して対応する
-
----
+- クラス名: `snake_case`
+- ファイル名: `ComponentName.module.scss`（PascalCase）
 
 ## プロパティ記述順序
-
-以下の順序でプロパティを記述する:
 
 ```scss
 .element {
@@ -124,23 +22,17 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 8px;
 
   // 2. ボックスモデル
   width: 100px;
-  min-width: 100px;
-  max-width: 100px;
   padding: 4px 8px;
   margin: 0;
 
   // 3. テキスト
   font-size: 13px;
-  font-weight: 500;
   text-align: left;
   white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
   color: rgb(80, 80, 80);
 
   // 4. 装飾
@@ -150,66 +42,25 @@
 
   // 5. その他
   cursor: pointer;
-  vertical-align: middle;
 }
 ```
 
----
-
 ## 値の記述
 
-### 色
-- **`rgb()`を使用**（16進数やカラーネームは使用しない）
+- 色: `rgb()`を使用（16進数・カラーネーム不可）
+- 単位: `px`基本、`0`は単位省略
+- 共通プロパティは複数セレクタをカンマ区切りでまとめる
 
-```scss
-// ❌ 悪い例
-color: #333;
-color: gray;
+## 詳細度
 
-// ✅ 良い例
-color: rgb(51, 51, 51);
-color: rgb(128, 128, 128);
-```
-
-### 単位
-- `0`の場合は単位を省略: `margin: 0`
-- `px`を基本単位として使用
-- フォントサイズは`px`を使用
-
-### マジックナンバー
-- 繰り返し使う値はSCSS変数にする検討をする
-- ただし1箇所でしか使わない値は直接記述してよい
-
----
-
-## 動的スタイル
-
-### クラスの切り替えで対応
-```tsx
-// ❌ 悪い例
-<div style={{ display: isVisible ? 'block' : 'none' }}>
-
-// ✅ 良い例
-<div className={cx(styles.content, { [styles.visible]: isVisible })}>
-// または
-<div className={isVisible ? styles.visible : styles.hidden}>
-```
-
-### 条件付きクラスの結合
-- `cx()`ユーティリティを使用してクラスを結合する
-
-```tsx
-<th className={cx(style.th, column.className, column.headerClass)}>
-```
-
----
+- `!important`は使用しない
+- 上書きが必要な場合はセレクタを重ねる: `.align_right.align_right`
+- CSS Modulesの読み込み順に依存しないよう、汎用コンポーネント側にユーティリティクラスを用意する
 
 ## レスポンシブ
 
 - メディアクエリはコンポーネント単位でSCSSファイル内に記述
-- モバイルファーストで記述し、`min-width`で拡張
-
----
+- モバイルファーストで`min-width`で拡張
 
 ## 更新履歴
 - 2026-04-16: 初版作成

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,27 +1,48 @@
-# Claude Code フロントエンド開発ルール
+# フロントエンド開発ルール
 
-## 基本原則
+## TypeScript
 
-### 1. TypeScript厳格モード
-- **絶対にany型を使用しない**
-- すべての変数、関数の引数、戻り値に適切な型を定義する
-- 型推論が効く場合でも、複雑な型は明示的に定義する
+- any型は使用しない
+- すべての関数の引数・戻り値に型を定義する
+- `undefined`/`null`の可能性がある値は`?.`や`??`でチェックする
+- console.logは使用しない（エラーはサイレント処理またはUI通知）
 
-### 2. エラーハンドリング
-- `undefined`や`null`の可能性がある場合は必ずチェックする
-- オプショナルチェーン（`?.`）や Nullish Coalescing（`??`）を活用
-- try-catchブロックではエラーを適切に処理し、console.logは使用しない
+## React/Next.js
 
-### 3. React/Next.js規約
-- 関数コンポーネントを使用（クラスコンポーネントは使用しない）
-- カスタムフックは`use`プレフィックスを付ける
-- コンポーネント名はPascalCase、その他の関数はcamelCase
-- 関数コンポーネントの引数は分割代入せず、propsとして受け取ってから内部で展開する
+- 関数コンポーネントのみ使用
+- コンポーネント名はPascalCase、関数はcamelCase
+- カスタムフックは`use`プレフィックス
+- Propsは分割代入せず`props`で受け取り、内部で展開する
 
-## コーディング規約
-
-### インポート順序
 ```typescript
+export default function Component(props: Props): React.JSX.Element {
+  const { value, onChange } = props
+}
+```
+
+## 命名規則
+
+| 対象 | 規則 | 例 |
+|------|------|-----|
+| Props型 | `Props`のみ | `interface Props {}` |
+| 状態変数 | `[value, setValue]` | `[count, setCount]` |
+| イベントハンドラー | `handle${Event}` | `handleSubmit` |
+| boolean変数 | `is${State}` | `isLoading`, `isOpen` |
+
+## useState
+
+- 必ず型引数を指定する
+
+```typescript
+const [count, setCount] = useState<number>(0)
+const [name, setName] = useState<string>('')
+const [items, setItems] = useState<Item[]>([])
+const [user, setUser] = useState<User | null>(null)
+```
+
+## インポート順序
+
+```
 1. React関連
 2. 外部ライブラリ
 3. 内部型定義
@@ -29,118 +50,46 @@
 5. スタイル
 ```
 
-### 命名規則
-- **Props型**: 必ず`Props`のみを使用（`${ComponentName}Props`は使用しない）
-- **状態変数**: `[value, setValue]`の形式
-- **イベントハンドラー**: `handle${EventName}`の形式
-- **boolean変数**: 基本的に`is${State}`を使用（`should${Action}`も可）
+## 非同期処理
 
-### スタイル
-- 詳細は [CSS/SCSSコーディングルール](css.md) を参照
-- **必ずCSS Modulesを使用**（`.module.scss`）
-- **インラインスタイルは絶対に使用しない**
+- API呼び出しは`async/await`で記述する
+- エラーハンドリングは`Result`型（`isErr()`）パターンで行う
+- ローディング状態は`useIsLoading`フックで管理する
 
-## 品質管理
+## コンポーネント設計
 
-### ESLint/Prettier遵守
-- **必ずLinterのチェックを実行すること（`npm run lint`）**
-- すべてのESLintエラーを解決
-- ファイル末尾に改行を追加
-- セミコロンなし（設定による）
-- トレーリングカンマを使用
+- 1ファイル1コンポーネント（default export）
+- ロジックが複雑になったらカスタムフックに切り出す
+- `pages/`はデータ取得（`getServerSideProps`等）とテンプレート呼び出しのみ
+- `templates/`にページの実装を置く
 
-### 型安全性
-```typescript
-// ❌ 悪い例
-const playerRef = useRef<any>(null)
-const handleClick = (e: any) => {}
+## ディレクトリ構成の責務
 
-// ✅ 良い例
-type Player = ReturnType<typeof videojs>
-const playerRef = useRef<Player | null>(null)
-const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {}
-```
-
-### コンポーネントのProps受け取り方
-```typescript
-// ❌ 悪い例
-export default function VideoJS({ options, onReady }: Props): React.JSX.Element {
-  // ...
-}
-
-// ✅ 良い例
-export default function VideoJS(props: Props): React.JSX.Element {
-  const { options, onReady } = props
-  // ...
-}
-```
-
-### Null/Undefinedチェック
-```typescript
-// ❌ 悪い例
-playerRef.current.play()
-
-// ✅ 良い例
-if (playerRef.current && playerRef.current.play) {
-  playerRef.current.play()
-}
-// または
-playerRef.current?.play?.()
-```
+| ディレクトリ | 責務 |
+|------|------|
+| `pages/` | ルーティング、SSRデータ取得 |
+| `templates/` | ページの実装、状態管理 |
+| `widgets/` | 複合コンポーネント（Modal, Card等） |
+| `parts/` | 汎用UIコンポーネント（Button, Input等） |
+| `hooks/` | カスタムフック |
+| `api/` | APIクライアント関数 |
+| `types/` | 型定義 |
+| `utils/` | ユーティリティ関数 |
 
 ## スタイル
 
-CSS/SCSSのルールは [CSS/SCSSコーディングルール](css.md) を参照。
+[SCSSコーディングルール](css.md) を参照。
 
-## プロジェクト固有ルール
+## リンターチェック（必須）
 
-### video.js使用時
-- Player型は`ReturnType<typeof videojs>`を使用
-- `any`型の代わりに適切な型定義を探す
-- プレーヤーの存在確認を必ず行う
+コードを書いた後、必ず `npm run lint` を実行する。
 
-### Media関連コンポーネント
-- 既存のスタイルを活用
-- デザインシステムを崩さない
-- レスポンシブデザインを考慮
-
-### パフォーマンス
-- 不要な再レンダリングを避ける（useCallback、useMemoの適切な使用）
-- 大きなコンポーネントは適切に分割
-- 画像は適切なサイズと形式を使用
-
-## デバッグとエラー処理
-
-### console使用禁止
-```typescript
-// ❌ 悪い例
-console.log('Error:', error)
-
-// ✅ 良い例
-// エラーはサイレントに処理するか、適切なエラーハンドリングを実装
-.catch(() => {
-  // Handle error silently or show user-friendly message
-})
-```
-
-### 開発時の確認事項
-1. TypeScriptエラーが0件であること
-2. ESLintエラーが0件であること
-3. ビルドが成功すること
-4. 実行時エラーがないこと
-5. コメントアウトは日本語であること
-
-## コンポーネント作成チェックリスト
-
-- [ ] TypeScript型定義が完全
-- [ ] any型を使用していない
-- [ ] Propsインターフェースを定義
-- [ ] エラーハンドリングを実装
-- [ ] ESLintエラーなし
-- [ ] 既存のスタイルを活用
-- [ ] レスポンシブ対応
-- [ ] パフォーマンス最適化
+### 確認事項
+1. TypeScriptエラーが0件
+2. ESLintエラーが0件
+3. コメントは日本語で記述
 
 ## 更新履歴
 - 2024-08-21: 初版作成
-- 2025-08-21: Props名の統一ルール、関数コンポーネントの引数展開ルール、Linterチェックの必須化を追加
+- 2025-08-21: Props名統一、引数展開ルール、Linterチェック必須化
+- 2026-04-16: useState型引数必須、docs/に一元化、構成整理


### PR DESCRIPTION
## Summary
- 3ファイルのコーディングルールを簡潔に再構成（-750行, +155行）
- BE/FEに実用的なルールを追加
- 冗長なGood/Bad例を削除しルール文のみに

## 変更内容

### `docs/backend.md`
- 追加: 例外処理（素のexcept禁止、adapter層でのみエラーメッセージ返却）
- 追加: 文字列（f-string推奨、ログではキーワード引数）
- 追加: 層の責務テーブル（adapter/usecase/domain各層の依存方向を明示）
- 削除: 冗長なGood/Badコード例、プロジェクト固有セクション、運用セクション

### `docs/frontend.md`
- 追加: 非同期処理（async/await、Result型パターン）
- 追加: コンポーネント設計（1ファイル1コンポーネント、pages/templatesの分離）
- 追加: ディレクトリ構成の責務テーブル
- 追加: useState型引数必須ルール
- 削除: 冗長なコード例、チェックリスト、プロジェクト固有セクション

### `docs/css.md`
- Good/Bad例をすべて削除しルール文のみに
- SCSS/ネスト構文の基本原則を明確化
- CSS Modules適用範囲を明記（parts/widgets → module.scss、templates → グローバルCSS可）