### PR TITLE
【front】SearchParmsをSearchParamsにリネーム

### DIFF
--- a/frontend/src/api/internal/manage/video.ts
+++ b/frontend/src/api/internal/manage/video.ts
@@ -3,12 +3,12 @@ import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
 import { VideoUpdateIn } from 'types/internal/media/input'
-import { SearchParms, Video } from 'types/internal/media/output'
+import { SearchParams, Video } from 'types/internal/media/output'
 import { ErrorOut } from 'types/internal/other'
 import { apiManageVideo, apiManageVideos } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
-export const getManageVideos = async (params: SearchParms, req?: Req): Promise<ApiOut<Video[]>> => {
+export const getManageVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<Video[]>> => {
   return await apiOut(apiClient('json').get(apiManageVideos, cookieHeader(req, params)))
 }
 

--- a/frontend/src/api/internal/media/list.ts
+++ b/frontend/src/api/internal/media/list.ts
@@ -2,37 +2,37 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { SearchParms, MediaHome, Video, Music, Comic, Picture, Blog, Chat } from 'types/internal/media/output'
+import { SearchParams, MediaHome, Video, Music, Comic, Picture, Blog, Chat } from 'types/internal/media/output'
 import { apiHome, apiRecommend, apiVideos, apiMusics, apiComics, apiPictures, apiBlogs, apiChats } from 'api/uri'
 
-export const getHome = async (params: SearchParms, req?: Req): Promise<ApiOut<MediaHome>> => {
+export const getHome = async (params: SearchParams, req?: Req): Promise<ApiOut<MediaHome>> => {
   return await apiOut(apiClient('json').get(apiHome, cookieHeader(req, params)))
 }
 
-export const getRecommend = async (params: SearchParms, req?: Req): Promise<ApiOut<MediaHome>> => {
+export const getRecommend = async (params: SearchParams, req?: Req): Promise<ApiOut<MediaHome>> => {
   return await apiOut(apiClient('json').get(apiRecommend, cookieHeader(req, params)))
 }
 
-export const getVideos = async (params: SearchParms, req?: Req): Promise<ApiOut<Video[]>> => {
+export const getVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<Video[]>> => {
   return await apiOut(apiClient('json').get(apiVideos, cookieHeader(req, params)))
 }
 
-export const getMusics = async (params: SearchParms, req?: Req): Promise<ApiOut<Music[]>> => {
+export const getMusics = async (params: SearchParams, req?: Req): Promise<ApiOut<Music[]>> => {
   return await apiOut(apiClient('json').get(apiMusics, cookieHeader(req, params)))
 }
 
-export const getComics = async (params: SearchParms, req?: Req): Promise<ApiOut<Comic[]>> => {
+export const getComics = async (params: SearchParams, req?: Req): Promise<ApiOut<Comic[]>> => {
   return await apiOut(apiClient('json').get(apiComics, cookieHeader(req, params)))
 }
 
-export const getPictures = async (params: SearchParms, req?: Req): Promise<ApiOut<Picture[]>> => {
+export const getPictures = async (params: SearchParams, req?: Req): Promise<ApiOut<Picture[]>> => {
   return await apiOut(apiClient('json').get(apiPictures, cookieHeader(req, params)))
 }
 
-export const getBlogs = async (params: SearchParms, req?: Req): Promise<ApiOut<Blog[]>> => {
+export const getBlogs = async (params: SearchParams, req?: Req): Promise<ApiOut<Blog[]>> => {
   return await apiOut(apiClient('json').get(apiBlogs, cookieHeader(req, params)))
 }
 
-export const getChats = async (params: SearchParms, req?: Req): Promise<ApiOut<Chat[]>> => {
+export const getChats = async (params: SearchParams, req?: Req): Promise<ApiOut<Chat[]>> => {
   return await apiOut(apiClient('json').get(apiChats, cookieHeader(req, params)))
 }

--- a/frontend/src/api/internal/user.ts
+++ b/frontend/src/api/internal/user.ts
@@ -2,7 +2,7 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { SearchParms } from 'types/internal/media/output'
+import { SearchParams } from 'types/internal/media/output'
 import { ErrorOut } from 'types/internal/other'
 import { Follow, FollowIn, FollowOut, LikeCommentIn, LikeMediaIn, LikeOut, NotificationOut, SearchTagIn, SearchTagOut, UserMe } from 'types/internal/user'
 import { UserPage, UserPageMedia } from 'types/internal/userpage'
@@ -34,11 +34,11 @@ export const putSearchTag = async (tags: SearchTagIn[]): Promise<ApiOut<ErrorOut
   return await apiOut(apiClient('json').put(apiSearchTag, camelSnake(tags)))
 }
 
-export const getFollow = async (params: SearchParms, req?: Req): Promise<ApiOut<Follow[]>> => {
+export const getFollow = async (params: SearchParams, req?: Req): Promise<ApiOut<Follow[]>> => {
   return await apiOut(apiClient('json').get(apiFollow, cookieHeader(req, params)))
 }
 
-export const getFollower = async (params: SearchParms, req?: Req): Promise<ApiOut<Follow[]>> => {
+export const getFollower = async (params: SearchParams, req?: Req): Promise<ApiOut<Follow[]>> => {
   return await apiOut(apiClient('json').get(apiFollower, cookieHeader(req, params)))
 }
 

--- a/frontend/src/types/internal/media/output.d.ts
+++ b/frontend/src/types/internal/media/output.d.ts
@@ -7,7 +7,7 @@ export interface Search {
   count: number
 }
 
-export interface SearchParms {
+export interface SearchParams {
   search?: string
 }
 


### PR DESCRIPTION
## Summary
- `SearchParms` のスペルを `SearchParams` に修正（`Parms` はタイポ）
- #707 のレビューで指摘した follow-up 対応
- バックエンドは該当箇所なし（`grep -r SearchParms myus/` で 0 件）

## 変更内容

### 型定義
- `frontend/src/types/internal/media/output.d.ts`
  - `export interface SearchParms` → `export interface SearchParams`

### 利用箇所
- `frontend/src/api/internal/media/list.ts`
  - `getHome` / `getRecommend` / `getVideos` / `getMusics` / `getComics` / `getPictures` / `getBlogs` / `getChats` の引数型
- `frontend/src/api/internal/user.ts`
  - `getFollow` / `getFollower` の引数型
- `frontend/src/api/internal/manage/video.ts`
  - `getManageVideos` の引数型

## 動作確認
- `npx tsc --noEmit`: エラー 0
- `npm run lint`: エラー 0（既存 warning 9件のみ）