### PR TITLE
【front】ブログの管理画面（DataTable一覧・編集・一括削除）を追加

### DIFF
--- a/frontend/src/api/internal/manage/delete.ts
+++ b/frontend/src/api/internal/manage/delete.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageComics, apiManageMusics, apiManagePictures, apiManageVideos } from 'api/uri'
+import { apiManageBlogs, apiManageComics, apiManageMusics, apiManagePictures, apiManageVideos } from 'api/uri'
 
 export const deleteManageVideos = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageVideos, { data: { ulids } }))
@@ -17,4 +17,8 @@ export const deleteManageComics = async (ulids: string[]): Promise<ApiOut<ErrorO
 
 export const deleteManagePictures = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManagePictures, { data: { ulids } }))
+}
+
+export const deleteManageBlogs = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').delete(apiManageBlogs, { data: { ulids } }))
 }

--- a/frontend/src/api/internal/manage/get.ts
+++ b/frontend/src/api/internal/manage/get.ts
@@ -2,8 +2,8 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { Comic, Music, Picture, SearchParams, Video } from 'types/internal/media/output'
-import { apiManageComic, apiManageComics, apiManageMusic, apiManageMusics, apiManagePicture, apiManagePictures, apiManageVideo, apiManageVideos } from 'api/uri'
+import { Blog, Comic, Music, Picture, SearchParams, Video } from 'types/internal/media/output'
+import { apiManageBlog, apiManageBlogs, apiManageComic, apiManageComics, apiManageMusic, apiManageMusics, apiManagePicture, apiManagePictures, apiManageVideo, apiManageVideos } from 'api/uri'
 
 export const getManageVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<Video[]>> => {
   return await apiOut(apiClient('json').get(apiManageVideos, cookieHeader(req, params)))
@@ -21,6 +21,10 @@ export const getManagePictures = async (params: SearchParams, req?: Req): Promis
   return await apiOut(apiClient('json').get(apiManagePictures, cookieHeader(req, params)))
 }
 
+export const getManageBlogs = async (params: SearchParams, req?: Req): Promise<ApiOut<Blog[]>> => {
+  return await apiOut(apiClient('json').get(apiManageBlogs, cookieHeader(req, params)))
+}
+
 export const getManageVideo = async (ulid: string, req?: Req): Promise<ApiOut<Video>> => {
   return await apiOut(apiClient('json').get(apiManageVideo(ulid), cookieHeader(req)))
 }
@@ -35,4 +39,8 @@ export const getManageComic = async (ulid: string, req?: Req): Promise<ApiOut<Co
 
 export const getManagePicture = async (ulid: string, req?: Req): Promise<ApiOut<Picture>> => {
   return await apiOut(apiClient('json').get(apiManagePicture(ulid), cookieHeader(req)))
+}
+
+export const getManageBlog = async (ulid: string, req?: Req): Promise<ApiOut<Blog>> => {
+  return await apiOut(apiClient('json').get(apiManageBlog(ulid), cookieHeader(req)))
 }

--- a/frontend/src/api/internal/manage/update.ts
+++ b/frontend/src/api/internal/manage/update.ts
@@ -1,8 +1,8 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
-import { ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn } from 'types/internal/media/input'
+import { BlogUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn } from 'types/internal/media/input'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageComic, apiManageMusic, apiManagePicture, apiManageVideo } from 'api/uri'
+import { apiManageBlog, apiManageComic, apiManageMusic, apiManagePicture, apiManageVideo } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const putManageVideo = async (ulid: string, request: VideoUpdateIn): Promise<ApiOut<ErrorOut>> => {
@@ -19,4 +19,8 @@ export const putManageComic = async (ulid: string, request: ComicUpdateIn): Prom
 
 export const putManagePicture = async (ulid: string, request: PictureUpdateIn): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('form').put(apiManagePicture(ulid), camelSnake(request)))
