### PR TITLE
【front】動画管理テーブルのカラム順序・幅調整とSCSS整理

### DIFF
--- a/frontend/src/components/templates/manage/Media.module.scss
+++ b/frontend/src/components/templates/manage/Media.module.scss
@@ -52,12 +52,16 @@
   max-width: 280px;
 }
 
-.datetime {
-  width: 100px;
+.narrow {
+  width: 60px;
 }
 
-.narrow {
-  width: 56px;
+.normal {
+  width: 140px;
+}
+
+.datetime {
+  width: 100px;
 }
 
 .center {
@@ -71,9 +75,9 @@
 
 .publish {
   text-align: center;
-}
 
-.publish_inner {
-  display: inline-flex;
-  align-items: center;
+  .publish_inner {
+    display: inline-flex;
+    align-items: center;
+  }
 }

--- a/frontend/src/components/templates/manage/Media.module.scss
+++ b/frontend/src/components/templates/manage/Media.module.scss
@@ -53,7 +53,7 @@
 }
 
 .narrow {
-  width: 60px;
+  width: 80px;
 }
 
 .normal {
@@ -61,7 +61,7 @@
 }
 
 .datetime {
-  width: 100px;
+  width: 120px;
 }
 
 .center {

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -86,20 +86,12 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       cell: (v) => v.content,
     },
     {
-      key: 'created',
-      header: '投稿日時',
-      sortable: true,
-      sortValue: (v) => new Date(v.created).getTime(),
-      className: style.datetime,
-      cell: (v) => formatDatetime(v.created),
-    },
-    {
       key: 'read',
       header: '再生',
       align: 'right',
       sortable: true,
       sortValue: (v) => v.read,
-      className: style.narrow,
+      className: style.normal,
       cellClass: style.number,
       cell: (v) => v.read,
     },
@@ -109,7 +101,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       align: 'right',
       sortable: true,
       sortValue: (v) => v.like,
-      className: style.narrow,
+      className: style.normal,
       cellClass: style.number,
       cell: (v) => v.like,
     },
@@ -126,6 +118,14 @@ export default function ManageVideos(props: Props): React.JSX.Element {
           <Toggle isActive={v.publish} disable />
         </div>
       ),
+    },
+    {
+      key: 'created',
+      header: '投稿日時',
+      sortable: true,
+      sortValue: (v) => new Date(v.created).getTime(),
+      className: style.datetime,
+      cell: (v) => formatDatetime(v.created),
     },
   ]
 


### PR DESCRIPTION
## Summary
- 動画管理テーブルのカラム順序を変更（投稿日時を末尾に移動）
- 再生数・いいね数カラムの幅を拡大（56px → 140px）
- Media.module.scssのスタイルクラス整理

## 変更内容
### manage/video/index.tsx
- `created`（投稿日時）カラムを`content`の直後から`publish`（公開）の後に移動
- `read`（再生）、`like`（いいね）カラムのclassNameを`style.narrow` → `style.normal`に変更

### Media.module.scss
- `.narrow`: 56px → 60pxに調整
- `.normal`: 140px幅のクラスを新規追加（再生数・いいね数用）
- `.datetime`と`.narrow`の定義順を整理
- `.publish_inner`を`.publish`のネストに変更（スコープの明確化）