### PR TITLE
【front】DataTableヘッダーの数値カラム右寄せ・公開カラム中央寄せ対応

### DIFF
--- a/frontend/src/components/parts/DataTable/DataTable.module.scss
+++ b/frontend/src/components/parts/DataTable/DataTable.module.scss
@@ -1,76 +1,92 @@
 .data_table {
+  overflow-x: auto;
   border: 1px solid rgb(220, 220, 220);
   border-radius: 5px;
-  overflow-x: auto;
 
   .table {
-    border-collapse: collapse;
     width: 100%;
     font-size: 13px;
+    border-collapse: collapse;
 
     .thead {
       background: rgb(245, 245, 245);
     }
   }
-}
 
-.checkbox {
-  width: 32px;
-  max-width: 32px;
-  text-align: center;
-  vertical-align: middle;
-  padding: 4px 0;
-}
+  .checkbox {
+    width: 32px;
+    max-width: 32px;
+    padding: 4px 0;
+    text-align: center;
+    vertical-align: middle;
+  }
 
-.th,
-.td {
-  padding: 4px 8px;
-  vertical-align: middle;
-  white-space: nowrap;
-}
+  .th,
+  .td {
+    padding: 4px 8px;
+    white-space: nowrap;
+    vertical-align: middle;
+  }
 
