### PR TITLE
【back】漫画の管理API（/manage/media/comic）追加とbulk_delete順序統一

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,12 +1,12 @@
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
-from api.src.adapter.media import convert_musics, convert_videos
+from api.src.adapter.media import convert_comics, convert_musics, convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media.input import BulkDeleteIn, MusicUpdateIn, VideoUpdateIn
-from api.src.types.schema.media.output import MusicOut, VideoOut
+from api.src.types.schema.media.input import BulkDeleteIn, ComicUpdateIn, MusicUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.output import ComicOut, MusicOut, VideoOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.manage.media import delete_manage_music, delete_manage_video, get_manage_music, get_manage_musics, get_manage_video, get_manage_videos, update_manage_music, update_manage_video
+from api.src.usecase.manage.media import delete_manage_comic, delete_manage_music, delete_manage_video, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_video, get_manage_videos, update_manage_comic, update_manage_music, update_manage_video
 
 
 class ManageVideoAPI:
@@ -126,6 +126,67 @@ class ManageMusicAPI:
             return 401, ErrorOut(message="Unauthorized")
 
         if not delete_manage_music(user_id, input.ulids):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")
+
+
+class ManageComicAPI:
+    """ManageComicAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[ComicOut], 401: ErrorOut})
+    def list(request: HttpRequest, search: str = ""):
+        log.info("ManageComicAPI list", search=search)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs = get_manage_comics(user_id, search)
+        return 200, convert_comics(objs)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: ComicOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManageComicAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_comic(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Comic not found")
+
+        return 200, convert_comics([obj])[0]
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: ComicUpdateIn):
+        log.info("ManageComicAPI put", ulid=ulid, input=input)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_comic(user_id, ulid, input):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManageComicAPI delete", ulids=input.ulids)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_comic(user_id, input.ulids):
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/domain/entity/media/comic/repository.py
+++ b/myus/api/src/domain/entity/media/comic/repository.py
@@ -24,6 +24,8 @@ class ComicRepository(ComicInterface):
             q_list.append(Q(ulid=filter.ulid))
         if filter.publish is not None:
             q_list.append(Q(publish=filter.publish))
+        if filter.owner_id:
+            q_list.append(Q(channel__owner_id=filter.owner_id))
         if filter.channel_id:
             q_list.append(Q(channel_id=filter.channel_id))
         if filter.category_id:
@@ -58,6 +60,7 @@ class ComicRepository(ComicInterface):
 
         models = [marshal_data(o) for o in objs]
         new_ids = get_new_ids(models, Comic)
+        new_id_set = set(new_ids)
 
         with transaction.atomic():
             Comic.objects.bulk_create(
@@ -68,10 +71,14 @@ class ComicRepository(ComicInterface):
             ComicPage.objects.bulk_create([
                 ComicPage(comic_id=model.id, image=page_path, sequence=seq)
                 for obj, model in zip(objs, models)
+                if model.id in new_id_set
                 for seq, page_path in enumerate(obj.pages)
             ])
 
         return new_ids
+
+    def bulk_delete(self, ids: list[int]) -> None:
+        Comic.objects.filter(id__in=ids).delete()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Comic.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/music/repository.py
+++ b/myus/api/src/domain/entity/media/music/repository.py
@@ -67,8 +67,8 @@ class MusicRepository(MusicInterface):
 
         return new_ids
 
-    def is_liked(self, media_id: int, user_id: int) -> bool:
-        return Music.objects.filter(id=media_id, like__id=user_id).exists()
-
     def bulk_delete(self, ids: list[int]) -> None:
         Music.objects.filter(id__in=ids).delete()
+
+    def is_liked(self, media_id: int, user_id: int) -> bool:
+        return Music.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -67,8 +67,8 @@ class VideoRepository(VideoInterface):
 
         return new_ids
 
-    def is_liked(self, media_id: int, user_id: int) -> bool:
-        return Video.objects.filter(id=media_id, like__id=user_id).exists()
-
     def bulk_delete(self, ids: list[int]) -> None:
         Video.objects.filter(id__in=ids).delete()
+
+    def is_liked(self, media_id: int, user_id: int) -> bool:
+        return Video.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/interface/media/comic/interface.py
+++ b/myus/api/src/domain/interface/media/comic/interface.py
@@ -17,5 +17,9 @@ class ComicInterface(ABC):
         ...
 
     @abstractmethod
+    def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
     def is_liked(self, media_id: int, user_id: int) -> bool:
         ...

--- a/myus/api/src/domain/interface/media/music/interface.py
+++ b/myus/api/src/domain/interface/media/music/interface.py
@@ -17,9 +17,9 @@ class MusicInterface(ABC):
         ...
 
     @abstractmethod
-    def is_liked(self, media_id: int, user_id: int) -> bool:
+    def bulk_delete(self, ids: list[int]) -> None:
         ...
 
     @abstractmethod
-    def bulk_delete(self, ids: list[int]) -> None:
+    def is_liked(self, media_id: int, user_id: int) -> bool:
         ...

--- a/myus/api/src/domain/interface/media/video/interface.py
+++ b/myus/api/src/domain/interface/media/video/interface.py
@@ -17,9 +17,9 @@ class VideoInterface(ABC):
         ...
 
     @abstractmethod
-    def is_liked(self, media_id: int, user_id: int) -> bool:
+    def bulk_delete(self, ids: list[int]) -> None:
         ...
 
     @abstractmethod
-    def bulk_delete(self, ids: list[int]) -> None:
+    def is_liked(self, media_id: int, user_id: int) -> bool:
         ...

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,7 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
-from api.src.adapter.manage import ManageMusicAPI, ManageVideoAPI
+from api.src.adapter.manage import ManageComicAPI, ManageMusicAPI, ManageVideoAPI
 from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -20,6 +20,7 @@ api.add_router("/setting/notification", SettingNotificationAPI().router, tags=["
 
 api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Video"])
 api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Music"])
+api.add_router("/manage/media/comic", ManageComicAPI().router, tags=["Manage Comic"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -61,5 +61,11 @@ class MusicUpdateIn(BaseModel):
     publish: bool
 
 
+class ComicUpdateIn(BaseModel):
+    title: str
+    content: str
+    publish: bool
+
+
 class BulkDeleteIn(BaseModel):
     ulids: list[str]

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -4,9 +4,11 @@ from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.music.data import MusicData
 from api.src.domain.interface.media.music.interface import MusicInterface
+from api.src.domain.interface.media.comic.data import ComicData
+from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media.input import MusicUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.input import ComicUpdateIn, MusicUpdateIn, VideoUpdateIn
 from api.utils.functions.index import create_url
 
 
@@ -138,4 +140,71 @@ def delete_manage_music(user_id: int, ulids: list[str]) -> bool:
         return True
     except Exception as e:
         log.error("delete_manage_music error", exc=e)
+        return False
+
+
+def get_manage_comics(user_id: int, search: str) -> list[ComicData]:
+    repository = injector.get(ComicInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    objs = repository.bulk_get(ids=ids)
+
+    data = [replace(o,
+        image=create_url(o.image),
+        pages=[create_url(p) for p in o.pages],
+    ) for o in objs]
+    return data
+
+
+def get_manage_comic(user_id: int, ulid: str) -> ComicData | None:
+    repository = injector.get(ComicInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.info("Comic not found", ulid=ulid, user_id=user_id)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    return replace(obj,
+        image=create_url(obj.image),
+        pages=[create_url(p) for p in obj.pages],
+    )
+
+
+def update_manage_comic(user_id: int, ulid: str, input: ComicUpdateIn) -> bool:
+    repository = injector.get(ComicInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Comic not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Comic owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    update_data = replace(obj, title=input.title, content=input.content, publish=input.publish)
+    try:
+        repository.bulk_save([update_data])
+        return True
+    except Exception as e:
+        log.error("update_manage_comic error", exc=e)
+        return False
+
+
+def delete_manage_comic(user_id: int, ulids: list[str]) -> bool:
+    repository = injector.get(ComicInterface)
+    delete_ids: list[int] = []
+
+    for ulid in ulids:
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        if len(ids) == 0:
+            log.error("Comic not found or owner mismatch", ulid=ulid, user_id=user_id)
+            return False
+        delete_ids.append(ids[0])
+
+    try:
+        repository.bulk_delete(delete_ids)
+        return True
+    except Exception as e:
+        log.error("delete_manage_comic error", exc=e)
         return False


### PR DESCRIPTION
## Summary
- `/manage/media/comic` エンドポイント（list/get/put/delete）を新設し、FE の漫画管理画面（PR #714）に対応する BE 実装を追加
- `ComicRepository` に `bulk_delete` と `owner_id` フィルタを追加、さらに `bulk_save` の既存バグ（更新時に `ComicPage` を重複生成）を修正
- video / music / comic の 3 メディアで `bulk_delete` の実装位置を `bulk_save` 直下に統一

## 変更内容

### ドメイン層
- `myus/api/src/domain/interface/media/comic/interface.py`
  - `bulk_delete(ids)` 抽象メソッドを追加（VideoInterface と揃える）
- `myus/api/src/domain/entity/media/comic/repository.py`
  - `bulk_delete` 実装を追加
  - `get_ids` に `owner_id` フィルタを追加（管理画面でユーザ自身の漫画のみ取得できるように）
  - `bulk_save` で `new_id_set` を使って新規作成時のみ `ComicPage` を挿入するよう修正（更新時のページ重複バグを解消）

### `bulk_delete` 実装位置の統一
- `myus/api/src/domain/interface/media/{video,music,comic}/interface.py`
- `myus/api/src/domain/entity/media/{video,music,comic}/repository.py`
  - 全メディアで `get_ids → bulk_get → bulk_save → bulk_delete → is_liked` の順序に揃えた
  - 元は `bulk_delete` が `is_liked` の下の末尾にあり、メソッド責務のグループ（書き込み系と参照系）が崩れていた

### スキーマ
- `myus/api/src/types/schema/media/input.py`
  - `ComicUpdateIn(title, content, publish)` を追加（video と同じ 3 フィールド）

### ユースケース
- `myus/api/src/usecase/manage/media.py`
  - `get_manage_comics` / `get_manage_comic` / `update_manage_comic` / `delete_manage_comic` を追加
  - `get_manage_comics` / `get_manage_comic` では `image` と `pages` を `create_url()` で絶対 URL に変換

### アダプタ・ルーター
- `myus/api/src/adapter/manage.py`
  - `ManageComicAPI` クラスを追加（list / get / put / delete、401/404/400 エラー応答込み）
- `myus/api/src/routers.py`
  - `/manage/media/comic` を `ManageComicAPI` にマウント

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件は `logger.py` / `video_converter.py` / `db/models/*` / `adapter/media.py` の `period` 型不整合などで変更前から発生しているもの）

## 備考
- FE の PR #714 と同時にマージすることで漫画管理画面が完結する