### PR TITLE
【front】画像の管理画面（DataTable一覧・編集・一括削除）を追加

### DIFF
--- a/frontend/src/api/internal/manage/delete.ts
+++ b/frontend/src/api/internal/manage/delete.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageComics, apiManageMusics, apiManageVideos } from 'api/uri'
+import { apiManageComics, apiManageMusics, apiManagePictures, apiManageVideos } from 'api/uri'
 
 export const deleteManageVideos = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageVideos, { data: { ulids } }))
@@ -13,4 +13,8 @@ export const deleteManageMusics = async (ulids: string[]): Promise<ApiOut<ErrorO
 
 export const deleteManageComics = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageComics, { data: { ulids } }))
+}
+
+export const deleteManagePictures = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').delete(apiManagePictures, { data: { ulids } }))
 }

--- a/frontend/src/api/internal/manage/get.ts
+++ b/frontend/src/api/internal/manage/get.ts
@@ -2,8 +2,8 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { Comic, Music, SearchParams, Video } from 'types/internal/media/output'
-import { apiManageComic, apiManageComics, apiManageMusic, apiManageMusics, apiManageVideo, apiManageVideos } from 'api/uri'
+import { Comic, Music, Picture, SearchParams, Video } from 'types/internal/media/output'
+import { apiManageComic, apiManageComics, apiManageMusic, apiManageMusics, apiManagePicture, apiManagePictures, apiManageVideo, apiManageVideos } from 'api/uri'
 
 export const getManageVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<Video[]>> => {
   return await apiOut(apiClient('json').get(apiManageVideos, cookieHeader(req, params)))
@@ -17,6 +17,10 @@ export const getManageComics = async (params: SearchParams, req?: Req): Promise<
   return await apiOut(apiClient('json').get(apiManageComics, cookieHeader(req, params)))
 }
 
+export const getManagePictures = async (params: SearchParams, req?: Req): Promise<ApiOut<Picture[]>> => {
+  return await apiOut(apiClient('json').get(apiManagePictures, cookieHeader(req, params)))
+}
+
 export const getManageVideo = async (ulid: string, req?: Req): Promise<ApiOut<Video>> => {
   return await apiOut(apiClient('json').get(apiManageVideo(ulid), cookieHeader(req)))
 }
@@ -27,4 +31,8 @@ export const getManageMusic = async (ulid: string, req?: Req): Promise<ApiOut<Mu
 
 export const getManageComic = async (ulid: string, req?: Req): Promise<ApiOut<Comic>> => {
   return await apiOut(apiClient('json').get(apiManageComic(ulid), cookieHeader(req)))
+}
+
+export const getManagePicture = async (ulid: string, req?: Req): Promise<ApiOut<Picture>> => {
+  return await apiOut(apiClient('json').get(apiManagePicture(ulid), cookieHeader(req)))
 }

