### PR TITLE
【front】video/comic/pictureの編集画面でサムネイル画像も編集可能に

### DIFF
--- a/frontend/src/api/internal/manage/update.ts
+++ b/frontend/src/api/internal/manage/update.ts
@@ -6,7 +6,7 @@ import { apiManageComic, apiManageMusic, apiManagePicture, apiManageVideo } from
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const putManageVideo = async (ulid: string, request: VideoUpdateIn): Promise<ApiOut<ErrorOut>> => {
-  return await apiOut(apiClient('json').put(apiManageVideo(ulid), camelSnake(request)))
+  return await apiOut(apiClient('form').put(apiManageVideo(ulid), camelSnake(request)))
 }
 
 export const putManageMusic = async (ulid: string, request: MusicUpdateIn): Promise<ApiOut<ErrorOut>> => {
@@ -14,9 +14,9 @@ export const putManageMusic = async (ulid: string, request: MusicUpdateIn): Prom
 }
 
 export const putManageComic = async (ulid: string, request: ComicUpdateIn): Promise<ApiOut<ErrorOut>> => {
-  return await apiOut(apiClient('json').put(apiManageComic(ulid), camelSnake(request)))
+  return await apiOut(apiClient('form').put(apiManageComic(ulid), camelSnake(request)))
 }
 
 export const putManagePicture = async (ulid: string, request: PictureUpdateIn): Promise<ApiOut<ErrorOut>> => {
-  return await apiOut(apiClient('json').put(apiManagePicture(ulid), camelSnake(request)))
+  return await apiOut(apiClient('form').put(apiManagePicture(ulid), camelSnake(request)))
 }

--- a/frontend/src/components/templates/manage/comic/edit.tsx
+++ b/frontend/src/components/templates/manage/comic/edit.tsx
@@ -13,6 +13,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import InputFile from 'components/parts/Input/File'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -34,12 +35,13 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<ComicUpdateIn>({ ...data })
+  const [values, setValues] = useState<ComicUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
 
   const handleBack = () => router.push('/manage/comic')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
     const { title, content } = values
@@ -69,6 +71,7 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/picture/edit.tsx
+++ b/frontend/src/components/templates/manage/picture/edit.tsx
@@ -13,6 +13,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import InputFile from 'components/parts/Input/File'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -34,12 +35,13 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<PictureUpdateIn>({ ...data })
+  const [values, setValues] = useState<PictureUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
 
   const handleBack = () => router.push('/manage/picture')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
     const { title, content } = values
@@ -69,6 +71,7 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <InputFile label="画像" accept="image/*" onChange={handleFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/video/edit.tsx
+++ b/frontend/src/components/templates/manage/video/edit.tsx
@@ -13,6 +13,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import InputFile from 'components/parts/Input/File'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -34,12 +35,13 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<VideoUpdateIn>({ ...data })
+  const [values, setValues] = useState<VideoUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
 
   const handleBack = () => router.push('/manage/video')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
     const { title, content } = values
@@ -69,6 +71,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -56,6 +56,7 @@ export interface VideoUpdateIn {
   title: string
   content: string
   publish: boolean
+  image?: File
 }
 
 export interface MusicUpdateIn {
@@ -70,10 +71,12 @@ export interface ComicUpdateIn {
   title: string
   content: string
   publish: boolean
+  image?: File
 }
 
 export interface PictureUpdateIn {
   title: string
   content: string
   publish: boolean
+  image?: File
 }


### PR DESCRIPTION
## Summary
- video / comic / picture の管理編集画面で、create 画面と同様にサムネイル画像を差し替えできるように変更
- `*UpdateIn` に `image?: File` を追加し、API クライアントを multipart 送信に切替
- 対応する BE PR は別途用意

## 変更内容

### 型定義
- `frontend/src/types/internal/media/input.d.ts`
  - `VideoUpdateIn` / `ComicUpdateIn` / `PictureUpdateIn` に `image?: File` を追加（任意フィールド）

### API クライアント
- `frontend/src/api/internal/manage/update.ts`
  - `putManageVideo` / `putManageComic` / `putManagePicture` を `apiClient('json')` から `apiClient('form')` に変更
  - multipart/form-data で送信するように切替（create API と同じパターン）
  - `putManageMusic` はサムネイルを持たないため `json` のまま

### 編集画面
- `frontend/src/components/templates/manage/video/edit.tsx`
- `frontend/src/components/templates/manage/comic/edit.tsx`
- `frontend/src/components/templates/manage/picture/edit.tsx`
  - `<InputFile label="サムネイル" accept="image/*" onChange={handleFile} />` を追加（picture のみ label は「画像」）
  - `handleFile` を追加して選択ファイルを `values.image` に反映
  - `useState` 初期値は `image` を含めず `{ title, content, publish }` の 3 フィールドで初期化（`image` は未選択時 `undefined`）

## UX
- ファイル未選択時は既存サムネイルが維持される（BE 側で `image is None` のときは更新データに image を含めないため）
- ファイル選択時のみ差し替えが適用される

## 動作確認
- `npx tsc --noEmit`: エラー 0
- `npm run lint`: エラー 0（既存 warning 9件のみ）

## 備考
対応する BE 実装（`adapter/manage.py` の `put` を `Form + File` 受信に変更、`usecase/manage/media.py` の `update_manage_*` が image を受けて `save_upload` で保存する変更）はローカルに別途準備済みで、別 PR で提出予定。本 PR 単体では BE が JSON body を期待するため保存時に 400/422 になる点に留意。