### PR TITLE
【front】投稿管理トップページ追加とDropMenuの投稿管理リンク移動

### DIFF
--- a/frontend/src/components/layout/Header/DropMenu/Cloud.tsx
+++ b/frontend/src/components/layout/Header/DropMenu/Cloud.tsx
@@ -1,8 +1,10 @@
 import router from 'next/router'
 import cx from 'utils/functions/cx'
+import { useUser } from 'components/hooks/useUser'
 import IconBlog from 'components/parts/Icon/Blog'
 import IconChat from 'components/parts/Icon/Chat'
 import IconComic from 'components/parts/Icon/Comic'
+import IconGrid from 'components/parts/Icon/Grid'
 import IconMusic from 'components/parts/Icon/Music'
 import IconPicture from 'components/parts/Icon/Picture'
 import IconVideo from 'components/parts/Icon/Video'
@@ -17,6 +19,14 @@ interface Props {
 export default function DropMenuCloud(props: Props): React.JSX.Element {
   const { open, onClose } = props
 
+  const { user } = useUser()
+
+  const handleManage = () => {
+    if (user.isStaff) router.push('http://127.0.0.1:8000/myus-admin')
+    if (user.isActive) router.push('/manage')
+    onClose()
+  }
+
   const handleRouter = (media: string) => {
     router.push(`/manage/${media}/create`)
     onClose()
@@ -25,6 +35,7 @@ export default function DropMenuCloud(props: Props): React.JSX.Element {
   return (
     <nav className={cx(style.drop_menu, open && style.active)}>
       <ul>
+        <MenuItem label="投稿管理" icon={<IconGrid size="1.5em" />} className={style.item} onClick={() => handleManage()} />
         <MenuItem label="Videoアップロード" icon={<IconVideo size="1.5em" />} className={style.item} onClick={() => handleRouter('video')} />
         <MenuItem label="Musicアップロード" icon={<IconMusic size="1.5em" />} className={style.item} onClick={() => handleRouter('music')} />
         <MenuItem label="Comicアップロード" icon={<IconComic size="1.5em" />} className={style.item} onClick={() => handleRouter('comic')} />

--- a/frontend/src/components/layout/Header/DropMenu/Profile.tsx
+++ b/frontend/src/components/layout/Header/DropMenu/Profile.tsx
@@ -4,7 +4,6 @@ import cx from 'utils/functions/cx'
 import { useUser } from 'components/hooks/useUser'
 import IconArrow from 'components/parts/Icon/Arrow'
 import IconCredit from 'components/parts/Icon/Credit'
-import IconGrid from 'components/parts/Icon/Grid'
 import IconPerson from 'components/parts/Icon/Person'
 import MenuItem from 'components/parts/NavItem/MenuItem'
 import style from './DropMenu.module.scss'
@@ -18,7 +17,7 @@ export default function DropMenuProfile(props: Props): React.JSX.Element {
   const { open, onClose } = props
 
   const router = useRouter()
-  const { user, resetUser } = useUser()
+  const { resetUser } = useUser()
 
   const handleRouter = (url: string) => {
     router.push(url)
@@ -34,23 +33,11 @@ export default function DropMenuProfile(props: Props): React.JSX.Element {
     resetUser()
   }
 
-  const handleManagement = () => {
-    if (user.isStaff) {
-      router.push('http://127.0.0.1:8000/myus-admin')
-    } else if (user.isActive) {
-      router.push('http://127.0.0.1:8000/myus-manage')
-    } else {
-      router.push('/')
-    }
-    onClose()
-  }
-
   return (
     <nav className={cx(style.drop_menu, open && style.active)}>
       <ul>
         <MenuItem label="アカウント" icon={<IconPerson size="1.5em" type="circle" />} className={style.item} onClick={() => handleRouter('/setting/profile')} />
         <MenuItem label="マイページ" icon={<IconPerson size="1.5em" type="square" />} className={style.item} onClick={() => handleRouter('/setting/mypage')} />
-        <MenuItem label="投稿管理" icon={<IconGrid size="1.5em" />} className={style.item} onClick={handleManagement} />
         <MenuItem label="料金プラン" icon={<IconCredit size="1.5em" />} className={style.item} onClick={() => handleRouter('/setting/payment')} />
         <MenuItem label="退会処理" icon={<IconPerson size="1.5em" type="cross" />} className={style.item} onClick={() => handleRouter('/setting/withdrawal')} />
         <MenuItem label="ログイン" icon={<IconArrow size="1.5em" type="in" />} className={style.item} onClick={handleLogin} />

--- a/frontend/src/components/templates/manage/Manage.module.scss
+++ b/frontend/src/components/templates/manage/Manage.module.scss
@@ -1,79 +1,42 @@
-.manage {
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  padding: 16px 0;
+}
+
+.card {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.header_actions {
-  display: flex;
   align-items: center;
   gap: 12px;
+  padding: 24px 16px;
+  color: rgb(60, 60, 60);
+  border: 1px solid rgb(220, 220, 220);
+  border-radius: 8px;
+  background: rgb(250, 250, 250);
+  font: inherit;
+  cursor: pointer;
 
-  .selected_count {
-    font-size: 13px;
-    color: rgb(80, 80, 80);
-    white-space: nowrap;
-  }
-}
+  &:hover {
+    color: rgb(0, 70, 175);
+    background: rgb(248, 248, 248);
+    border-color: rgb(50, 110, 200);
 
-.filter {
-  width: 240px;
-}
-
-.thumbnail {
-  width: 120px;
-  min-width: 120px;
-  max-width: 120px;
-
-  img {
-    width: 96px;
-    height: 54px;
-    object-fit: cover;
-    border-radius: 4px;
-  }
-}
-
-.title {
-  min-width: 160px;
-  max-width: 240px;
-
-  .title_link {
-    color: rgb(50, 110, 200);
-    cursor: pointer;
-
-    &:hover {
-      text-decoration: underline;
+    .icon {
+      color: rgb(0, 70, 175);
     }
   }
 }
 
-.content {
-  min-width: 200px;
-  max-width: 280px;
-}
-
-.datetime {
-  width: 100px;
-}
-
-.narrow {
-  width: 56px;
-}
-
-.center {
-  text-align: center;
-}
-
-.number {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.publish {
-  text-align: center;
-}
-
-.publish_inner {
-  display: inline-flex;
+.icon {
+  display: flex;
   align-items: center;
+  justify-content: center;
+  color: rgb(80, 80, 80);
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 500;
 }

--- a/frontend/src/components/templates/manage/Media.module.scss
+++ b/frontend/src/components/templates/manage/Media.module.scss
@@ -1,0 +1,79 @@
+.manage {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.header_actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .selected_count {
+    font-size: 13px;
+    color: rgb(80, 80, 80);
+    white-space: nowrap;
+  }
+}
+
+.filter {
+  width: 240px;
+}
+
+.thumbnail {
+  width: 120px;
+  min-width: 120px;
+  max-width: 120px;
+
+  img {
+    width: 96px;
+    height: 54px;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+}
+
+.title {
+  min-width: 160px;
+  max-width: 240px;
+
+  .title_link {
+    color: rgb(50, 110, 200);
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.content {
+  min-width: 200px;
+  max-width: 280px;
+}
+
+.datetime {
+  width: 100px;
+}
+
+.narrow {
+  width: 56px;
+}
+
+.center {
+  text-align: center;
+}
+
+.number {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.publish {
+  text-align: center;
+}
+
+.publish_inner {
+  display: inline-flex;
+  align-items: center;
+}

--- a/frontend/src/components/templates/manage/index.tsx
+++ b/frontend/src/components/templates/manage/index.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router'
+import Main from 'components/layout/Main'
+import IconBlog from 'components/parts/Icon/Blog'
+import IconChat from 'components/parts/Icon/Chat'
+import IconComic from 'components/parts/Icon/Comic'
+import IconMusic from 'components/parts/Icon/Music'
+import IconPicture from 'components/parts/Icon/Picture'
+import IconVideo from 'components/parts/Icon/Video'
+import style from './Manage.module.scss'
+
+const menus = [
+  { label: 'Video', icon: <IconVideo size="2em" />, path: 'video' },
+  { label: 'Music', icon: <IconMusic size="2em" />, path: 'music' },
+  { label: 'Comic', icon: <IconComic size="2em" />, path: 'comic' },
+  { label: 'Picture', icon: <IconPicture size="2em" />, path: 'picture' },
+  { label: 'Blog', icon: <IconBlog size="2em" />, path: 'blog' },
+  { label: 'Chat', icon: <IconChat size="2em" />, path: 'chat' },
+]
+
+export default function Manage(): React.JSX.Element {
+  const router = useRouter()
+
+  return (
+    <Main title="投稿管理" type="table" isFooter={false}>
+      <div className={style.grid}>
+        {menus.map((menu) => (
+          <button key={menu.label} type="button" className={style.card} onClick={() => router.push(`/manage/${menu.path}`)}>
+            <div className={style.icon}>{menu.icon}</div>
+            <span className={style.label}>{menu.label}</span>
+          </button>
+        ))}
+      </div>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -16,7 +16,7 @@ import ExImage from 'components/parts/ExImage'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Toggle from 'components/parts/Input/Toggle'
 import DeleteModal from 'components/widgets/Modal/Delete'
-import style from '../Manage.module.scss'
+import style from '../Media.module.scss'
 
 interface Props {
   datas: Video[]

--- a/frontend/src/pages/manage/index.tsx
+++ b/frontend/src/pages/manage/index.tsx
@@ -1,0 +1,12 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import Manage from 'components/templates/manage'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  return { props: { ...translations } }
+}
+
+export default function ManagePage(): React.JSX.Element {
+  return <Manage />
+}


### PR DESCRIPTION
## Summary
- 投稿管理トップページ（`/manage`）を新規追加し、メディア種別ごとのカードグリッドUIを実装
- DropMenuの「投稿管理」リンクをProfileメニューからCloudメニューに移動
- 既存のManage.module.scssをトップページ用に変更し、メディア管理用スタイルをMedia.module.scssに分離

## 変更内容
### 新規ファイル
- `components/templates/manage/index.tsx`: 投稿管理トップページテンプレート（Video/Music/Comic/Picture/Blog/Chatのカードグリッド）
- `components/templates/manage/Media.module.scss`: メディア個別管理ページ用スタイル（旧Manage.module.scssの内容を移動）
- `pages/manage/index.tsx`: `/manage`ルートのページコンポーネント

### 変更ファイル
- `DropMenu/Cloud.tsx`: 「投稿管理」メニュー項目を追加、isStaff/isActiveに応じた遷移先分岐
- `DropMenu/Profile.tsx`: 「投稿管理」メニュー項目を削除、未使用のIconGrid・user変数を除去
- `Manage.module.scss`: トップページ用のグリッド・カードスタイルに変更
- `manage/video/index.tsx`: スタイルのimportをMedia.module.scssに変更