### PR TITLE
【front】チャットの管理画面（DataTable一覧・編集・一括削除）を追加

### DIFF
--- a/frontend/src/api/internal/manage/delete.ts
+++ b/frontend/src/api/internal/manage/delete.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageBlogs, apiManageComics, apiManageMusics, apiManagePictures, apiManageVideos } from 'api/uri'
+import { apiManageVideos, apiManageMusics, apiManageComics, apiManagePictures, apiManageBlogs, apiManageChats } from 'api/uri'
 
 export const deleteManageVideos = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageVideos, { data: { ulids } }))
@@ -21,4 +21,8 @@ export const deleteManagePictures = async (ulids: string[]): Promise<ApiOut<Erro
 
 export const deleteManageBlogs = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageBlogs, { data: { ulids } }))
+}
+
+export const deleteManageChats = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').delete(apiManageChats, { data: { ulids } }))
 }

--- a/frontend/src/api/internal/manage/get.ts
+++ b/frontend/src/api/internal/manage/get.ts
@@ -2,8 +2,21 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { Blog, Comic, Music, Picture, SearchParams, Video } from 'types/internal/media/output'
-import { apiManageBlog, apiManageBlogs, apiManageComic, apiManageComics, apiManageMusic, apiManageMusics, apiManagePicture, apiManagePictures, apiManageVideo, apiManageVideos } from 'api/uri'
+import { SearchParams, Video, Music, Comic, Picture, Blog, Chat } from 'types/internal/media/output'
+import {
+  apiManageBlog,
+  apiManageBlogs,
+  apiManageChat,
+  apiManageChats,
+  apiManageComic,
+  apiManageComics,
+  apiManageMusic,
+  apiManageMusics,
+  apiManagePicture,
+  apiManagePictures,
+  apiManageVideo,
+  apiManageVideos,
+} from 'api/uri'
 
 export const getManageVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<Video[]>> => {
   return await apiOut(apiClient('json').get(apiManageVideos, cookieHeader(req, params)))
@@ -25,6 +38,10 @@ export const getManageBlogs = async (params: SearchParams, req?: Req): Promise<A
   return await apiOut(apiClient('json').get(apiManageBlogs, cookieHeader(req, params)))
 }
 
+export const getManageChats = async (params: SearchParams, req?: Req): Promise<ApiOut<Chat[]>> => {
+  return await apiOut(apiClient('json').get(apiManageChats, cookieHeader(req, params)))
+}
+
 export const getManageVideo = async (ulid: string, req?: Req): Promise<ApiOut<Video>> => {
   return await apiOut(apiClient('json').get(apiManageVideo(ulid), cookieHeader(req)))
 }
@@ -43,4 +60,8 @@ export const getManagePicture = async (ulid: string, req?: Req): Promise<ApiOut<
 
 export const getManageBlog = async (ulid: string, req?: Req): Promise<ApiOut<Blog>> => {
   return await apiOut(apiClient('json').get(apiManageBlog(ulid), cookieHeader(req)))
+}
+
+export const getManageChat = async (ulid: string, req?: Req): Promise<ApiOut<Chat>> => {
+  return await apiOut(apiClient('json').get(apiManageChat(ulid), cookieHeader(req)))
 }

--- a/frontend/src/api/internal/manage/update.ts
+++ b/frontend/src/api/internal/manage/update.ts
@@ -1,8 +1,8 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
-import { BlogUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn } from 'types/internal/media/input'
+import { BlogUpdateIn, ChatUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn } from 'types/internal/media/input'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageBlog, apiManageComic, apiManageMusic, apiManagePicture, apiManageVideo } from 'api/uri'
+import { apiManageBlog, apiManageChat, apiManageComic, apiManageMusic, apiManagePicture, apiManageVideo } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const putManageVideo = async (ulid: string, request: VideoUpdateIn): Promise<ApiOut<ErrorOut>> => {
@@ -23,4 +23,8 @@ export const putManagePicture = async (ulid: string, request: PictureUpdateIn): 
 
 export const putManageBlog = async (ulid: string, request: BlogUpdateIn): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('form').put(apiManageBlog(ulid), camelSnake(request)))
