### PR TITLE
【back】ブログの管理API（/manage/media/blog）追加とBlogOut/richtext対応

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,12 +1,12 @@
 from django.http import HttpRequest
 from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
-from api.src.adapter.media import convert_comics, convert_musics, convert_pictures, convert_videos
+from api.src.adapter.media import convert_blogs, convert_comics, convert_musics, convert_pictures, convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media.input import BulkDeleteIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
-from api.src.types.schema.media.output import ComicOut, MusicOut, PictureOut, VideoOut
+from api.src.types.schema.media.input import BlogUpdateIn, BulkDeleteIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.output import BlogOut, ComicOut, MusicOut, PictureOut, VideoOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.manage.media import delete_manage_comic, delete_manage_music, delete_manage_picture, delete_manage_video, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_picture, get_manage_pictures, get_manage_video, get_manage_videos, update_manage_comic, update_manage_music, update_manage_picture, update_manage_video
+from api.src.usecase.manage.media import delete_manage_blog, delete_manage_comic, delete_manage_music, delete_manage_picture, delete_manage_video, get_manage_blog, get_manage_blogs, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_picture, get_manage_pictures, get_manage_video, get_manage_videos, update_manage_blog, update_manage_comic, update_manage_music, update_manage_picture, update_manage_video
 
 
 class ManageVideoAPI:
@@ -248,6 +248,67 @@ class ManagePictureAPI:
             return 401, ErrorOut(message="Unauthorized")
 
         if not delete_manage_picture(user_id, input.ulids):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")
