### PR TITLE
【front】Paginationコンポーネントを新規追加

### DIFF
--- a/frontend/src/components/parts/Pagination/ArrowButton/ArrowButton.module.scss
+++ b/frontend/src/components/parts/Pagination/ArrowButton/ArrowButton.module.scss
@@ -1,0 +1,22 @@
+.button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  color: rgb(60, 60, 60);
+  background: none;
+  border: 1px solid rgb(220, 220, 220);
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover:not(.disabled) {
+    background: rgb(245, 245, 245);
+  }
+
+  &.disabled {
+    color: rgb(180, 180, 180);
+    cursor: default;
+  }
+}

--- a/frontend/src/components/parts/Pagination/ArrowButton/index.tsx
+++ b/frontend/src/components/parts/Pagination/ArrowButton/index.tsx
@@ -1,0 +1,19 @@
+import cx from 'utils/functions/cx'
+import IconChevront from 'components/parts/Icon/Chevront'
+import style from './ArrowButton.module.scss'
+
+interface Props {
+  type: 'left' | 'right'
+  disabled: boolean
+  onClick: () => void
+}
+
+export default function ArrowButton(props: Props): React.JSX.Element {
+  const { type, disabled, onClick } = props
+
+  return (
+    <button type="button" className={cx(style.button, disabled && style.disabled)} disabled={disabled} onClick={onClick}>
+      <IconChevront width="12" height="12" type={type} />
+    </button>
+  )
+}

--- a/frontend/src/components/parts/Pagination/PageButton/PageButton.module.scss
+++ b/frontend/src/components/parts/Pagination/PageButton/PageButton.module.scss
@@ -1,0 +1,24 @@
+.button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  font-size: 13px;
+  color: rgb(60, 60, 60);
+  background: none;
+  border: 1px solid rgb(220, 220, 220);
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover:not(.active) {
+    background: rgb(245, 245, 245);
+  }
+
+  &.active {
+    color: rgb(255, 255, 255);
+    background: rgb(0, 120, 255);
+    border-color: rgb(0, 120, 255);
+  }
+}

--- a/frontend/src/components/parts/Pagination/PageButton/index.tsx
+++ b/frontend/src/components/parts/Pagination/PageButton/index.tsx
@@ -1,0 +1,18 @@
+import cx from 'utils/functions/cx'
+import style from './PageButton.module.scss'
+
+interface Props {
+  page: number
+  isActive: boolean
+  onClick: () => void
+}
+
+export default function PageButton(props: Props): React.JSX.Element {
+  const { page, isActive, onClick } = props
+
+  return (
+    <button type="button" className={cx(style.button, isActive && style.active)} onClick={onClick}>
+      {page}
+    </button>
+  )
+}

--- a/frontend/src/components/parts/Pagination/Pagination.module.scss
+++ b/frontend/src/components/parts/Pagination/Pagination.module.scss
@@ -1,0 +1,17 @@
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 0;
+
+  .ellipsis {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-width: 32px;
+    height: 32px;
+    font-size: 13px;
+    color: rgb(130, 130, 130);
+  }
+}

--- a/frontend/src/components/parts/Pagination/index.tsx
+++ b/frontend/src/components/parts/Pagination/index.tsx
@@ -1,0 +1,48 @@
+import ArrowButton from './ArrowButton'
+import PageButton from './PageButton'
+import style from './Pagination.module.scss'
+
+const calcPages = (current: number, total: number): (number | '...')[] => {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+  const pages: (number | '...')[] = [1]
+  if (current > 3) pages.push('...')
+  const start = Math.max(2, current - 1)
+  const end = Math.min(total - 1, current + 1)
+  for (let i = start; i <= end; i++) pages.push(i)
+  if (current < total - 2) pages.push('...')
+  pages.push(total)
+  return pages
+}
+
+interface Props {
+  currentPage: number
+  totalPages: number
+  onChange: (page: number) => void
+}
+
+export default function Pagination(props: Props): React.JSX.Element | null {
+  const { currentPage, totalPages, onChange } = props
+
+  const pages = calcPages(currentPage, totalPages)
+  const handlePrev = () => onChange(currentPage - 1)
+  const handleNext = () => onChange(currentPage + 1)
+  const handlePage = (page: number) => () => onChange(page)
+
+  return (
+    <nav className={style.pagination}>
+      <ArrowButton type="left" disabled={currentPage === 1} onClick={handlePrev} />
+      {pages.map((page, i) =>
+        page === '...' ? (
+          <span key={`ellipsis-${i}`} className={style.ellipsis}>
+            …
+          </span>
+        ) : (
+          <PageButton key={page} page={page} isActive={page === currentPage} onClick={handlePage(page)} />
+        ),
+      )}
+      <ArrowButton type="right" disabled={currentPage === totalPages} onClick={handleNext} />
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- ページネーション用の汎用コンポーネント（Pagination）を新規追加
- ArrowButton・PageButtonをサブコンポーネントとして分離

## 変更内容
### 新規ファイル
#### Pagination/index.tsx
- ページ番号の計算ロジック（`calcPages`）: 7ページ以下は全表示、それ以上は省略記号付き
- Props: `currentPage`, `totalPages`, `onChange`
- ArrowButton・PageButtonを組み合わせたナビゲーション

#### Pagination/ArrowButton/
- 前へ/次へボタン（IconChevront使用）
- disabled状態のスタイル対応

#### Pagination/PageButton/
- ページ番号ボタン
- active状態で青背景（`rgb(0, 120, 255)`）

#### Pagination/Pagination.module.scss
- レイアウト（flexbox中央寄せ）と省略記号のスタイル

### 備考
- DataTableへの統合は別PRで対応予定