+}
+
+export const putManageBlog = async (ulid: string, request: BlogUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('form').put(apiManageBlog(ulid), camelSnake(request)))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -73,5 +73,8 @@ export const apiManageComic = (ulid: string) => base + `/manage/media/comic/${ul
 export const apiManagePictures = base + '/manage/media/picture'
 export const apiManagePicture = (ulid: string) => base + `/manage/media/picture/${ulid}`
 
+export const apiManageBlogs = base + '/manage/media/blog'
+export const apiManageBlog = (ulid: string) => base + `/manage/media/blog/${ulid}`
+
 // 外部API
 export const apiAddress = base + '/search'

--- a/frontend/src/components/templates/manage/blog/edit.tsx
+++ b/frontend/src/components/templates/manage/blog/edit.tsx
@@ -1,0 +1,88 @@
+import { useState, ChangeEvent } from 'react'
+import dynamic from 'next/dynamic'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { BlogUpdateIn } from 'types/internal/media/input'
+import { Blog } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { putManageBlog } from 'api/internal/manage/update'
+import { FetchError } from 'utils/constants/enum'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import InputFile from 'components/parts/Input/File'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+
+const TextEditor = dynamic(() => import('components/widgets/TextEditor'), { ssr: false })
+
+interface Props {
+  data: Blog
+  channels: Channel[]
+}
+
+export default function ManageBlogEdit(props: Props): React.JSX.Element {
+  const { data, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [values, setValues] = useState<BlogUpdateIn>({ title: data.title, content: data.content, richtext: data.richtext, publish: data.publish })
+
+  const handleBack = () => router.push('/manage/blog')
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
+
+  const handleRichtext = (html: string) => {
+    const richtext = html.trim() === '<p></p>' ? '' : html.trim()
+    setValues({ ...values, richtext })
+  }
+
+  const handleForm = async () => {
+    const { title, content, richtext } = values
+    if (!isRequiredCheck({ title, content, richtext })) return
+    handleLoading(true)
+    const ret = await putManageBlog(data.ulid, values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Put, ret.error.message)
+      return
+    }
+    handleToast('保存しました', false)
+  }
+
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="保存する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
+  return (
+    <Main title="ブログ編集" type="table" toast={toast} isFooter={false} button={button}>
+      <form method="POST" action="">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
+          <TextEditor label="本文" value={values.richtext} required={isRequired} onChange={handleRichtext} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/blog/index.tsx
+++ b/frontend/src/components/templates/manage/blog/index.tsx
@@ -1,0 +1,171 @@
+import { ChangeEvent, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { Blog } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { deleteManageBlogs } from 'api/internal/manage/delete'
+import { FetchError } from 'utils/constants/enum'
+import { formatDatetime } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { usePagination } from 'components/hooks/usePagination'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import DataTable, { Column } from 'components/parts/DataTable'
+import ExImage from 'components/parts/ExImage'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Toggle from 'components/parts/Input/Toggle'
+import Pagination from 'components/parts/Pagination'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from '../Media.module.scss'
+
+interface Props {
+  datas: Blog[]
+  channels: Channel[]
+}
+
+export default function ManageBlogs(props: Props): React.JSX.Element {
+  const { datas, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+  const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+  const channelDatas = useMemo(() => datas.filter((b) => b.channel.ulid === channelUlid), [datas, channelUlid])
+  const { currentPage, totalPages, pageDatas, handlePage } = usePagination(channelDatas, 50)
+
+  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleEdit = (blog: Blog) => router.push(`/manage/blog/${blog.ulid}`)
+  const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
+
+  const handleDeleteSubmit = async () => {
+    const ulids = Array.from(selectedKeys)
+    if (ulids.length === 0) return
+
+    handleLoading(true)
+    const ret = await deleteManageBlogs(ulids)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Delete, ret.error.message)
+      return
+    }
+    setSelectedKeys(new Set())
+    handleDelete()
+    router.replace(router.asPath)
+  }
+
+  const columns: Column<Blog>[] = [
+    {
+      key: 'thumbnail',
+      header: 'サムネイル',
+      className: style.thumbnail,
+      cell: (b) => b.image && <ExImage src={b.image} width="96" height="54" />,
+    },
+    {
+      key: 'title',
+      header: 'タイトル',
+      sortable: true,
+      sortValue: (b) => b.title,
+      className: style.title,
+      cell: (b) => (
+        <a className={style.title_link} onClick={() => handleEdit(b)}>
+          {b.title}
+        </a>
+      ),
+    },
+    {
+      key: 'content',
+      header: '内容',
+      className: style.content,
+      cell: (b) => b.content,
+    },
+    {
+      key: 'read',
+      header: '閲覧',
+      align: 'right',
+      sortable: true,
+      sortValue: (b) => b.read,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (b) => b.read,
+    },
+    {
+      key: 'like',
+      header: 'いいね',
+      align: 'right',
+      sortable: true,
+      sortValue: (b) => b.like,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (b) => b.like,
+    },
+    {
+      key: 'publish',
+      header: '公開',
+      align: 'center',
+      sortable: true,
+      sortValue: (b) => (b.publish ? 1 : 0),
+      className: style.narrow,
+      cellClass: style.publish,
+      cell: (b) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={b.publish} disable />
+        </div>
+      ),
+    },
+    {
+      key: 'created',
+      header: '投稿日時',
+      sortable: true,
+      sortValue: (b) => new Date(b.created).getTime(),
+      className: style.datetime,
+      cell: (b) => formatDatetime(b.created),
+    },
+  ]
+
+  return (
+    <Main
+      title="ブログ管理"
+      type="table"
+      toast={toast}
+      isFooter={false}
+      button={
+        <div className={style.header_actions}>
+          {selectedKeys.size > 0 && (
+            <>
+              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
+              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
+            </>
+          )}
+          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
+        </div>
+      }
+    >
+      <div className={style.manage}>
+        <DataTable
+          datas={pageDatas}
+          columns={columns}
+          rowKey={(b) => b.ulid}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelection={setSelectedKeys}
+          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
+        />
+      </div>
+      <DeleteModal
+        open={isDeleteModal}
+        title="ブログの削除"
+        content={`${selectedKeys.size}件のブログを削除しますか？`}
+        loading={isLoading}
+        onClose={handleDelete}
+        onAction={handleDeleteSubmit}
+      />
+    </Main>
+  )
+}

--- a/frontend/src/pages/manage/blog/[ulid].tsx
+++ b/frontend/src/pages/manage/blog/[ulid].tsx
@@ -1,0 +1,33 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Blog } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManageBlog } from 'api/internal/manage/get'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageBlogEdit from 'components/templates/manage/blog/edit'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ulid = String(params?.ulid ?? '')
+  const [blogRet, channelsRet] = await Promise.all([getManageBlog(ulid, req), getChannels(req)])
+  if (blogRet.isErr()) return { props: { status: blogRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const data = blogRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, data, channels } }
+}
+
+interface Props {
+  status: number
+  data: Blog
+  channels: Channel[]
+}
+
+export default function ManageBlogEditPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageBlogEdit {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/pages/manage/blog/index.tsx
+++ b/frontend/src/pages/manage/blog/index.tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Blog } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManageBlogs } from 'api/internal/manage/get'
+import { searchParams } from 'utils/functions/common'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageBlogs from 'components/templates/manage/blog'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const params = searchParams(query)
+  const [blogsRet, channelsRet] = await Promise.all([getManageBlogs(params, req), getChannels(req)])
+  if (blogsRet.isErr()) return { props: { status: blogsRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const datas = blogsRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, datas, channels } }
+}
+
+interface Props {
+  status: number
+  datas: Blog[]
+  channels: Channel[]
+}
+
+export default function ManageBlogsPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageBlogs {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -80,3 +80,11 @@ export interface PictureUpdateIn {
   publish: boolean
   image?: File
 }
+
+export interface BlogUpdateIn {
+  title: string
+  content: string
+  richtext: string
+  publish: boolean
+  image?: File
+}


### PR DESCRIPTION
## Summary
- `/manage/blog` の DataTable 形式の一覧・編集・一括削除機能を他メディアに続いて追加
- `BlogUpdateIn` 型と manage API クライアントの blog 関数を追加
- 編集画面ではサムネイル差し替え＋本文（リッチテキスト）も編集可能
- 対応する BE PR は別途用意

## 変更内容

### 型定義
- `frontend/src/types/internal/media/input.d.ts`
  - `BlogUpdateIn(title, content, richtext, publish, image?)` を追加（他メディアと違い `richtext` 含む）

### URI・API クライアント
- `frontend/src/api/uri.ts`
  - `apiManageBlogs` / `apiManageBlog(ulid)` を追加
- `frontend/src/api/internal/manage/get.ts`
  - `getManageBlogs` / `getManageBlog` を追加
- `frontend/src/api/internal/manage/update.ts`
  - `putManageBlog` を `apiClient('form')` で追加（multipart/form-data 送信）
- `frontend/src/api/internal/manage/delete.ts`
  - `deleteManageBlogs` を追加

### 画面テンプレート
- `frontend/src/components/templates/manage/blog/index.tsx`（新規）
  - DataTable（サムネイル/タイトル/内容/閲覧/いいね/公開/投稿日時）
  - チャンネルフィルタ、ページネーション、一括削除モーダル
- `frontend/src/components/templates/manage/blog/edit.tsx`（新規）
  - 公開トグル + タイトル/内容/サムネイル/本文（TextEditor）の編集フォーム
  - `TextEditor` は `next/dynamic` の `ssr: false` で読み込み（create 側と同じパターン）
  - `handleRichtext` で空タグ `<p></p>` は空文字に正規化

### ページ
- `frontend/src/pages/manage/blog/index.tsx`（新規）一覧
- `frontend/src/pages/manage/blog/[ulid].tsx`（新規）編集

## 他メディアとの差異

- `richtext` フィールドを編集対象に含める（他メディアの 3〜4 フィールドと違い blog は 4 フィールド + image）
- 本文エディタは rich text 用の `TextEditor` コンポーネントを動的ロード
- 一覧タイトルは「ブログ管理」、削除モーダルは「ブログの削除」

## 動作確認
- `npx tsc --noEmit`: エラー 0
- `npm run lint`: エラー 0（既存 warning 9件のみ）

## 備考
対応する BE 実装（`/manage/media/blog` エンドポイント、`BlogUpdateIn`、`BlogRepository.bulk_delete` など）はローカルに別途準備済みで、別 PR で提出予定。