--- a/frontend/src/api/internal/manage/update.ts
+++ b/frontend/src/api/internal/manage/update.ts
@@ -1,8 +1,8 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
-import { ComicUpdateIn, MusicUpdateIn, VideoUpdateIn } from 'types/internal/media/input'
+import { ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn } from 'types/internal/media/input'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageComic, apiManageMusic, apiManageVideo } from 'api/uri'
+import { apiManageComic, apiManageMusic, apiManagePicture, apiManageVideo } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const putManageVideo = async (ulid: string, request: VideoUpdateIn): Promise<ApiOut<ErrorOut>> => {
@@ -15,4 +15,8 @@ export const putManageMusic = async (ulid: string, request: MusicUpdateIn): Prom
 
 export const putManageComic = async (ulid: string, request: ComicUpdateIn): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').put(apiManageComic(ulid), camelSnake(request)))
+}
+
+export const putManagePicture = async (ulid: string, request: PictureUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').put(apiManagePicture(ulid), camelSnake(request)))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -70,5 +70,8 @@ export const apiManageMusic = (ulid: string) => base + `/manage/media/music/${ul
 export const apiManageComics = base + '/manage/media/comic'
 export const apiManageComic = (ulid: string) => base + `/manage/media/comic/${ulid}`
 
+export const apiManagePictures = base + '/manage/media/picture'
+export const apiManagePicture = (ulid: string) => base + `/manage/media/picture/${ulid}`
+
 // 外部API
 export const apiAddress = base + '/search'

--- a/frontend/src/components/templates/manage/picture/edit.tsx
+++ b/frontend/src/components/templates/manage/picture/edit.tsx
@@ -1,0 +1,76 @@
+import { useState, ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { PictureUpdateIn } from 'types/internal/media/input'
+import { Picture } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { putManagePicture } from 'api/internal/manage/update'
+import { FetchError } from 'utils/constants/enum'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+
+interface Props {
+  data: Picture
+  channels: Channel[]
+}
+
+export default function ManagePictureEdit(props: Props): React.JSX.Element {
+  const { data, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [values, setValues] = useState<PictureUpdateIn>({ ...data })
+
+  const handleBack = () => router.push('/manage/picture')
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleForm = async () => {
+    const { title, content } = values
+    if (!isRequiredCheck({ title, content })) return
+    handleLoading(true)
+    const ret = await putManagePicture(data.ulid, values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Put, ret.error.message)
+      return
+    }
+    handleToast('保存しました', false)
+  }
+
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="保存する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
+  return (
+    <Main title="画像編集" type="table" toast={toast} isFooter={false} button={button}>
+      <form method="POST" action="" encType="multipart/form-data">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/picture/index.tsx
+++ b/frontend/src/components/templates/manage/picture/index.tsx
@@ -1,0 +1,171 @@
+import { ChangeEvent, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { Picture } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { deleteManagePictures } from 'api/internal/manage/delete'
+import { FetchError } from 'utils/constants/enum'
+import { formatDatetime } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { usePagination } from 'components/hooks/usePagination'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import DataTable, { Column } from 'components/parts/DataTable'
+import ExImage from 'components/parts/ExImage'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Toggle from 'components/parts/Input/Toggle'
+import Pagination from 'components/parts/Pagination'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from '../Media.module.scss'
+
+interface Props {
+  datas: Picture[]
+  channels: Channel[]
+}
+
+export default function ManagePictures(props: Props): React.JSX.Element {
+  const { datas, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+  const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+  const channelDatas = useMemo(() => datas.filter((p) => p.channel.ulid === channelUlid), [datas, channelUlid])
+  const { currentPage, totalPages, pageDatas, handlePage } = usePagination(channelDatas, 50)
+
+  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleEdit = (picture: Picture) => router.push(`/manage/picture/${picture.ulid}`)
+  const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
+
+  const handleDeleteSubmit = async () => {
+    const ulids = Array.from(selectedKeys)
+    if (ulids.length === 0) return
+
+    handleLoading(true)
+    const ret = await deleteManagePictures(ulids)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Delete, ret.error.message)
+      return
+    }
+    setSelectedKeys(new Set())
+    handleDelete()
+    router.replace(router.asPath)
+  }
+
+  const columns: Column<Picture>[] = [
+    {
+      key: 'thumbnail',
+      header: '画像',
+      className: style.thumbnail,
+      cell: (p) => p.image && <ExImage src={p.image} width="96" height="54" />,
+    },
+    {
+      key: 'title',
+      header: 'タイトル',
+      sortable: true,
+      sortValue: (p) => p.title,
+      className: style.title,
+      cell: (p) => (
+        <a className={style.title_link} onClick={() => handleEdit(p)}>
+          {p.title}
+        </a>
+      ),
+    },
+    {
+      key: 'content',
+      header: '内容',
+      className: style.content,
+      cell: (p) => p.content,
+    },
+    {
+      key: 'read',
+      header: '閲覧',
+      align: 'right',
+      sortable: true,
+      sortValue: (p) => p.read,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (p) => p.read,
+    },
+    {
+      key: 'like',
+      header: 'いいね',
+      align: 'right',
+      sortable: true,
+      sortValue: (p) => p.like,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (p) => p.like,
+    },
+    {
+      key: 'publish',
+      header: '公開',
+      align: 'center',
+      sortable: true,
+      sortValue: (p) => (p.publish ? 1 : 0),
+      className: style.narrow,
+      cellClass: style.publish,
+      cell: (p) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={p.publish} disable />
+        </div>
+      ),
+    },
+    {
+      key: 'created',
+      header: '投稿日時',
+      sortable: true,
+      sortValue: (p) => new Date(p.created).getTime(),
+      className: style.datetime,
+      cell: (p) => formatDatetime(p.created),
+    },
+  ]
+
+  return (
+    <Main
+      title="画像管理"
+      type="table"
+      toast={toast}
+      isFooter={false}
+      button={
+        <div className={style.header_actions}>
+          {selectedKeys.size > 0 && (
+            <>
+              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
+              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
+            </>
+          )}
+          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
+        </div>
+      }
+    >
+      <div className={style.manage}>
+        <DataTable
+          datas={pageDatas}
+          columns={columns}
+          rowKey={(p) => p.ulid}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelection={setSelectedKeys}
+          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
+        />
+      </div>
+      <DeleteModal
+        open={isDeleteModal}
+        title="画像の削除"
+        content={`${selectedKeys.size}件の画像を削除しますか？`}
+        loading={isLoading}
+        onClose={handleDelete}
+        onAction={handleDeleteSubmit}
+      />
+    </Main>
+  )
+}

--- a/frontend/src/pages/manage/picture/[ulid].tsx
+++ b/frontend/src/pages/manage/picture/[ulid].tsx
@@ -1,0 +1,33 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Picture } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManagePicture } from 'api/internal/manage/get'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManagePictureEdit from 'components/templates/manage/picture/edit'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ulid = String(params?.ulid ?? '')
+  const [pictureRet, channelsRet] = await Promise.all([getManagePicture(ulid, req), getChannels(req)])
+  if (pictureRet.isErr()) return { props: { status: pictureRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const data = pictureRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, data, channels } }
+}
+
+interface Props {
+  status: number
+  data: Picture
+  channels: Channel[]
+}
+
+export default function ManagePictureEditPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManagePictureEdit {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/pages/manage/picture/index.tsx
+++ b/frontend/src/pages/manage/picture/index.tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Picture } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManagePictures } from 'api/internal/manage/get'
+import { searchParams } from 'utils/functions/common'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManagePictures from 'components/templates/manage/picture'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const params = searchParams(query)
+  const [picturesRet, channelsRet] = await Promise.all([getManagePictures(params, req), getChannels(req)])
+  if (picturesRet.isErr()) return { props: { status: picturesRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const datas = picturesRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, datas, channels } }
+}
+
+interface Props {
+  status: number
+  datas: Picture[]
+  channels: Channel[]
+}
+
+export default function ManagePicturesPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManagePictures {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -71,3 +71,9 @@ export interface ComicUpdateIn {
   content: string
   publish: boolean
 }
+
+export interface PictureUpdateIn {
+  title: string
+  content: string
+  publish: boolean
+}


### PR DESCRIPTION
## Summary
- `/manage/picture` の DataTable 形式の一覧・編集・一括削除機能を video / music / comic に続いて追加
- `PictureUpdateIn` 型と manage API クライアントの picture 関数を追加
- 対応する BE PR は別途用意

## 変更内容

### 型定義
- `frontend/src/types/internal/media/input.d.ts`
  - `PictureUpdateIn(title, content, publish)` を追加（video / comic と同じ 3 フィールド）

### URI・API クライアント
- `frontend/src/api/uri.ts`
  - `apiManagePictures` / `apiManagePicture(ulid)` を追加
- `frontend/src/api/internal/manage/get.ts`
  - `getManagePictures` / `getManagePicture` を追加
- `frontend/src/api/internal/manage/update.ts`
  - `putManagePicture` を追加
- `frontend/src/api/internal/manage/delete.ts`
  - `deleteManagePictures` を追加

### 画面テンプレート
- `frontend/src/components/templates/manage/picture/index.tsx`（新規）
  - DataTable（画像/タイトル/内容/閲覧/いいね/公開/投稿日時）
  - チャンネルフィルタ、ページネーション、一括削除モーダル
- `frontend/src/components/templates/manage/picture/edit.tsx`（新規）
  - 公開トグルとタイトル/内容の編集フォーム

### ページ
- `frontend/src/pages/manage/picture/index.tsx`（新規）一覧
- `frontend/src/pages/manage/picture/[ulid].tsx`（新規）編集

## 差異ポイント（他メディアとの違い）

- 一覧の画像列ヘッダは「画像」（video / comic の「サムネイル」とは異なる）
- 「閲覧」列（video は「再生」）
- 一覧タイトルは「画像管理」、削除モーダルタイトルは「画像の削除」

## 動作確認
- `npx tsc --noEmit`: エラー 0
- `npm run lint`: エラー 0（既存 warning 9件のみ）

## 備考
対応する BE 実装（`/manage/media/picture` エンドポイント、`PictureUpdateIn`、`PictureRepository.bulk_delete` など）はローカルに別途準備済みで、別 PR で提出予定。本 PR 単体では `/manage/picture` ページから BE へのリクエスト時に 404 になる点に留意。