+
+
+class ManageBlogAPI:
+    """ManageBlogAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[BlogOut], 401: ErrorOut})
+    def list(request: HttpRequest, search: str = ""):
+        log.info("ManageBlogAPI list", search=search)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs = get_manage_blogs(user_id, search)
+        return 200, convert_blogs(objs)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: BlogOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManageBlogAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_blog(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Blog not found")
+
+        return 200, convert_blogs([obj])[0]
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: BlogUpdateIn = Form(...), image: UploadedFile | None = File(None)):
+        log.info("ManageBlogAPI put", ulid=ulid, input=input, image=image)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_blog(user_id, ulid, input, image):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManageBlogAPI delete", ulids=input.ulids)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_blog(user_id, input.ulids):
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -518,6 +518,7 @@ def convert_blogs(objs: list[BlogData]) -> list[BlogOut]:
             title=x.title,
             content=x.content,
             image=x.image,
+            richtext=x.richtext,
             read=x.read,
             like=x.like,
             publish=x.publish,

--- a/myus/api/src/domain/entity/media/blog/repository.py
+++ b/myus/api/src/domain/entity/media/blog/repository.py
@@ -22,6 +22,8 @@ class BlogRepository(BlogInterface):
             q_list.append(Q(ulid=filter.ulid))
         if filter.publish is not None:
             q_list.append(Q(publish=filter.publish))
+        if filter.owner_id:
+            q_list.append(Q(channel__owner_id=filter.owner_id))
         if filter.channel_id:
             q_list.append(Q(channel_id=filter.channel_id))
         if filter.category_id:
@@ -64,6 +66,9 @@ class BlogRepository(BlogInterface):
         )
 
         return new_ids
+
+    def bulk_delete(self, ids: list[int]) -> None:
+        Blog.objects.filter(id__in=ids).delete()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Blog.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/interface/media/blog/interface.py
+++ b/myus/api/src/domain/interface/media/blog/interface.py
@@ -17,5 +17,9 @@ class BlogInterface(ABC):
         ...
 
     @abstractmethod
+    def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
     def is_liked(self, media_id: int, user_id: int) -> bool:
         ...

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,7 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
-from api.src.adapter.manage import ManageComicAPI, ManageMusicAPI, ManagePictureAPI, ManageVideoAPI
+from api.src.adapter.manage import ManageBlogAPI, ManageComicAPI, ManageMusicAPI, ManagePictureAPI, ManageVideoAPI
 from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -22,6 +22,7 @@ api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Vid
 api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Music"])
 api.add_router("/manage/media/comic", ManageComicAPI().router, tags=["Manage Comic"])
 api.add_router("/manage/media/picture", ManagePictureAPI().router, tags=["Manage Picture"])
+api.add_router("/manage/media/blog", ManageBlogAPI().router, tags=["Manage Blog"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -73,5 +73,12 @@ class PictureUpdateIn(BaseModel):
     publish: bool
 
 
+class BlogUpdateIn(BaseModel):
+    title: str
+    content: str
+    richtext: str
+    publish: bool
+
+
 class BulkDeleteIn(BaseModel):
     ulids: list[str]

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -62,6 +62,7 @@ class PictureOut(MediaOut):
 
 class BlogOut(MediaOut):
     image: str
+    richtext: str
 
 
 class ChatOut(MediaOut):

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -9,9 +9,11 @@ from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.picture.interface import PictureInterface
+from api.src.domain.interface.media.blog.data import BlogData
+from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media.input import ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.input import BlogUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
 from api.utils.enum.index import ImageUpload
 from api.utils.functions.index import create_url
 from api.utils.functions.media import save_upload
@@ -282,4 +284,68 @@ def delete_manage_picture(user_id: int, ulids: list[str]) -> bool:
         return True
     except Exception as e:
         log.error("delete_manage_picture error", exc=e)
+        return False
+
+
+def get_manage_blogs(user_id: int, search: str) -> list[BlogData]:
+    repository = injector.get(BlogInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    objs = repository.bulk_get(ids=ids)
+
+    data = [replace(o, image=create_url(o.image)) for o in objs]
+    return data
+
+
+def get_manage_blog(user_id: int, ulid: str) -> BlogData | None:
+    repository = injector.get(BlogInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.info("Blog not found", ulid=ulid, user_id=user_id)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    return replace(obj, image=create_url(obj.image))
+
+
+def update_manage_blog(user_id: int, ulid: str, input: BlogUpdateIn, image: UploadedFile | None = None) -> bool:
+    repository = injector.get(BlogInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Blog not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Blog owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    update_data = replace(obj, title=input.title, content=input.content, richtext=input.richtext, publish=input.publish)
+    if image is not None:
+        update_data = replace(update_data, image=save_upload(image, ImageUpload.BLOG, obj.channel.ulid))
+
+    try:
+        repository.bulk_save([update_data])
+        return True
+    except Exception as e:
+        log.error("update_manage_blog error", exc=e)
+        return False
+
+
+def delete_manage_blog(user_id: int, ulids: list[str]) -> bool:
+    repository = injector.get(BlogInterface)
+    delete_ids: list[int] = []
+
+    for ulid in ulids:
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        if len(ids) == 0:
+            log.error("Blog not found or owner mismatch", ulid=ulid, user_id=user_id)
+            return False
+        delete_ids.append(ids[0])
+
+    try:
+        repository.bulk_delete(delete_ids)
+        return True
+    except Exception as e:
+        log.error("delete_manage_blog error", exc=e)
         return False


### PR DESCRIPTION
## Summary
- `/manage/media/blog` エンドポイント（list/get/put/delete）を新設し、FE の管理画面（PR #720）に対応
- `BlogOut` スキーマに `richtext` フィールドを追加し、編集画面で本文の初期値が取得できるように修正
- サムネイル差し替えにも対応（`Form + File` 受信）

## 変更内容

### ドメイン層
- `myus/api/src/domain/interface/media/blog/interface.py`
  - `bulk_delete(ids)` 抽象メソッドを追加（`bulk_save` 直下、他メディアと同じ位置）
- `myus/api/src/domain/entity/media/blog/repository.py`
  - `bulk_delete` 実装を追加（同位置）
  - `get_ids` に `owner_id` フィルタ追加（管理画面でユーザ自身のブログのみ取得）

### スキーマ
- `myus/api/src/types/schema/media/input.py`
  - `BlogUpdateIn(title, content, richtext, publish)` を追加（他メディアと違い `richtext` を含む）
- `myus/api/src/types/schema/media/output.py`
  - `BlogOut` に `richtext: str` を追加
  - これまで `BlogOut` は `MediaOut` 由来の基本 5 フィールド + `image` のみで、本文 HTML が返らず、編集画面で初期値が空になる不具合の原因だった

### アダプタ: 変換関数
- `myus/api/src/adapter/media.py`
  - `convert_blogs` で `richtext=x.richtext` を詰めるよう修正

### ユースケース
- `myus/api/src/usecase/manage/media.py`
  - `get_manage_blogs` / `get_manage_blog` / `update_manage_blog` / `delete_manage_blog` を追加
  - `update_manage_blog` は `input.richtext` も反映
  - `image` が渡されたときは `save_upload(image, ImageUpload.BLOG, channel.ulid)` で保存

### アダプタ: API
- `myus/api/src/adapter/manage.py`
  - `ManageBlogAPI` クラス追加（list / get / put / delete）
  - `put` は `input: BlogUpdateIn = Form(...), image: UploadedFile | None = File(None)` で multipart 受信

### ルーター
- `myus/api/src/routers.py`
  - `/manage/media/blog` を `ManageBlogAPI` にマウント

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件は `logger.py` / `video_converter.py` / `db/models/*` / `adapter/media.py` の `period` 型不整合などで変更前から発生しているもの）

## 備考
- FE PR #720 と同時にマージすることで `/manage/blog` ページ、編集画面（richtext 本文＋サムネイル差し替え）が完結する