+}
+
+export const putManageChat = async (ulid: string, request: ChatUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').put(apiManageChat(ulid), camelSnake(request)))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -76,5 +76,8 @@ export const apiManagePicture = (ulid: string) => base + `/manage/media/picture/
 export const apiManageBlogs = base + '/manage/media/blog'
 export const apiManageBlog = (ulid: string) => base + `/manage/media/blog/${ulid}`
 
+export const apiManageChats = base + '/manage/media/chat'
+export const apiManageChat = (ulid: string) => base + `/manage/media/chat/${ulid}`
+
 // 外部API
 export const apiAddress = base + '/search'

--- a/frontend/src/components/templates/manage/chat/edit.tsx
+++ b/frontend/src/components/templates/manage/chat/edit.tsx
@@ -1,0 +1,78 @@
+import { useState, ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { ChatUpdateIn } from 'types/internal/media/input'
+import { Chat } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { putManageChat } from 'api/internal/manage/update'
+import { FetchError } from 'utils/constants/enum'
+import { formatDate } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+
+interface Props {
+  data: Chat
+  channels: Channel[]
+}
+
+export default function ManageChatEdit(props: Props): React.JSX.Element {
+  const { data, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [values, setValues] = useState<ChatUpdateIn>({ title: data.title, content: data.content, period: formatDate(data.period), publish: data.publish })
+
+  const handleBack = () => router.push('/manage/chat')
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleForm = async () => {
+    const { title, content, period } = values
+    if (!isRequiredCheck({ title, content, period })) return
+    handleLoading(true)
+    const ret = await putManageChat(data.ulid, values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Put, ret.error.message)
+      return
+    }
+    handleToast('保存しました', false)
+  }
+
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="保存する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
+  return (
+    <Main title="チャット編集" type="table" toast={toast} isFooter={false} button={button}>
+      <form method="POST" action="">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <Input label="期間" name="period" value={values.period} required={isRequired} onChange={handleInput} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/chat/index.tsx
+++ b/frontend/src/components/templates/manage/chat/index.tsx
@@ -1,0 +1,182 @@
+import { ChangeEvent, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import { Channel } from 'types/internal/channel'
+import { Chat } from 'types/internal/media/output'
+import { Option } from 'types/internal/other'
+import { deleteManageChats } from 'api/internal/manage/delete'
+import { FetchError } from 'utils/constants/enum'
+import { formatDate, formatDatetime } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { usePagination } from 'components/hooks/usePagination'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import DataTable, { Column } from 'components/parts/DataTable'
+import SelectBox from 'components/parts/Input/SelectBox'
+import Toggle from 'components/parts/Input/Toggle'
+import Pagination from 'components/parts/Pagination'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from '../Media.module.scss'
+
+interface Props {
+  datas: Chat[]
+  channels: Channel[]
+}
+
+export default function ManageChats(props: Props): React.JSX.Element {
+  const { datas, channels } = props
+
+  const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+  const [channelUlid, setChannelUlid] = useState<string>(channels[0]?.ulid ?? '')
+  const channelDatas = useMemo(() => datas.filter((c) => c.channel.ulid === channelUlid), [datas, channelUlid])
+  const { currentPage, totalPages, pageDatas, handlePage } = usePagination(channelDatas, 50)
+
+  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleEdit = (chat: Chat) => router.push(`/manage/chat/${chat.ulid}`)
+  const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => setChannelUlid(e.target.value)
+
+  const handleDeleteSubmit = async () => {
+    const ulids = Array.from(selectedKeys)
+    if (ulids.length === 0) return
+
+    handleLoading(true)
+    const ret = await deleteManageChats(ulids)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Delete, ret.error.message)
+      return
+    }
+    setSelectedKeys(new Set())
+    handleDelete()
+    router.replace(router.asPath)
+  }
+
+  const columns: Column<Chat>[] = [
+    {
+      key: 'title',
+      header: 'タイトル',
+      sortable: true,
+      sortValue: (c) => c.title,
+      className: style.title,
+      cell: (c) => (
+        <a className={style.title_link} onClick={() => handleEdit(c)}>
+          {c.title}
+        </a>
+      ),
+    },
+    {
+      key: 'content',
+      header: '内容',
+      className: style.content,
+      cell: (c) => c.content,
+    },
+    {
+      key: 'thread',
+      header: 'スレッド',
+      align: 'right',
+      sortable: true,
+      sortValue: (c) => c.thread,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (c) => c.thread,
+    },
+    {
+      key: 'joined',
+      header: '参加',
+      align: 'right',
+      sortable: true,
+      sortValue: (c) => c.joined,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (c) => c.joined,
+    },
+    {
+      key: 'like',
+      header: 'いいね',
+      align: 'right',
+      sortable: true,
+      sortValue: (c) => c.like,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (c) => c.like,
+    },
+    {
+      key: 'publish',
+      header: '公開',
+      align: 'center',
+      sortable: true,
+      sortValue: (c) => (c.publish ? 1 : 0),
+      className: style.narrow,
+      cellClass: style.publish,
+      cell: (c) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={c.publish} disable />
+        </div>
+      ),
+    },
+    {
+      key: 'period',
+      header: '期限',
+      sortable: true,
+      sortValue: (c) => new Date(c.period).getTime(),
+      className: style.datetime,
+      cell: (c) => formatDate(c.period),
+    },
+    {
+      key: 'created',
+      header: '投稿日時',
+      sortable: true,
+      sortValue: (c) => new Date(c.created).getTime(),
+      className: style.datetime,
+      cell: (c) => formatDatetime(c.created),
+    },
+  ]
+
+  return (
+    <Main
+      title="チャット管理"
+      type="table"
+      toast={toast}
+      isFooter={false}
+      button={
+        <div className={style.header_actions}>
+          {selectedKeys.size > 0 && (
+            <>
+              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
+              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
+            </>
+          )}
+          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
+        </div>
+      }
+    >
+      <div className={style.manage}>
+        <DataTable
+          datas={pageDatas}
+          columns={columns}
+          rowKey={(c) => c.ulid}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelection={setSelectedKeys}
+          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
+        />
+      </div>
+      <DeleteModal
+        open={isDeleteModal}
+        title="チャットの削除"
+        content={`${selectedKeys.size}件のチャットを削除しますか？`}
+        loading={isLoading}
+        onClose={handleDelete}
+        onAction={handleDeleteSubmit}
+      />
+    </Main>
+  )
+}

--- a/frontend/src/pages/manage/chat/[ulid].tsx
+++ b/frontend/src/pages/manage/chat/[ulid].tsx
@@ -1,0 +1,33 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Chat } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManageChat } from 'api/internal/manage/get'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageChatEdit from 'components/templates/manage/chat/edit'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ulid = String(params?.ulid ?? '')
+  const [chatRet, channelsRet] = await Promise.all([getManageChat(ulid, req), getChannels(req)])
+  if (chatRet.isErr()) return { props: { status: chatRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const data = chatRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, data, channels } }
+}
+
+interface Props {
+  status: number
+  data: Chat
+  channels: Channel[]
+}
+
+export default function ManageChatEditPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageChatEdit {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/pages/manage/chat/index.tsx
+++ b/frontend/src/pages/manage/chat/index.tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Channel } from 'types/internal/channel'
+import { Chat } from 'types/internal/media/output'
+import { getChannels } from 'api/internal/channel'
+import { getManageChats } from 'api/internal/manage/get'
+import { searchParams } from 'utils/functions/common'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageChats from 'components/templates/manage/chat'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const params = searchParams(query)
+  const [chatsRet, channelsRet] = await Promise.all([getManageChats(params, req), getChannels(req)])
+  if (chatsRet.isErr()) return { props: { status: chatsRet.error.status } }
+  if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  const datas = chatsRet.value
+  const channels = channelsRet.value
+  return { props: { ...translations, datas, channels } }
+}
+
+interface Props {
+  status: number
+  datas: Chat[]
+  channels: Channel[]
+}
+
+export default function ManageChatsPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageChats {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -88,3 +88,10 @@ export interface BlogUpdateIn {
   publish: boolean
   image?: File
 }
+
+export interface ChatUpdateIn {
+  title: string
+  content: string
+  period: string
+  publish: boolean
+}

--- a/frontend/src/types/internal/media/output.d.ts
+++ b/frontend/src/types/internal/media/output.d.ts
@@ -76,6 +76,7 @@ export interface Chat extends Media {
   read: number
   joined: number
   thread: number
+  period: Date
 }
 
 export interface MediaHome {


### PR DESCRIPTION
## Summary
- `/manage/chat` の DataTable 形式の一覧・編集・一括削除機能を追加（6 メディア目、管理画面横展開の最後）
- `ChatUpdateIn` 型と manage API クライアントの chat 関数を追加
- FE の `Chat` 型に `period: Date` を追加（BE がすでに返しているが型定義に欠けていた）
- 対応する BE PR は別途用意

## 変更内容

### 型定義
- `frontend/src/types/internal/media/input.d.ts`
  - `ChatUpdateIn(title, content, period, publish)` を追加（期間は `yyyy-mm-dd` 文字列）
- `frontend/src/types/internal/media/output.d.ts`
  - `Chat` に `period: Date` を追加（欠落していた）

### URI・API クライアント
- `frontend/src/api/uri.ts`
  - `apiManageChats` / `apiManageChat(ulid)` を追加
- `frontend/src/api/internal/manage/get.ts`
  - `getManageChats` / `getManageChat`
- `frontend/src/api/internal/manage/update.ts`
  - `putManageChat`（chat はファイル無しのため `apiClient('json')`）
- `frontend/src/api/internal/manage/delete.ts`
  - `deleteManageChats`

### 画面テンプレート
- `frontend/src/components/templates/manage/chat/index.tsx`（新規）
  - DataTable カラム: タイトル / 内容 / スレッド / 参加 / いいね / 公開 / 期限 / 投稿日時
  - read 列は省略、chat 固有の thread/joined/period を代わりに表示
- `frontend/src/components/templates/manage/chat/edit.tsx`（新規）
  - 公開トグル + タイトル / 内容 / 期間の編集フォーム
  - 期間は `formatDate(data.period)` で `yyyy/mm/dd` 文字列に整形して初期値設定

### ページ
- `frontend/src/pages/manage/chat/index.tsx`（新規）一覧
- `frontend/src/pages/manage/chat/[ulid].tsx`（新規）編集

## 他メディアとの差異

- サムネイル・本文リッチテキスト・ダウンロードなど他メディア固有フィールドはなし
- 代わりに期限（period）が編集対象
- サムネイル無しのため `apiClient('form')` ではなく `apiClient('json')` を使用
- 一覧カラム構成が異なる（閲覧→スレッド/参加、期限追加）

## 動作確認
- `npx tsc --noEmit`: エラー 0
- `npm run lint`: エラー 0（既存 warning 9件のみ）

## 備考
対応する BE 実装（`/manage/media/chat` エンドポイント、`ChatUpdateIn`、`ChatRepository.bulk_delete` など）はローカルに別途準備済みで、別 PR で提出予定。これにより 6 メディア全ての管理画面が揃います。