### PR TITLE
【back】video/comic/pictureの管理PUT APIでサムネイル画像更新に対応

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest
-from ninja import Router
+from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
 from api.src.adapter.media import convert_comics, convert_musics, convert_pictures, convert_videos
 from api.src.types.schema.common import ErrorOut
@@ -43,14 +43,14 @@ class ManageVideoAPI:
 
     @staticmethod
     @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
-    def put(request: HttpRequest, ulid: str, input: VideoUpdateIn):
-        log.info("ManageVideoAPI put", ulid=ulid, input=input)
+    def put(request: HttpRequest, ulid: str, input: VideoUpdateIn = Form(...), image: UploadedFile | None = File(None)):
+        log.info("ManageVideoAPI put", ulid=ulid, input=input, image=image)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        if not update_manage_video(user_id, ulid, input):
+        if not update_manage_video(user_id, ulid, input, image):
             return 400, ErrorOut(message="保存に失敗しました!")
 
         return 204, ErrorOut(message="保存しました!")
@@ -165,14 +165,14 @@ class ManageComicAPI:
 
     @staticmethod
     @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
-    def put(request: HttpRequest, ulid: str, input: ComicUpdateIn):
-        log.info("ManageComicAPI put", ulid=ulid, input=input)
+    def put(request: HttpRequest, ulid: str, input: ComicUpdateIn = Form(...), image: UploadedFile | None = File(None)):
+        log.info("ManageComicAPI put", ulid=ulid, input=input, image=image)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        if not update_manage_comic(user_id, ulid, input):
+        if not update_manage_comic(user_id, ulid, input, image):
             return 400, ErrorOut(message="保存に失敗しました!")
 
         return 204, ErrorOut(message="保存しました!")
@@ -226,14 +226,14 @@ class ManagePictureAPI:
 
     @staticmethod
     @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
-    def put(request: HttpRequest, ulid: str, input: PictureUpdateIn):
-        log.info("ManagePictureAPI put", ulid=ulid, input=input)
+    def put(request: HttpRequest, ulid: str, input: PictureUpdateIn = Form(...), image: UploadedFile | None = File(None)):
+        log.info("ManagePictureAPI put", ulid=ulid, input=input, image=image)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        if not update_manage_picture(user_id, ulid, input):
+        if not update_manage_picture(user_id, ulid, input, image):
             return 400, ErrorOut(message="保存に失敗しました!")
 
         return 204, ErrorOut(message="保存しました!")

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from ninja import UploadedFile
 from api.modules.logger import log
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
@@ -11,7 +12,9 @@ from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
 from api.src.types.schema.media.input import ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.utils.enum.index import ImageUpload
 from api.utils.functions.index import create_url
+from api.utils.functions.media import save_upload
 
 
 def get_manage_videos(user_id: int, search: str) -> list[VideoData]:
@@ -44,7 +47,7 @@ def get_manage_video(user_id: int, ulid: str) -> VideoData | None:
     )
 
 
-def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn) -> bool:
+def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(VideoInterface)
     ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
     if len(ids) == 0:
@@ -57,6 +60,9 @@ def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn) -> bool:
         return False
 
     update_data = replace(obj, title=input.title, content=input.content, publish=input.publish)
+    if image is not None:
+        update_data = replace(update_data, image=save_upload(image, ImageUpload.VIDEO, obj.channel.ulid))
+
     try:
         repository.bulk_save([update_data])
         return True
@@ -172,7 +178,7 @@ def get_manage_comic(user_id: int, ulid: str) -> ComicData | None:
     )
 
 
-def update_manage_comic(user_id: int, ulid: str, input: ComicUpdateIn) -> bool:
+def update_manage_comic(user_id: int, ulid: str, input: ComicUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(ComicInterface)
     ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
     if len(ids) == 0:
@@ -185,6 +191,9 @@ def update_manage_comic(user_id: int, ulid: str, input: ComicUpdateIn) -> bool:
         return False
 
     update_data = replace(obj, title=input.title, content=input.content, publish=input.publish)
+    if image is not None:
+        update_data = replace(update_data, image=save_upload(image, ImageUpload.COMIC, obj.channel.ulid))
+
     try:
         repository.bulk_save([update_data])
         return True
@@ -233,7 +242,7 @@ def get_manage_picture(user_id: int, ulid: str) -> PictureData | None:
     return replace(obj, image=create_url(obj.image))
 
 
-def update_manage_picture(user_id: int, ulid: str, input: PictureUpdateIn) -> bool:
+def update_manage_picture(user_id: int, ulid: str, input: PictureUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(PictureInterface)
     ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
     if len(ids) == 0:
@@ -246,6 +255,9 @@ def update_manage_picture(user_id: int, ulid: str, input: PictureUpdateIn) -> bo
         return False
 
     update_data = replace(obj, title=input.title, content=input.content, publish=input.publish)
+    if image is not None:
+        update_data = replace(update_data, image=save_upload(image, ImageUpload.PICTURE, obj.channel.ulid))
+
     try:
         repository.bulk_save([update_data])
         return True


### PR DESCRIPTION
## Summary
- `/manage/media/{video,comic,picture}` の PUT エンドポイントを `application/json` から `multipart/form-data` 受信に変更し、サムネイル画像のアップロードを受け付ける
- `update_manage_{video,comic,picture}` usecase に `image: UploadedFile | None` 引数を追加し、渡された場合のみ `save_upload()` で保存して差し替え
- 対応する FE PR #718 と同時マージで動作する

## 変更内容

### アダプタ層
- `myus/api/src/adapter/manage.py`
  - `from ninja import File, Form, Router, UploadedFile` を追加
  - `ManageVideoAPI.put` / `ManageComicAPI.put` / `ManagePictureAPI.put` の引数を以下に変更:
    - `input: *UpdateIn = Form(...)`（JSON body → multipart form）
    - `image: UploadedFile | None = File(None)`（任意のサムネイル画像）
  - usecase 呼び出しに `image` を渡す
  - ログに `image` も記録

### ユースケース層
- `myus/api/src/usecase/manage/media.py`
  - `from ninja import UploadedFile` を追加
  - `from api.utils.enum.index import ImageUpload` / `from api.utils.functions.media import save_upload` を追加
  - `update_manage_video(user_id, ulid, input, image: UploadedFile | None = None)`
    - `image is not None` のときだけ `save_upload(image, ImageUpload.VIDEO, obj.channel.ulid)` で保存し、`update_data.image` を差し替え
  - `update_manage_comic` / `update_manage_picture` も同パターン（`ImageUpload.COMIC` / `ImageUpload.PICTURE`）
  - music は thumbnail を持たないため変更なし

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件のみ）

## 備考
- FE PR #718 と同時にマージすることでサムネイル差し替え機能が完結する
- ファイル未指定時は既存サムネイルが維持される（`if image is not None` ブロック内のみ差し替え処理が走る）