-.th {
-  text-align: left;
-  font-weight: 500;
-  border-bottom: 1px solid rgb(220, 220, 220);
+  .th {
+    font-weight: 500;
+    text-align: left;
+    border-bottom: 1px solid rgb(220, 220, 220);
 
-  .sort_button {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 0;
-    border: none;
-    background: none;
-    color: inherit;
-    font: inherit;
-    cursor: pointer;
+    .sort_button {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      width: 100%;
+      padding: 0;
+      background: none;
+      border: none;
+      cursor: pointer;
+
+      &:hover {
+        color: rgb(50, 110, 200);
+      }
+
+      .sort_mark {
+        font-size: 11px;
+        color: rgb(130, 130, 130);
+      }
+    }
+
+  }
+
+  .th_right {
+    text-align: right;
+
+    .sort_button {
+      justify-content: flex-end;
+    }
+  }
+
+  .th_center {
+    text-align: center;
+
+    .sort_button {
+      justify-content: center;
+    }
+  }
+
+  .td {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  .tr {
+    border-bottom: 1px solid rgb(235, 235, 235);
 
     &:hover {
-      color: rgb(50, 110, 200);
-    }
-
-    .sort_mark {
-      font-size: 11px;
-      color: rgb(130, 130, 130);
+      background: rgb(250, 250, 250);
     }
   }
-}
 
-.td {
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-.tr {
-  border-bottom: 1px solid rgb(235, 235, 235);
-
-  &:hover {
-    background: rgb(250, 250, 250);
+  .empty {
+    padding: 40px;
+    text-align: center;
+    color: rgb(150, 150, 150);
   }
-}
-
-.empty {
-  padding: 40px;
-  text-align: center;
-  color: rgb(150, 150, 150);
 }

--- a/frontend/src/components/parts/DataTable/DataTable.module.scss
+++ b/frontend/src/components/parts/DataTable/DataTable.module.scss
@@ -39,8 +39,10 @@
       gap: 4px;
       width: 100%;
       padding: 0;
-      background: none;
       border: none;
+      background: none;
+      color: inherit;
+      font: inherit;
       cursor: pointer;
 
       &:hover {

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -7,9 +7,10 @@ type SortOrder = 'asc' | 'desc'
 export interface Column<T> {
   key: string
   header: string
+  align?: 'left' | 'center' | 'right'
   sortable?: boolean
   sortValue?: (row: T) => string | number
-  render: (row: T) => React.ReactNode
+  cell: (row: T) => React.ReactNode
   className?: string
   headerClass?: string
   cellClass?: string
@@ -93,7 +94,17 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
               </th>
             )}
             {columns.map((column) => (
-              <th key={column.key} className={cx(style.th, column.className, column.headerClass)}>
+              <th
+                key={column.key}
+                className={cx(
+                  style.th,
+                  column.className,
+                  column.headerClass,
+                  column.cellClass,
+                  column.align === 'right' && style.th_right,
+                  column.align === 'center' && style.th_center,
+                )}
+              >
                 {column.sortable ? (
                   <button type="button" className={style.sort_button} onClick={() => handleSort(column.key)}>
                     {column.header}
@@ -118,7 +129,7 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
                 )}
                 {columns.map((column) => (
                   <td key={column.key} className={cx(style.td, column.className, column.cellClass)}>
-                    {column.render(row)}
+                    {column.cell(row)}
                   </td>
                 ))}
               </tr>

--- a/frontend/src/components/templates/manage/media/video/index.tsx
+++ b/frontend/src/components/templates/manage/media/video/index.tsx
@@ -65,7 +65,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       key: 'thumbnail',
       header: 'サムネイル',
       className: style.thumbnail,
-      render: (v) => v.image && <ExImage src={v.image} width="96" height="54" />,
+      cell: (v) => v.image && <ExImage src={v.image} width="96" height="54" />,
     },
     {
       key: 'title',
@@ -73,7 +73,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => v.title,
       className: style.title,
-      render: (v) => (
+      cell: (v) => (
         <a className={style.title_link} onClick={() => handleEdit(v)}>
           {v.title}
         </a>
@@ -85,7 +85,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => v.content,
       className: style.content,
-      render: (v) => v.content,
+      cell: (v) => v.content,
     },
     {
       key: 'created',
@@ -93,35 +93,37 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       sortable: true,
       sortValue: (v) => new Date(v.created).getTime(),
       className: style.datetime,
-      render: (v) => formatDatetime(v.created),
+      cell: (v) => formatDatetime(v.created),
     },
     {
       key: 'read',
       header: '再生',
+      align: 'right',
       sortable: true,
       sortValue: (v) => v.read,
       className: style.narrow,
       cellClass: style.number,
-      render: (v) => v.read,
+      cell: (v) => v.read,
     },
     {
       key: 'like',
       header: 'いいね',
+      align: 'right',
       sortable: true,
       sortValue: (v) => v.like,
       className: style.narrow,
       cellClass: style.number,
-      render: (v) => v.like,
+      cell: (v) => v.like,
     },
     {
       key: 'publish',
       header: '公開',
+      align: 'center',
       sortable: true,
       sortValue: (v) => (v.publish ? 1 : 0),
       className: style.narrow,
-      headerClass: style.center,
       cellClass: style.publish,
-      render: (v) => (
+      cell: (v) => (
         <div className={style.publish_inner}>
           <Toggle isActive={v.publish} disable />
         </div>


### PR DESCRIPTION
## Summary
- DataTableの数値カラム（再生・いいね）のヘッダーを右寄せ、公開カラムのヘッダーを中央寄せに対応
- Column型に`align`プロパティを追加し、`render`を`cell`にリネーム
- SCSSをルールに準拠するよう整理（ネスト構文・プロパティ順序）

## 変更内容
### DataTable (`parts/DataTable/`)
- **index.tsx**: `Column<T>`に`align?: 'left' | 'center' | 'right'`を追加。`render`→`cell`にリネーム。`th`に`th_right`/`th_center`クラスを適用
- **DataTable.module.scss**: `.th_right`/`.th_center`に`text-align`を追加。`.sort_button`に`width: 100%`を追加しflex配置を有効化。全体をネスト構文に統一しプロパティ順序をルールに準拠

### 動画管理 (`templates/manage/media/video/`)
- **index.tsx**: `render`→`cell`のリネーム対応。再生・いいねに`align: 'right'`、公開に`align: 'center'`を設定