### PR TITLE
【front】usePaginationフック追加とDataTableのページネーション対応

### DIFF
--- a/frontend/src/components/hooks/usePagination.ts
+++ b/frontend/src/components/hooks/usePagination.ts
@@ -1,0 +1,25 @@
+import { useEffect, useMemo, useState } from 'react'
+
+interface UsePaginationResult<T> {
+  currentPage: number
+  totalPages: number
+  pageDatas: T[]
+  handlePage: (page: number) => void
+}
+
+export const usePagination = <T>(datas: T[], pageSize: number): UsePaginationResult<T> => {
+  const [currentPage, setCurrentPage] = useState<number>(1)
+
+  useEffect(() => setCurrentPage(1), [datas])
+
+  const totalPages = Math.ceil(datas.length / pageSize)
+
+  const pageDatas = useMemo(() => {
+    const start = (currentPage - 1) * pageSize
+    return datas.slice(start, start + pageSize)
+  }, [datas, currentPage, pageSize])
+
+  const handlePage = (page: number) => setCurrentPage(page)
+
+  return { currentPage, totalPages, pageDatas, handlePage }
+}

--- a/frontend/src/components/parts/DataTable/index.tsx
+++ b/frontend/src/components/parts/DataTable/index.tsx
@@ -23,10 +23,11 @@ interface Props<T> {
   selectable?: boolean
   selectedKeys?: Set<string>
   onSelection?: (selectedKeys: Set<string>) => void
+  footer?: React.ReactNode
 }
 
 export default function DataTable<T>(props: Props<T>): React.JSX.Element {
-  const { datas, columns, rowKey, selectable, selectedKeys, onSelection } = props
+  const { datas, columns, rowKey, selectable, selectedKeys, onSelection, footer } = props
 
   const [sortKey, setSortKey] = useState<string | null>(null)
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc')
@@ -138,6 +139,7 @@ export default function DataTable<T>(props: Props<T>): React.JSX.Element {
         </tbody>
       </table>
       {datas.length === 0 && <div className={style.empty}>データがありません</div>}
+      {footer}
     </div>
   )
 }

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -8,6 +8,7 @@ import { FetchError } from 'utils/constants/enum'
 import { formatDatetime } from 'utils/functions/datetime'
 import { useApiError } from 'components/hooks/useApiError'
 import { useIsLoading } from 'components/hooks/useIsLoading'
+import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
@@ -15,6 +16,7 @@ import DataTable, { Column } from 'components/parts/DataTable'
 import ExImage from 'components/parts/ExImage'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Toggle from 'components/parts/Input/Toggle'
+import Pagination from 'components/parts/Pagination'
 import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
 
@@ -26,6 +28,8 @@ interface Props {
 export default function ManageVideos(props: Props): React.JSX.Element {
   const { datas, channels } = props
 
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { toast, handleToast } = useToast()
@@ -33,6 +37,8 @@ export default function ManageVideos(props: Props): React.JSX.Element {
   const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
   const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+  const channelDatas = useMemo(() => datas.filter((v) => v.channel.ulid === channelUlid), [datas, channelUlid])
+  const { currentPage, totalPages, pageDatas, handlePage } = usePagination(channelDatas, 50)
 
   const handleDelete = () => setIsDeleteModal(!isDeleteModal)
   const handleEdit = (video: Video) => router.push(`/manage/video/${video.ulid}`)
@@ -53,12 +59,6 @@ export default function ManageVideos(props: Props): React.JSX.Element {
     handleDelete()
     router.replace(router.asPath)
   }
-
-  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
-
-  const channelDatas = useMemo(() => {
-    return datas.filter((v) => v.channel.ulid === channelUlid)
-  }, [datas, channelUlid])
 
   const columns: Column<Video>[] = [
     {
@@ -148,7 +148,15 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       }
     >
       <div className={style.manage}>
-        <DataTable datas={channelDatas} columns={columns} rowKey={(v) => v.ulid} selectable selectedKeys={selectedKeys} onSelection={setSelectedKeys} />
+        <DataTable
+          datas={pageDatas}
+          columns={columns}
+          rowKey={(v) => v.ulid}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelection={setSelectedKeys}
+          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
+        />
       </div>
       <DeleteModal
         open={isDeleteModal}


### PR DESCRIPTION
## Summary
- `usePagination`カスタムフックを新規追加し、ページネーションロジックを再利用可能に
- DataTableに`footer` propを追加し、外部からフッターコンテンツを注入可能に
- 動画管理ページに1ページ50件のページネーションを実装

## 変更内容
### 新規: hooks/usePagination.ts
- ジェネリック型対応のページネーションフック
- `datas`と`pageSize`を受け取り、`currentPage`, `totalPages`, `pageDatas`, `handlePage`を返す
- データ変更時に自動でページ1にリセット（`useEffect`）
- 他のメディア管理ページでもそのまま再利用可能

### 変更: DataTable/index.tsx
- `footer?: React.ReactNode` propを追加
- テーブル下部に`{footer}`を描画
- ページネーションのロジックはDataTableに持たせず、親から注入する設計

### 変更: manage/video/index.tsx
- `usePagination(channelDatas, 50)`でページネーション管理
- `pageDatas`（ページ分割済みデータ）をDataTableに渡す
- `Pagination`コンポーネントをDataTableの`footer`として渡す