### PR TITLE
【back】画像の管理API（/manage/media/picture）を追加

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,12 +1,12 @@
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
-from api.src.adapter.media import convert_comics, convert_musics, convert_videos
+from api.src.adapter.media import convert_comics, convert_musics, convert_pictures, convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media.input import BulkDeleteIn, ComicUpdateIn, MusicUpdateIn, VideoUpdateIn
-from api.src.types.schema.media.output import ComicOut, MusicOut, VideoOut
+from api.src.types.schema.media.input import BulkDeleteIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.output import ComicOut, MusicOut, PictureOut, VideoOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.manage.media import delete_manage_comic, delete_manage_music, delete_manage_video, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_video, get_manage_videos, update_manage_comic, update_manage_music, update_manage_video
+from api.src.usecase.manage.media import delete_manage_comic, delete_manage_music, delete_manage_picture, delete_manage_video, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_picture, get_manage_pictures, get_manage_video, get_manage_videos, update_manage_comic, update_manage_music, update_manage_picture, update_manage_video
 
 
 class ManageVideoAPI:
@@ -187,6 +187,67 @@ class ManageComicAPI:
             return 401, ErrorOut(message="Unauthorized")
 
         if not delete_manage_comic(user_id, input.ulids):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")
+
+
+class ManagePictureAPI:
+    """ManagePictureAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[PictureOut], 401: ErrorOut})
+    def list(request: HttpRequest, search: str = ""):
+        log.info("ManagePictureAPI list", search=search)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs = get_manage_pictures(user_id, search)
+        return 200, convert_pictures(objs)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: PictureOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManagePictureAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_picture(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Picture not found")
+
+        return 200, convert_pictures([obj])[0]
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: PictureUpdateIn):
+        log.info("ManagePictureAPI put", ulid=ulid, input=input)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_picture(user_id, ulid, input):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManagePictureAPI delete", ulids=input.ulids)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_picture(user_id, input.ulids):
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/domain/entity/media/picture/repository.py
+++ b/myus/api/src/domain/entity/media/picture/repository.py
@@ -22,6 +22,8 @@ class PictureRepository(PictureInterface):
             q_list.append(Q(ulid=filter.ulid))
         if filter.publish is not None:
             q_list.append(Q(publish=filter.publish))
+        if filter.owner_id:
+            q_list.append(Q(channel__owner_id=filter.owner_id))
         if filter.channel_id:
             q_list.append(Q(channel_id=filter.channel_id))
         if filter.category_id:
@@ -64,6 +66,9 @@ class PictureRepository(PictureInterface):
         )
 
         return new_ids
+
+    def bulk_delete(self, ids: list[int]) -> None:
+        Picture.objects.filter(id__in=ids).delete()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Picture.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/interface/media/picture/interface.py
+++ b/myus/api/src/domain/interface/media/picture/interface.py
@@ -17,5 +17,9 @@ class PictureInterface(ABC):
         ...
 
     @abstractmethod
+    def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
     def is_liked(self, media_id: int, user_id: int) -> bool:
         ...

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,7 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
-from api.src.adapter.manage import ManageComicAPI, ManageMusicAPI, ManageVideoAPI
+from api.src.adapter.manage import ManageComicAPI, ManageMusicAPI, ManagePictureAPI, ManageVideoAPI
 from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -21,6 +21,7 @@ api.add_router("/setting/notification", SettingNotificationAPI().router, tags=["
 api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Video"])
 api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Music"])
 api.add_router("/manage/media/comic", ManageComicAPI().router, tags=["Manage Comic"])
+api.add_router("/manage/media/picture", ManagePictureAPI().router, tags=["Manage Picture"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -67,5 +67,11 @@ class ComicUpdateIn(BaseModel):
     publish: bool
 
 
+class PictureUpdateIn(BaseModel):
+    title: str
+    content: str
+    publish: bool
+
+
 class BulkDeleteIn(BaseModel):
     ulids: list[str]

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -6,9 +6,11 @@ from api.src.domain.interface.media.music.data import MusicData
 from api.src.domain.interface.media.music.interface import MusicInterface
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.comic.interface import ComicInterface
+from api.src.domain.interface.media.picture.data import PictureData
+from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media.input import ComicUpdateIn, MusicUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.input import ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
 from api.utils.functions.index import create_url
 
 
@@ -207,4 +209,65 @@ def delete_manage_comic(user_id: int, ulids: list[str]) -> bool:
         return True
     except Exception as e:
         log.error("delete_manage_comic error", exc=e)
+        return False
+
+
+def get_manage_pictures(user_id: int, search: str) -> list[PictureData]:
+    repository = injector.get(PictureInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    objs = repository.bulk_get(ids=ids)
+
+    data = [replace(o, image=create_url(o.image)) for o in objs]
+    return data
+
+
+def get_manage_picture(user_id: int, ulid: str) -> PictureData | None:
+    repository = injector.get(PictureInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.info("Picture not found", ulid=ulid, user_id=user_id)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    return replace(obj, image=create_url(obj.image))
+
+
+def update_manage_picture(user_id: int, ulid: str, input: PictureUpdateIn) -> bool:
+    repository = injector.get(PictureInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Picture not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Picture owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    update_data = replace(obj, title=input.title, content=input.content, publish=input.publish)
+    try:
+        repository.bulk_save([update_data])
+        return True
+    except Exception as e:
+        log.error("update_manage_picture error", exc=e)
+        return False
+
+
+def delete_manage_picture(user_id: int, ulids: list[str]) -> bool:
+    repository = injector.get(PictureInterface)
+    delete_ids: list[int] = []
+
+    for ulid in ulids:
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        if len(ids) == 0:
+            log.error("Picture not found or owner mismatch", ulid=ulid, user_id=user_id)
+            return False
+        delete_ids.append(ids[0])
+
+    try:
+        repository.bulk_delete(delete_ids)
+        return True
+    except Exception as e:
+        log.error("delete_manage_picture error", exc=e)
         return False


### PR DESCRIPTION
## Summary
- `/manage/media/picture` エンドポイント（list/get/put/delete）を新設し、FE の画像管理画面（PR #716）に対応する BE 実装を追加
- `PictureRepository` に `bulk_delete` と `owner_id` フィルタを追加し、管理操作の前提を満たす
- `PictureUpdateIn` スキーマで編集フォーム（title / content / publish）を受け付け

## 変更内容

### ドメイン層
- `myus/api/src/domain/interface/media/picture/interface.py`
  - `bulk_delete(ids)` 抽象メソッドを追加（`bulk_save` 直下の位置に配置）
- `myus/api/src/domain/entity/media/picture/repository.py`
  - `bulk_delete` 実装を追加（同位置）
  - `get_ids` に `owner_id` フィルタを追加（管理画面でユーザ自身の画像のみ取得できるように）

### スキーマ
- `myus/api/src/types/schema/media/input.py`
  - `PictureUpdateIn(title, content, publish)` を追加（video / comic と同形）

### ユースケース
- `myus/api/src/usecase/manage/media.py`
  - `get_manage_pictures` / `get_manage_picture` / `update_manage_picture` / `delete_manage_picture` を追加
  - `get_manage_pictures` / `get_manage_picture` では `image` を `create_url()` で絶対 URL に変換

### アダプタ・ルーター
- `myus/api/src/adapter/manage.py`
  - `ManagePictureAPI` クラスを追加（list / get / put / delete、401/404/400 エラー応答込み）
- `myus/api/src/routers.py`
  - `/manage/media/picture` を `ManagePictureAPI` にマウント

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件のみ）

## 備考
- FE の PR #716 と同時にマージすることで画像管理画面が完結する