### PR TITLE
【back】schema/media.pyをパッケージ化しinput/outputに分離

### DIFF
--- a/frontend/src/types/internal/media/index.d.ts
+++ b/frontend/src/types/internal/media/index.d.ts
@@ -1,13 +1,17 @@
 import { Channel } from 'types/internal/channel'
 
-export interface MediaUser {
-  isLike: boolean
-  isSubscribe: boolean
-}
-
 export interface Search {
   name?: string
   count: number
+}
+
+export interface SearchParms {
+  search?: string
+}
+
+export interface MediaUser {
+  isLike: boolean
+  isSubscribe: boolean
 }
 
 export interface Media {
@@ -61,8 +65,4 @@ export interface MediaHome {
   pictures: Picture[]
   blogs: Blog[]
   chats: Chat[]
-}
-
-export interface SearchParms {
-  search?: string
 }

--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -3,7 +3,8 @@ from ninja import Router
 from api.modules.logger import log
 from api.src.adapter.media import convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media import BulkDeleteIn, VideoOut, VideoUpdateIn
+from api.src.types.schema.media.input import BulkDeleteIn, VideoUpdateIn
+from api.src.types.schema.media.output import VideoOut
 from api.src.usecase.auth import auth_check
 from api.src.usecase.manage.media import delete_manage_video, get_manage_video, get_manage_videos, update_manage_video
 

--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -15,10 +15,10 @@ from api.src.types.dto.message import MessageDTO
 from api.src.types.dto.user import AuthorDTO, MediaUserDTO
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.comment import CommentOut, ReplyOut
-from api.src.types.schema.media import VideoIn, MusicIn, ComicIn,PictureIn, BlogIn, ChatIn
-from api.src.types.schema.media import HomeOut, VideoOut, MusicOut, ComicOut, PictureOut, BlogOut, ChatOut, MediaCreateOut, HashtagOut
-from api.src.types.schema.media import VideoDetailOut, MusicDetailOut, ComicDetailOut, PictureDetailOut, BlogDetailOut, ChatDetailOut
-from api.src.types.schema.media import VideoDetailsOut, MusicDetailsOut, ComicDetailsOut, PictureDetailsOut, BlogDetailsOut, ChatDetailsOut
+from api.src.types.schema.media.input import VideoIn, MusicIn, ComicIn, PictureIn, BlogIn, ChatIn
+from api.src.types.schema.media.output import HomeOut, VideoOut, MusicOut, ComicOut, PictureOut, BlogOut, ChatOut, MediaCreateOut, HashtagOut
+from api.src.types.schema.media.output import VideoDetailOut, MusicDetailOut, ComicDetailOut, PictureDetailOut, BlogDetailOut, ChatDetailOut
+from api.src.types.schema.media.output import VideoDetailsOut, MusicDetailsOut, ComicDetailsOut, PictureDetailsOut, BlogDetailsOut, ChatDetailsOut
 from api.src.types.schema.message import MessageOut
 from api.src.types.schema.channel import ChannelOut
 from api.src.types.schema.user import AuthorOut, MediaUserOut

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -1,0 +1,57 @@
+from pydantic import BaseModel
+
+
+class VideoIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+
+
+class MusicIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+    lyric: str
+    download: bool
+
+
+class ComicIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+
+
+class PictureIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+
+
+class BlogIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+    richtext: str
+
+
+class ChatIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+    period: str
+
+
+class VideoUpdateIn(BaseModel):
+    title: str
+    content: str
+    publish: bool
+
+
+class BulkDeleteIn(BaseModel):
+    ulids: list[str]

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -46,66 +46,28 @@ class VideoOut(MediaOut):
     convert: str
 
 
-class VideoDetailOut(MediaDetailOut):
-    image: str
-    video: str
-    convert: str
-    comments: list[CommentOut]
-
-
 class MusicOut(MediaOut):
     lyric: str
     music: str
     download: bool
 
 
-class MusicDetailOut(MediaDetailOut):
-    lyric: str
-    music: str
-    download: bool
-    comments: list[CommentOut]
-
-
 class ComicOut(MediaOut):
     image: str
-
-
-class ComicDetailOut(MediaDetailOut):
-    image: str
-    pages: list[str]
-    comments: list[CommentOut]
 
 
 class PictureOut(MediaOut):
     image: str
 
 
-class PictureDetailOut(MediaDetailOut):
-    image: str
-    comments: list[CommentOut]
-
-
 class BlogOut(MediaOut):
     image: str
-
-
-class BlogDetailOut(MediaDetailOut):
-    richtext: str
-    image: str
-    comments: list[CommentOut]
 
 
 class ChatOut(MediaOut):
     thread: int
     joined: int
     period: datetime
-
-
-class ChatDetailOut(MediaDetailOut):
-    thread: int
-    joined: int
-    period: datetime
-    messages: list[MessageOut]
 
 
 class HomeOut(BaseModel):
@@ -115,6 +77,44 @@ class HomeOut(BaseModel):
     pictures: list[PictureOut]
     blogs: list[BlogOut]
     chats: list[ChatOut]
+
+
+class VideoDetailOut(MediaDetailOut):
+    image: str
+    video: str
+    convert: str
+    comments: list[CommentOut]
+
+
+class MusicDetailOut(MediaDetailOut):
+    lyric: str
+    music: str
+    download: bool
+    comments: list[CommentOut]
+
+
+class ComicDetailOut(MediaDetailOut):
+    image: str
+    pages: list[str]
+    comments: list[CommentOut]
+
+
+class PictureDetailOut(MediaDetailOut):
+    image: str
+    comments: list[CommentOut]
+
+
+class BlogDetailOut(MediaDetailOut):
+    richtext: str
+    image: str
+    comments: list[CommentOut]
+
+
+class ChatDetailOut(MediaDetailOut):
+    thread: int
+    joined: int
+    period: datetime
+    messages: list[MessageOut]
 
 
 class VideoDetailsOut(BaseModel):

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -6,66 +6,6 @@ from api.src.types.schema.channel import ChannelOut
 from api.src.types.schema.user import MediaUserOut
 
 
-# Inputs
-
-class VideoIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-
-
-class MusicIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-    lyric: str
-    download: bool
-
-
-class ComicIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-
-
-class PictureIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-
-
-class BlogIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-    richtext: str
-
-
-class ChatIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-    period: str
-
-
-class VideoUpdateIn(BaseModel):
-    title: str
-    content: str
-    publish: bool
-
-
-class BulkDeleteIn(BaseModel):
-    ulids: list[str]
-
-
-# Outputs
-
 class MediaCreateOut(BaseModel):
     ulid: str
 

--- a/myus/api/src/types/schema/userpage.py
+++ b/myus/api/src/types/schema/userpage.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pydantic import BaseModel
 from api.src.types.schema.channel import ChannelOut
-from api.src.types.schema.media import VideoOut, MusicOut, ComicOut, PictureOut, BlogOut, ChatOut
+from api.src.types.schema.media.output import VideoOut, MusicOut, ComicOut, PictureOut, BlogOut, ChatOut
 
 
 class UserPageOut(BaseModel):

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -4,7 +4,7 @@ from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media import VideoUpdateIn
+from api.src.types.schema.media.input import VideoUpdateIn
 from api.utils.functions.index import create_url
 
 

--- a/myus/api/src/usecase/media.py
+++ b/myus/api/src/usecase/media.py
@@ -17,7 +17,7 @@ from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, SortType, ExcludeOption
 from api.src.injectors.container import injector
 from api.src.types.dto.media import MediaCreateDTO, HomeDTO, VideoDetailDTO, MusicDetailDTO, ComicDetailDTO, PictureDetailDTO, BlogDetailDTO, ChatDetailDTO
-from api.src.types.schema.media import VideoIn, MusicIn, ComicIn, PictureIn, BlogIn, ChatIn
+from api.src.types.schema.media.input import VideoIn, MusicIn, ComicIn, PictureIn, BlogIn, ChatIn
 from api.src.usecase.channel import get_channel_data
 from api.src.usecase.comment import get_comments
 from api.src.usecase.message import get_messages


### PR DESCRIPTION
## Summary
- `api/src/types/schema/media.py` を `api/src/types/schema/media/` パッケージに移行
- `*In`（リクエスト型）を `media/input.py`、`*Out`（レスポンス型）を `media/output.py` に分離
- フロントエンド側の `types/internal/media/{index,input}.d.ts` 構成と対称になり、入出力の責務が明確化

## 変更内容

### 型定義ファイルの再編
- `myus/api/src/types/schema/media.py` → 削除
- `myus/api/src/types/schema/media/__init__.py`（新規・空）
- `myus/api/src/types/schema/media/input.py`（新規）
  - `VideoIn` / `MusicIn` / `ComicIn` / `PictureIn` / `BlogIn` / `ChatIn` / `VideoUpdateIn` / `BulkDeleteIn` を集約
- `myus/api/src/types/schema/media/output.py`（新規）
  - `MediaCreateOut` / `MediaOut` / `HashtagOut` / `MediaDetailOut`
  - 各メディアの `*Out` / `*DetailOut` / `*DetailsOut`
  - `HomeOut`

### import経路の更新
- `myus/api/src/adapter/media.py`
  - `*In` を `schema.media.input`、`*Out` 各種を `schema.media.output` から import
- `myus/api/src/adapter/manage.py`
  - `BulkDeleteIn` / `VideoUpdateIn` を `schema.media.input`、`VideoOut` を `schema.media.output` から import
- `myus/api/src/usecase/media.py`
  - `*In` を `schema.media.input` から import
- `myus/api/src/usecase/manage/media.py`
  - `VideoUpdateIn` を `schema.media.input` から import
- `myus/api/src/types/schema/userpage.py`
  - `*Out` 系を `schema.media.output` から import

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件は `logger.py` / `video_converter.py` / `db/models/*` / `adapter/media.py` の `period` 型不整合などで変更前から発生しているもの）