### PR TITLE
【back】チャットの管理API（/manage/media/chat）を追加

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,12 +1,12 @@
 from django.http import HttpRequest
 from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
-from api.src.adapter.media import convert_blogs, convert_comics, convert_musics, convert_pictures, convert_videos
+from api.src.adapter.media import convert_blogs, convert_chats, convert_comics, convert_musics, convert_pictures, convert_videos
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media.input import BlogUpdateIn, BulkDeleteIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
-from api.src.types.schema.media.output import BlogOut, ComicOut, MusicOut, PictureOut, VideoOut
+from api.src.types.schema.media.input import BlogUpdateIn, BulkDeleteIn, ChatUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.output import BlogOut, ChatOut, ComicOut, MusicOut, PictureOut, VideoOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.manage.media import delete_manage_blog, delete_manage_comic, delete_manage_music, delete_manage_picture, delete_manage_video, get_manage_blog, get_manage_blogs, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_picture, get_manage_pictures, get_manage_video, get_manage_videos, update_manage_blog, update_manage_comic, update_manage_music, update_manage_picture, update_manage_video
+from api.src.usecase.manage.media import delete_manage_blog, delete_manage_chat, delete_manage_comic, delete_manage_music, delete_manage_picture, delete_manage_video, get_manage_blog, get_manage_blogs, get_manage_chat, get_manage_chats, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_picture, get_manage_pictures, get_manage_video, get_manage_videos, update_manage_blog, update_manage_chat, update_manage_comic, update_manage_music, update_manage_picture, update_manage_video
 
 
 class ManageVideoAPI:
@@ -309,6 +309,67 @@ class ManageBlogAPI:
             return 401, ErrorOut(message="Unauthorized")
 
         if not delete_manage_blog(user_id, input.ulids):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")
