### PR TITLE
【back】音楽の管理API（/manage/media/music）を追加

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,12 +1,12 @@
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
-from api.src.adapter.media import convert_videos
+from api.src.adapter.media import convert_musics, convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media.input import BulkDeleteIn, VideoUpdateIn
-from api.src.types.schema.media.output import VideoOut
+from api.src.types.schema.media.input import BulkDeleteIn, MusicUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.output import MusicOut, VideoOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.manage.media import delete_manage_video, get_manage_video, get_manage_videos, update_manage_video
+from api.src.usecase.manage.media import delete_manage_music, delete_manage_video, get_manage_music, get_manage_musics, get_manage_video, get_manage_videos, update_manage_music, update_manage_video
 
 
 class ManageVideoAPI:
@@ -65,6 +65,67 @@ class ManageVideoAPI:
             return 401, ErrorOut(message="Unauthorized")
 
         if not delete_manage_video(user_id, input.ulids):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")
+
+
+class ManageMusicAPI:
+    """ManageMusicAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[MusicOut], 401: ErrorOut})
+    def list(request: HttpRequest, search: str = ""):
+        log.info("ManageMusicAPI list", search=search)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs = get_manage_musics(user_id, search)
+        return 200, convert_musics(objs)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: MusicOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManageMusicAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_music(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Music not found")
+
+        return 200, convert_musics([obj])[0]
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: MusicUpdateIn):
+        log.info("ManageMusicAPI put", ulid=ulid, input=input)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_music(user_id, ulid, input):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManageMusicAPI delete", ulids=input.ulids)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_music(user_id, input.ulids):
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/domain/entity/media/music/repository.py
+++ b/myus/api/src/domain/entity/media/music/repository.py
@@ -22,6 +22,8 @@ class MusicRepository(MusicInterface):
             q_list.append(Q(ulid=filter.ulid))
         if filter.publish is not None:
             q_list.append(Q(publish=filter.publish))
+        if filter.owner_id:
+            q_list.append(Q(channel__owner_id=filter.owner_id))
         if filter.channel_id:
             q_list.append(Q(channel_id=filter.channel_id))
         if filter.category_id:
@@ -67,3 +69,6 @@ class MusicRepository(MusicInterface):
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Music.objects.filter(id=media_id, like__id=user_id).exists()
+
+    def bulk_delete(self, ids: list[int]) -> None:
+        Music.objects.filter(id__in=ids).delete()

--- a/myus/api/src/domain/interface/media/music/interface.py
+++ b/myus/api/src/domain/interface/media/music/interface.py
@@ -19,3 +19,7 @@ class MusicInterface(ABC):
     @abstractmethod
     def is_liked(self, media_id: int, user_id: int) -> bool:
         ...
+
+    @abstractmethod
+    def bulk_delete(self, ids: list[int]) -> None:
+        ...

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,7 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
-from api.src.adapter.manage import ManageVideoAPI
+from api.src.adapter.manage import ManageMusicAPI, ManageVideoAPI
 from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -19,6 +19,7 @@ api.add_router("/setting/mypage", SettingMyPageAPI().router, tags=["Setting"])
 api.add_router("/setting/notification", SettingNotificationAPI().router, tags=["Setting"])
 
 api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Video"])
+api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Music"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -53,5 +53,13 @@ class VideoUpdateIn(BaseModel):
     publish: bool
 
 
+class MusicUpdateIn(BaseModel):
+    title: str
+    content: str
+    lyric: str
+    download: bool
+    publish: bool
+
+
 class BulkDeleteIn(BaseModel):
     ulids: list[str]

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -2,9 +2,11 @@ from dataclasses import replace
 from api.modules.logger import log
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
+from api.src.domain.interface.media.music.data import MusicData
+from api.src.domain.interface.media.music.interface import MusicInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media.input import VideoUpdateIn
+from api.src.types.schema.media.input import MusicUpdateIn, VideoUpdateIn
 from api.utils.functions.index import create_url
 
 
@@ -75,4 +77,65 @@ def delete_manage_video(user_id: int, ulids: list[str]) -> bool:
         return True
     except Exception as e:
         log.error("delete_manage_video error", exc=e)
+        return False
+
+
+def get_manage_musics(user_id: int, search: str) -> list[MusicData]:
+    repository = injector.get(MusicInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    objs = repository.bulk_get(ids=ids)
+
+    data = [replace(o, music=create_url(o.music)) for o in objs]
+    return data
+
+
+def get_manage_music(user_id: int, ulid: str) -> MusicData | None:
+    repository = injector.get(MusicInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.info("Music not found", ulid=ulid, user_id=user_id)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    return replace(obj, music=create_url(obj.music))
+
+
+def update_manage_music(user_id: int, ulid: str, input: MusicUpdateIn) -> bool:
+    repository = injector.get(MusicInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Music not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Music owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    update_data = replace(obj, title=input.title, content=input.content, lyric=input.lyric, download=input.download, publish=input.publish)
+    try:
+        repository.bulk_save([update_data])
+        return True
+    except Exception as e:
+        log.error("update_manage_music error", exc=e)
+        return False
+
+
+def delete_manage_music(user_id: int, ulids: list[str]) -> bool:
+    repository = injector.get(MusicInterface)
+    delete_ids: list[int] = []
+
+    for ulid in ulids:
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        if len(ids) == 0:
+            log.error("Music not found or owner mismatch", ulid=ulid, user_id=user_id)
+            return False
+        delete_ids.append(ids[0])
+
+    try:
+        repository.bulk_delete(delete_ids)
+        return True
+    except Exception as e:
+        log.error("delete_manage_music error", exc=e)
         return False


### PR DESCRIPTION
## Summary
- `/manage/media/music` エンドポイント（list/get/put/delete）を新設し、FE の音楽管理画面（PR #711）に対応する BE 実装を追加
- `MusicRepository` に `bulk_delete` と `owner_id` フィルタを追加し、管理操作の前提を満たす
- `MusicUpdateIn` スキーマで編集フォーム（title / content / lyric / download / publish）を受け付け

## 変更内容

### ドメイン層
- `myus/api/src/domain/interface/media/music/interface.py`
  - `bulk_delete(ids)` 抽象メソッドを追加（`VideoInterface` と揃える）
- `myus/api/src/domain/entity/media/music/repository.py`
  - `bulk_delete` 実装を追加
  - `get_ids` に `owner_id` フィルタを追加（管理画面でユーザ自身の音楽のみ取得できるように）

### スキーマ
- `myus/api/src/types/schema/media/input.py`
  - `MusicUpdateIn(title, content, lyric, download, publish)` を追加

### ユースケース
- `myus/api/src/usecase/manage/media.py`
  - `get_manage_musics` / `get_manage_music` / `update_manage_music` / `delete_manage_music` を追加
  - `update_manage_music` は `channel.owner_id` で所有者チェックし、`replace` で title/content/lyric/download/publish を更新

### アダプタ・ルーター
- `myus/api/src/adapter/manage.py`
  - `ManageMusicAPI` クラスを追加（list / get / put / delete、401/404/400 のエラー応答込み）
- `myus/api/src/routers.py`
  - `/manage/media/music` を `ManageMusicAPI` にマウント

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件は `logger.py` / `video_converter.py` / `db/models/*` / `adapter/media.py` の `period` 型不整合などで変更前から発生しているもの）