### PR TITLE
【other】音楽の管理画面（DataTable一覧・編集・一括削除）をFE/BEに追加

### DIFF
--- a/frontend/src/api/internal/manage/music.ts
+++ b/frontend/src/api/internal/manage/music.ts
@@ -1,0 +1,25 @@
+import { apiClient } from 'lib/axios/internal'
+import { cookieHeader } from 'lib/config'
+import { ApiOut, apiOut } from 'lib/error'
+import { Req } from 'types/global'
+import { MusicUpdateIn } from 'types/internal/media/input'
+import { Music, SearchParams } from 'types/internal/media/output'
+import { ErrorOut } from 'types/internal/other'
+import { apiManageMusic, apiManageMusics } from 'api/uri'
+import { camelSnake } from 'utils/functions/convertCase'
+
+export const getManageMusics = async (params: SearchParams, req?: Req): Promise<ApiOut<Music[]>> => {
+  return await apiOut(apiClient('json').get(apiManageMusics, cookieHeader(req, params)))
+}
+
+export const getManageMusic = async (ulid: string, req?: Req): Promise<ApiOut<Music>> => {
+  return await apiOut(apiClient('json').get(apiManageMusic(ulid), cookieHeader(req)))
+}
+
+export const putManageMusic = async (ulid: string, request: MusicUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').put(apiManageMusic(ulid), camelSnake(request)))
+}
+
+export const deleteManageMusics = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').delete(apiManageMusics, { data: { ulids } }))
+}

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -64,5 +64,8 @@ export const apiMessage = (ulid: string) => base + `/media/message/${ulid}`
 export const apiManageVideos = base + '/manage/media/video'
 export const apiManageVideo = (ulid: string) => base + `/manage/media/video/${ulid}`
 
+export const apiManageMusics = base + '/manage/media/music'
+export const apiManageMusic = (ulid: string) => base + `/manage/media/music/${ulid}`
+
 // 外部API
 export const apiAddress = base + '/search'

--- a/frontend/src/components/templates/manage/music/edit.tsx
+++ b/frontend/src/components/templates/manage/music/edit.tsx
@@ -13,6 +13,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import CheckBox from 'components/parts/Input/CheckBox'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -34,19 +35,13 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<MusicUpdateIn>({
-    title: data.title,
-    content: data.content,
-    lyric: data.lyric,
-    download: data.download,
-    publish: data.publish,
-  })
+  const [values, setValues] = useState<MusicUpdateIn>({ ...data })
 
   const handleBack = () => router.push('/manage/music')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