+
+
+class ManageChatAPI:
+    """ManageChatAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[ChatOut], 401: ErrorOut})
+    def list(request: HttpRequest, search: str = ""):
+        log.info("ManageChatAPI list", search=search)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs = get_manage_chats(user_id, search)
+        return 200, convert_chats(objs)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: ChatOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManageChatAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_chat(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Chat not found")
+
+        return 200, convert_chats([obj])[0]
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: ChatUpdateIn):
+        log.info("ManageChatAPI put", ulid=ulid, input=input)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_chat(user_id, ulid, input):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManageChatAPI delete", ulids=input.ulids)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_chat(user_id, input.ulids):
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")

--- a/myus/api/src/domain/entity/media/chat/repository.py
+++ b/myus/api/src/domain/entity/media/chat/repository.py
@@ -22,6 +22,8 @@ class ChatRepository(ChatInterface):
             q_list.append(Q(ulid=filter.ulid))
         if filter.publish is not None:
             q_list.append(Q(publish=filter.publish))
+        if filter.owner_id:
+            q_list.append(Q(channel__owner_id=filter.owner_id))
         if filter.channel_id:
             q_list.append(Q(channel_id=filter.channel_id))
         if filter.category_id:
@@ -64,6 +66,9 @@ class ChatRepository(ChatInterface):
         )
 
         return new_ids
+
+    def bulk_delete(self, ids: list[int]) -> None:
+        Chat.objects.filter(id__in=ids).delete()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Chat.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/interface/media/chat/interface.py
+++ b/myus/api/src/domain/interface/media/chat/interface.py
@@ -17,5 +17,9 @@ class ChatInterface(ABC):
         ...
 
     @abstractmethod
+    def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
     def is_liked(self, media_id: int, user_id: int) -> bool:
         ...

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,7 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
-from api.src.adapter.manage import ManageBlogAPI, ManageComicAPI, ManageMusicAPI, ManagePictureAPI, ManageVideoAPI
+from api.src.adapter.manage import ManageBlogAPI, ManageChatAPI, ManageComicAPI, ManageMusicAPI, ManagePictureAPI, ManageVideoAPI
 from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -23,6 +23,7 @@ api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Mus
 api.add_router("/manage/media/comic", ManageComicAPI().router, tags=["Manage Comic"])
 api.add_router("/manage/media/picture", ManagePictureAPI().router, tags=["Manage Picture"])
 api.add_router("/manage/media/blog", ManageBlogAPI().router, tags=["Manage Blog"])
+api.add_router("/manage/media/chat", ManageChatAPI().router, tags=["Manage Chat"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -80,5 +80,12 @@ class BlogUpdateIn(BaseModel):
     publish: bool
 
 
+class ChatUpdateIn(BaseModel):
+    title: str
+    content: str
+    period: str
+    publish: bool
+
+
 class BulkDeleteIn(BaseModel):
     ulids: list[str]

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from datetime import date
 from ninja import UploadedFile
 from api.modules.logger import log
 from api.src.domain.interface.media.video.data import VideoData
@@ -11,9 +12,11 @@ from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.blog.interface import BlogInterface
+from api.src.domain.interface.media.chat.data import ChatData
+from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media.input import BlogUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.input import BlogUpdateIn, ChatUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
 from api.utils.enum.index import ImageUpload
 from api.utils.functions.index import create_url
 from api.utils.functions.media import save_upload
@@ -348,4 +351,61 @@ def delete_manage_blog(user_id: int, ulids: list[str]) -> bool:
         return True
     except Exception as e:
         log.error("delete_manage_blog error", exc=e)
+        return False
+
+
+def get_manage_chats(user_id: int, search: str) -> list[ChatData]:
+    repository = injector.get(ChatInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    return repository.bulk_get(ids=ids)
+
+
+def get_manage_chat(user_id: int, ulid: str) -> ChatData | None:
+    repository = injector.get(ChatInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.info("Chat not found", ulid=ulid, user_id=user_id)
+        return None
+
+    return repository.bulk_get(ids)[0]
+
+
+def update_manage_chat(user_id: int, ulid: str, input: ChatUpdateIn) -> bool:
+    repository = injector.get(ChatInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    if len(ids) == 0:
+        log.error("Chat not found", ulid=ulid)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+    if obj.channel.owner_id != user_id:
+        log.error("Chat owner mismatch", ulid=ulid, user_id=user_id, owner_id=obj.channel.owner_id)
+        return False
+
+    update_data = replace(obj, title=input.title, content=input.content, period=date.fromisoformat(input.period), publish=input.publish)
+    try:
+        repository.bulk_save([update_data])
+        return True
+    except Exception as e:
+        log.error("update_manage_chat error", exc=e)
+        return False
+
+
+def delete_manage_chat(user_id: int, ulids: list[str]) -> bool:
+    repository = injector.get(ChatInterface)
+    delete_ids: list[int] = []
+
+    for ulid in ulids:
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        if len(ids) == 0:
+            log.error("Chat not found or owner mismatch", ulid=ulid, user_id=user_id)
+            return False
+        delete_ids.append(ids[0])
+
+    try:
+        repository.bulk_delete(delete_ids)
+        return True
+    except Exception as e:
+        log.error("delete_manage_chat error", exc=e)
         return False


### PR DESCRIPTION
## Summary
- `/manage/media/chat` エンドポイント（list/get/put/delete）を新設し、FE の管理画面（PR #722）に対応
- `ChatRepository` に `bulk_delete` と `owner_id` フィルタを追加
- `ChatUpdateIn` で title / content / period（ISO 日付文字列）/ publish を受け付け
- これで 6 メディア全て（video / music / comic / picture / blog / chat）の管理 API が揃う

## 変更内容

### ドメイン層
- `myus/api/src/domain/interface/media/chat/interface.py`
  - `bulk_delete(ids)` 抽象メソッドを `bulk_save` 直下に追加
- `myus/api/src/domain/entity/media/chat/repository.py`
  - `bulk_delete` 実装を追加
  - `get_ids` に `owner_id` フィルタ追加（管理画面でユーザ自身のチャットのみ取得）

### スキーマ
- `myus/api/src/types/schema/media/input.py`
  - `ChatUpdateIn(title, content, period, publish)` を追加
  - `period` は `str`（FE から `yyyy-mm-dd` 形式で受信）

### ユースケース
- `myus/api/src/usecase/manage/media.py`
  - `get_manage_chats` / `get_manage_chat` / `update_manage_chat` / `delete_manage_chat` を追加
  - `update_manage_chat` で `date.fromisoformat(input.period)` により文字列→ `date` 変換
  - `from datetime import date` を import 追加
  - chat は URL 変換（`create_url`）の対象フィールドを持たないので、`get_manage_*` は `bulk_get` の結果をそのまま返す

### アダプタ・ルーター
- `myus/api/src/adapter/manage.py`
  - `ManageChatAPI` クラス追加（list / get / put / delete）
  - `put` は JSON 受信（chat はファイル無しのため `Form + File` ではない）
- `myus/api/src/routers.py`
  - `/manage/media/chat` を `ManageChatAPI` にマウント

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件のみ）

## 備考
- FE PR #722 と同時マージすることで chat 管理画面が完結し、6 メディア全ての管理画面が揃う
- FE 側で `formatDate(data.period)` が `yyyy/mm/dd` 形式（スラッシュ区切り）を返す場合、BE の `date.fromisoformat()` は ValueError になる。実動作確認で問題が出た場合は FE の整形処理を ISO 形式（ハイフン区切り）に合わせる必要あり