-  const handleDownload = () => setValues({ ...values, download: !values.download })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleCheck = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.checked })
 
   const handleForm = async () => {
     const { title, content, lyric } = values
@@ -73,11 +68,11 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
-          <ToggleCard label="ダウンロード許可" isActive={values.download} onClick={handleDownload} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <Textarea label="歌詞" name="lyric" value={values.lyric} required={isRequired} onChange={handleText} />
+          <CheckBox label="ダウンロード許可" name="download" checked={values.download} onChange={handleCheck} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/music/edit.tsx
+++ b/frontend/src/components/templates/manage/music/edit.tsx
@@ -1,0 +1,85 @@
+import { useState, ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { MusicUpdateIn } from 'types/internal/media/input'
+import { Music } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { putManageMusic } from 'api/internal/manage/music'
+import { FetchError } from 'utils/constants/enum'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+
+interface Props {
+  data: Music
+  channels: Channel[]
+}
+
+export default function ManageMusicEdit(props: Props): React.JSX.Element {
+  const { data, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [values, setValues] = useState<MusicUpdateIn>({
+    title: data.title,
+    content: data.content,
+    lyric: data.lyric,
+    download: data.download,
+    publish: data.publish,
+  })
+
+  const handleBack = () => router.push('/manage/music')
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleDownload = () => setValues({ ...values, download: !values.download })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleForm = async () => {
+    const { title, content, lyric } = values
+    if (!isRequiredCheck({ title, content, lyric })) return
+    handleLoading(true)
+    const ret = await putManageMusic(data.ulid, values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Put, ret.error.message)
+      return
+    }
+    handleToast('保存しました', false)
+  }
+
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="保存する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
+  return (
+    <Main title="音楽編集" type="table" toast={toast} isFooter={false} button={button}>
+      <form method="POST" action="" encType="multipart/form-data">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <ToggleCard label="ダウンロード許可" isActive={values.download} onClick={handleDownload} />
+          <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <Textarea label="歌詞" name="lyric" value={values.lyric} required={isRequired} onChange={handleText} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/music/index.tsx
+++ b/frontend/src/components/templates/manage/music/index.tsx
@@ -1,0 +1,178 @@
+import { ChangeEvent, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { Music } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { deleteManageMusics } from 'api/internal/manage/music'
+import { FetchError } from 'utils/constants/enum'
+import { formatDatetime } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { usePagination } from 'components/hooks/usePagination'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import DataTable, { Column } from 'components/parts/DataTable'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Toggle from 'components/parts/Input/Toggle'
+import Pagination from 'components/parts/Pagination'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from '../Media.module.scss'
+
+interface Props {
+  datas: Music[]
+  channels: Channel[]
+}
+
+export default function ManageMusics(props: Props): React.JSX.Element {
+  const { datas, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+  const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+  const channelDatas = useMemo(() => datas.filter((m) => m.channel.ulid === channelUlid), [datas, channelUlid])
+  const { currentPage, totalPages, pageDatas, handlePage } = usePagination(channelDatas, 50)
+
+  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleEdit = (music: Music) => router.push(`/manage/music/${music.ulid}`)
+  const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
+
+  const handleDeleteSubmit = async () => {
+    const ulids = Array.from(selectedKeys)
+    if (ulids.length === 0) return
+
+    handleLoading(true)
+    const ret = await deleteManageMusics(ulids)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Delete, ret.error.message)
+      return
+    }
+    setSelectedKeys(new Set())
+    handleDelete()
+    router.replace(router.asPath)
+  }
+
+  const columns: Column<Music>[] = [
+    {
+      key: 'title',
+      header: 'タイトル',
+      sortable: true,
+      sortValue: (m) => m.title,
+      className: style.title,
+      cell: (m) => (
+        <a className={style.title_link} onClick={() => handleEdit(m)}>
+          {m.title}
+        </a>
+      ),
+    },
+    {
+      key: 'content',
+      header: '内容',
+      className: style.content,
+      cell: (m) => m.content,
+    },
+    {
+      key: 'read',
+      header: '再生',
+      align: 'right',
+      sortable: true,
+      sortValue: (m) => m.read,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (m) => m.read,
+    },
+    {
+      key: 'like',
+      header: 'いいね',
+      align: 'right',
+      sortable: true,
+      sortValue: (m) => m.like,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (m) => m.like,
+    },
+    {
+      key: 'download',
+      header: 'DL',
+      align: 'center',
+      sortable: true,
+      sortValue: (m) => (m.download ? 1 : 0),
+      className: style.narrow,
+      cellClass: style.publish,
+      cell: (m) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={m.download} disable />
+        </div>
+      ),
+    },
+    {
+      key: 'publish',
+      header: '公開',
+      align: 'center',
+      sortable: true,
+      sortValue: (m) => (m.publish ? 1 : 0),
+      className: style.narrow,
+      cellClass: style.publish,
+      cell: (m) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={m.publish} disable />
+        </div>
+      ),
+    },
+    {
+      key: 'created',
+      header: '投稿日時',
+      sortable: true,
+      sortValue: (m) => new Date(m.created).getTime(),
+      className: style.datetime,
+      cell: (m) => formatDatetime(m.created),
+    },
+  ]
+
+  return (
+    <Main
+      title="音楽管理"
+      type="table"
+      toast={toast}
+      isFooter={false}
+      button={
+        <div className={style.header_actions}>
+          {selectedKeys.size > 0 && (
+            <>
+              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
+              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
+            </>
+          )}
+          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
+        </div>
+      }
+    >
+      <div className={style.manage}>
+        <DataTable
+          datas={pageDatas}
+          columns={columns}
+          rowKey={(m) => m.ulid}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelection={setSelectedKeys}
+          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
+        />
+      </div>
+      <DeleteModal
+        open={isDeleteModal}
+        title="音楽の削除"
+        content={`${selectedKeys.size}件の音楽を削除しますか？`}
+        loading={isLoading}
+        onClose={handleDelete}
+        onAction={handleDeleteSubmit}
+      />
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/video/edit.tsx
+++ b/frontend/src/components/templates/manage/video/edit.tsx
@@ -34,7 +34,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<VideoUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
+  const [values, setValues] = useState<VideoUpdateIn>({ ...data })
 
   const handleBack = () => router.push('/manage/video')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })

--- a/frontend/src/pages/manage/music/[ulid].tsx
+++ b/frontend/src/pages/manage/music/[ulid].tsx
@@ -1,0 +1,33 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Music } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManageMusic } from 'api/internal/manage/music'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageMusicEdit from 'components/templates/manage/music/edit'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ulid = String(params?.ulid ?? '')
+  const [musicRet, channelsRet] = await Promise.all([getManageMusic(ulid, req), getChannels(req)])
+  if (musicRet.isErr()) return { props: { status: musicRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const data = musicRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, data, channels } }
+}
+
+interface Props {
+  status: number
+  data: Music
+  channels: Channel[]
+}
+
+export default function ManageMusicEditPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageMusicEdit {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/pages/manage/music/index.tsx
+++ b/frontend/src/pages/manage/music/index.tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Music } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManageMusics } from 'api/internal/manage/music'
+import { searchParams } from 'utils/functions/common'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageMusics from 'components/templates/manage/music'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const params = searchParams(query)
+  const [musicsRet, channelsRet] = await Promise.all([getManageMusics(params, req), getChannels(req)])
+  if (musicsRet.isErr()) return { props: { status: musicsRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const datas = musicsRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, datas, channels } }
+}
+
+interface Props {
+  status: number
+  datas: Music[]
+  channels: Channel[]
+}
+
+export default function ManageMusicsPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageMusics {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -57,3 +57,11 @@ export interface VideoUpdateIn {
   content: string
   publish: boolean
 }
+
+export interface MusicUpdateIn {
+  title: string
+  content: string
+  lyric: string
+  download: boolean
+  publish: boolean
+}


### PR DESCRIPTION
## Summary
- `/manage/music` の DataTable 形式の一覧・編集・一括削除機能を video 実装を参考に追加
- バックエンド `/manage/media/music` エンドポイント（list/get/put/delete）を新設
- MusicRepository に `bulk_delete` と `owner_id` フィルタを追加し、管理操作に必要な前提を満たす

## 変更内容

### バックエンド

#### ドメイン層
- `myus/api/src/domain/interface/media/music/interface.py`
  - `bulk_delete(ids)` 抽象メソッドを追加（VideoInterface と揃える）
- `myus/api/src/domain/entity/media/music/repository.py`
  - `bulk_delete` 実装を追加
  - `get_ids` に `owner_id` フィルタを追加（管理画面でユーザ自身の音楽のみ取得できるように）

#### スキーマ
- `myus/api/src/types/schema/media/input.py`
  - `MusicUpdateIn(title, content, lyric, download, publish)` を追加

#### ユースケース
- `myus/api/src/usecase/manage/media.py`
  - `get_manage_musics` / `get_manage_music` / `update_manage_music` / `delete_manage_music` を追加
  - video と同パターン（owner_id フィルタ、replace で更新、bulk_delete による削除）

#### アダプタ・ルーター
- `myus/api/src/adapter/manage.py`
  - `ManageMusicAPI` クラスを追加（list/get/put/delete）
- `myus/api/src/routers.py`
  - `/manage/media/music` ルートを `ManageMusicAPI` にマウント

### フロントエンド

#### 型定義
- `frontend/src/types/internal/media/input.d.ts`
  - `MusicUpdateIn(title, content, lyric, download, publish)` を追加

#### API クライアント・URI
- `frontend/src/api/uri.ts`
  - `apiManageMusics` / `apiManageMusic(ulid)` 定数を追加
- `frontend/src/api/internal/manage/music.ts`（新規）
  - `getManageMusics` / `getManageMusic` / `putManageMusic` / `deleteManageMusics`

#### 画面テンプレート
- `frontend/src/components/templates/manage/music/index.tsx`（新規）
  - DataTable（タイトル/内容/再生/いいね/DL/公開/投稿日時）
  - チャンネルフィルタ、ページネーション、一括削除モーダル
- `frontend/src/components/templates/manage/music/edit.tsx`（新規）
  - 公開・ダウンロード許可の ToggleCard、タイトル/内容/歌詞フィールド

#### ページ
- `frontend/src/pages/manage/music/index.tsx`（新規）一覧
- `frontend/src/pages/manage/music/[ulid].tsx`（新規）編集

## 差異ポイント（video との違い）

- 歌詞（lyric）フィールドを編集フォームに追加
- ダウンロード許可（download）トグルを一覧カラムと編集フォームに追加
- 一覧にはサムネイル列なし（音楽のサムネイル概念がないため）

## 動作確認

- `uv run mypy`（バックエンド関連ファイル）: 本 PR 起因のエラー 0（既存 43件は `logger.py` / `video_converter.py` / `db/models/*` / `adapter/media.py` の `period` 型不整合などで変更前から発生しているもの）
- `npx tsc --noEmit`: エラー 0
- `npm run lint`: エラー 0（既存 warning 9件のみ）

## 今後の展開
同パターンで comic / picture / blog / chat の管理画面も順次追加予定。各メディアの固有フィールド（comic: pages、blog: richtext、chat: period など）に応じて `*UpdateIn` を設計する。