### PR TITLE
【back】メディアの定義・列挙順をvideo/music/blog/comic/picture/chatに統一

### DIFF
--- a/myus/api/admin.py
+++ b/myus/api/admin.py
@@ -8,7 +8,7 @@ from django.db.models import Count
 from import_export.admin import ImportExportModelAdmin
 from api.db.models import Notification, AccessLog, Comment, Message, Follow, Advertise, ComicPage
 from api.db.models import User, Profile, MyPage, SearchTag, HashTag, UserNotification
-from api.db.models import Video, Music, Comic, Picture, Blog, Chat
+from api.db.models import Video, Music, Blog, Comic, Picture, Chat
 from api.db.models.channel import Channel
 from api.utils.constant import model_media_comment_dict
 

--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,12 +1,19 @@
 from django.http import HttpRequest
 from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
-from api.src.adapter.media import convert_blogs, convert_chats, convert_comics, convert_musics, convert_pictures, convert_videos
+from api.src.adapter.media import convert_videos, convert_musics, convert_blogs, convert_comics, convert_pictures, convert_chats
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.media.input import BlogUpdateIn, BulkDeleteIn, ChatUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
-from api.src.types.schema.media.output import BlogOut, ChatOut, ComicOut, MusicOut, PictureOut, VideoOut
+from api.src.types.schema.media.input import BulkDeleteIn, VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
+from api.src.types.schema.media.output import VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.manage.media import delete_manage_blog, delete_manage_chat, delete_manage_comic, delete_manage_music, delete_manage_picture, delete_manage_video, get_manage_blog, get_manage_blogs, get_manage_chat, get_manage_chats, get_manage_comic, get_manage_comics, get_manage_music, get_manage_musics, get_manage_picture, get_manage_pictures, get_manage_video, get_manage_videos, update_manage_blog, update_manage_chat, update_manage_comic, update_manage_music, update_manage_picture, update_manage_video
+from api.src.usecase.manage.media import (
+    get_manage_videos, get_manage_video, update_manage_video, delete_manage_video,
+    get_manage_musics, get_manage_music, update_manage_music, delete_manage_music,
+    get_manage_blogs, get_manage_blog, update_manage_blog, delete_manage_blog,
+    get_manage_comics, get_manage_comic, update_manage_comic, delete_manage_comic,
+    get_manage_pictures, get_manage_picture, update_manage_picture, delete_manage_picture,
+    get_manage_chats, get_manage_chat, update_manage_chat, delete_manage_chat,
+)
 
 
 class ManageVideoAPI:

--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -4,9 +4,9 @@ from api.modules.logger import log
 from api.src.types.dto.comment import CommentDTO, ReplyDTO
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.music.data import MusicData
+from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.picture.data import PictureData
-from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.domain.interface.media.data import HashtagData
 from api.src.domain.interface.channel.data import ChannelData
@@ -15,17 +15,17 @@ from api.src.types.dto.message import MessageDTO
 from api.src.types.dto.user import AuthorDTO, MediaUserDTO
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.comment import CommentOut, ReplyOut
-from api.src.types.schema.media.input import VideoIn, MusicIn, ComicIn, PictureIn, BlogIn, ChatIn
-from api.src.types.schema.media.output import HomeOut, VideoOut, MusicOut, ComicOut, PictureOut, BlogOut, ChatOut, MediaCreateOut, HashtagOut
-from api.src.types.schema.media.output import VideoDetailOut, MusicDetailOut, ComicDetailOut, PictureDetailOut, BlogDetailOut, ChatDetailOut
-from api.src.types.schema.media.output import VideoDetailsOut, MusicDetailsOut, ComicDetailsOut, PictureDetailsOut, BlogDetailsOut, ChatDetailsOut
+from api.src.types.schema.media.input import VideoIn, MusicIn, BlogIn, ComicIn, PictureIn, ChatIn
+from api.src.types.schema.media.output import HomeOut, VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut, MediaCreateOut, HashtagOut
+from api.src.types.schema.media.output import VideoDetailOut, MusicDetailOut, BlogDetailOut, ComicDetailOut, PictureDetailOut, ChatDetailOut
+from api.src.types.schema.media.output import VideoDetailsOut, MusicDetailsOut, BlogDetailsOut, ComicDetailsOut, PictureDetailsOut, ChatDetailsOut
 from api.src.types.schema.message import MessageOut
 from api.src.types.schema.channel import ChannelOut
 from api.src.types.schema.user import AuthorOut, MediaUserOut
 from api.src.usecase.auth import auth_check
-from api.src.usecase.media import create_video, create_music, create_comic, create_blog, create_picture, create_chat
-from api.src.usecase.media import get_home, get_recommend, get_videos, get_musics, get_comics, get_blogs, get_pictures, get_chats
-from api.src.usecase.media import get_video_detail, get_music_detail, get_comic_detail, get_blog_detail, get_picture_detail, get_chat_detail
+from api.src.usecase.media import create_video, create_music, create_blog, create_comic, create_picture, create_chat
+from api.src.usecase.media import get_home, get_recommend, get_videos, get_musics, get_blogs, get_comics, get_pictures, get_chats
+from api.src.usecase.media import get_video_detail, get_music_detail, get_blog_detail, get_comic_detail, get_picture_detail, get_chat_detail
 
 
 class HomeAPI:
@@ -42,9 +42,9 @@ class HomeAPI:
         data = HomeOut(
             videos=convert_videos(home.videos),
             musics=convert_musics(home.musics),
+            blogs=convert_blogs(home.blogs),
             comics=convert_comics(home.comics),
             pictures=convert_pictures(home.pictures),
-            blogs=convert_blogs(home.blogs),
             chats=convert_chats(home.chats),
         )
 
@@ -65,9 +65,9 @@ class RecommendAPI:
         data = HomeOut(
             videos=convert_videos(recommend.videos),
             musics=convert_musics(recommend.musics),
+            blogs=convert_blogs(recommend.blogs),
             comics=convert_comics(recommend.comics),
             pictures=convert_pictures(recommend.pictures),
-            blogs=convert_blogs(recommend.blogs),
             chats=convert_chats(recommend.chats),
         )
 

--- a/myus/api/src/adapter/user.py
+++ b/myus/api/src/adapter/user.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
-from api.src.adapter.media import convert_videos, convert_musics, convert_comics, convert_pictures, convert_blogs, convert_chats
+from api.src.adapter.media import convert_videos, convert_musics, convert_blogs, convert_comics, convert_pictures, convert_chats
 from api.src.types.schema.channel import ChannelOut
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.follow import FollowIn, FollowOut, FollowUserOut
@@ -302,9 +302,9 @@ class UserAPI:
         data = UserPageMediaOut(
             videos=convert_videos(media.videos),
             musics=convert_musics(media.musics),
+            blogs=convert_blogs(media.blogs),
             comics=convert_comics(media.comics),
             pictures=convert_pictures(media.pictures),
-            blogs=convert_blogs(media.blogs),
             chats=convert_chats(media.chats),
         )
 

--- a/myus/api/src/domain/entity/notification/repository.py
+++ b/myus/api/src/domain/entity/notification/repository.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.comment import Comment
-from api.db.models.media import Video, Music, Comic, Picture, Blog, Chat
+from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat
 from api.db.models.message import Message
 from api.db.models.notification import Notification
 from api.db.models.users import Follow

--- a/myus/api/src/domain/entity/user/_convert.py
+++ b/myus/api/src/domain/entity/user/_convert.py
@@ -104,18 +104,18 @@ def user_plan_data(user_plan: UserPlan) -> UserPlanData:
     )
 
 
-def get_media_model(media_type: MediaType) -> type[Video] | type[Music] | type[Comic] | type[Picture] | type[Blog] | type[Chat]:
+def get_media_model(media_type: MediaType) -> type[Video] | type[Music] | type[Blog] | type[Comic] | type[Picture] | type[Chat]:
     match media_type:
         case MediaType.VIDEO:
             return Video
         case MediaType.MUSIC:
             return Music
+        case MediaType.BLOG:
+            return Blog
         case MediaType.COMIC:
             return Comic
         case MediaType.PICTURE:
             return Picture
-        case MediaType.BLOG:
-            return Blog
         case MediaType.CHAT:
             return Chat
         case _:

--- a/myus/api/src/domain/entity/user/repository.py
+++ b/myus/api/src/domain/entity/user/repository.py
@@ -17,7 +17,7 @@ PROFILE_FIELDS = [
 ]
 MYPAGE_FIELDS = ["banner", "email", "content", "follower_count", "following_count", "tag_manager_id", "is_advertise"]
 NOTIFICATION_FIELDS = [
-    "is_video", "is_music", "is_comic", "is_picture", "is_blog",
+    "is_video", "is_music", "is_blog", "is_comic", "is_picture",
     "is_chat", "is_follow", "is_reply", "is_like", "is_views",
 ]
 USER_PLAN_FIELDS = ["customer_id", "subscription", "is_paid", "start_date", "end_date"]

--- a/myus/api/src/injectors/index.py
+++ b/myus/api/src/injectors/index.py
@@ -3,9 +3,9 @@ from api.src.domain.entity.user.repository import UserRepository
 from api.src.domain.entity.channel.repository import ChannelRepository
 from api.src.domain.entity.media.video.repository import VideoRepository
 from api.src.domain.entity.media.music.repository import MusicRepository
-from api.src.domain.entity.media.picture.repository import PictureRepository
 from api.src.domain.entity.media.blog.repository import BlogRepository
 from api.src.domain.entity.media.comic.repository import ComicRepository
+from api.src.domain.entity.media.picture.repository import PictureRepository
 from api.src.domain.entity.media.chat.repository import ChatRepository
 from api.src.domain.entity.comment.repository import CommentRepository
 from api.src.domain.entity.message.repository import MessageRepository
@@ -17,9 +17,9 @@ from api.src.domain.interface.user.interface import UserInterface
 from api.src.domain.interface.channel.interface import ChannelInterface
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.music.interface import MusicInterface
-from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.comic.interface import ComicInterface
+from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.comment.interface import CommentInterface
 from api.src.domain.interface.message.interface import MessageInterface
@@ -51,16 +51,16 @@ class MediaModule(Module):
         return MusicRepository()
 
     @provider
+    def provide_blog_repository(self) -> BlogInterface:
+        return BlogRepository()
+
+    @provider
     def provide_comic_repository(self) -> ComicInterface:
         return ComicRepository()
 
     @provider
     def provide_picture_repository(self) -> PictureInterface:
         return PictureRepository()
-
-    @provider
-    def provide_blog_repository(self) -> BlogInterface:
-        return BlogRepository()
 
     @provider
     def provide_chat_repository(self) -> ChatInterface:

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,8 +1,8 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
-from api.src.adapter.manage import ManageBlogAPI, ManageChatAPI, ManageComicAPI, ManageMusicAPI, ManagePictureAPI, ManageVideoAPI
-from api.src.adapter.media import BlogAPI, ChatAPI, ComicAPI, HomeAPI, MusicAPI, PictureAPI, RecommendAPI, VideoAPI
+from api.src.adapter.manage import ManageVideoAPI, ManageMusicAPI, ManageBlogAPI, ManageComicAPI, ManagePictureAPI, ManageChatAPI
+from api.src.adapter.media import HomeAPI, RecommendAPI, VideoAPI, MusicAPI, BlogAPI, ComicAPI, PictureAPI, ChatAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
 from api.src.adapter.setting import SettingMyPageAPI, SettingNotificationAPI, SettingProfileAPI
@@ -20,9 +20,9 @@ api.add_router("/setting/notification", SettingNotificationAPI().router, tags=["
 
 api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Video"])
 api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Music"])
+api.add_router("/manage/media/blog", ManageBlogAPI().router, tags=["Manage Blog"])
 api.add_router("/manage/media/comic", ManageComicAPI().router, tags=["Manage Comic"])
 api.add_router("/manage/media/picture", ManagePictureAPI().router, tags=["Manage Picture"])
-api.add_router("/manage/media/blog", ManageBlogAPI().router, tags=["Manage Blog"])
 api.add_router("/manage/media/chat", ManageChatAPI().router, tags=["Manage Chat"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
@@ -30,9 +30,9 @@ api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])
 api.add_router("/media/recommend", RecommendAPI().router, tags=["Media Recommend"])
 api.add_router("/media/video", VideoAPI().router, tags=["Media Video"])
 api.add_router("/media/music", MusicAPI().router, tags=["Media Music"])
+api.add_router("/media/blog", BlogAPI().router, tags=["Media Blog"])
 api.add_router("/media/comic", ComicAPI().router, tags=["Media Comic"])
 api.add_router("/media/picture", PictureAPI().router, tags=["Media Picture"])
-api.add_router("/media/blog", BlogAPI().router, tags=["Media Blog"])
 api.add_router("/media/chat", ChatAPI().router, tags=["Media Chat"])
 api.add_router("/media/comment", CommentAPI().router, tags=["Media Comment"])
 api.add_router("/media/message", MessageAPI().router, tags=["Media Message"])

--- a/myus/api/src/types/dto/media.py
+++ b/myus/api/src/types/dto/media.py
@@ -3,9 +3,9 @@ from datetime import date, datetime
 from api.src.domain.interface.media.data import HashtagData
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.music.data import MusicData
+from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.picture.data import PictureData
-from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.types.dto.comment import CommentDTO
 from api.src.types.dto.message import MessageDTO
@@ -17,9 +17,9 @@ from api.src.types.dto.user import MediaUserDTO
 class HomeDTO:
     videos: list[VideoData]
     musics: list[MusicData]
+    blogs: list[BlogData]
     comics: list[ComicData]
     pictures: list[PictureData]
-    blogs: list[BlogData]
     chats: list[ChatData]
 
 
@@ -61,6 +61,13 @@ class MusicDetailDTO(MediaDetailDTO):
 
 
 @dataclass(frozen=True, slots=True)
+class BlogDetailDTO(MediaDetailDTO):
+    richtext: str
+    image: str
+    comments: list[CommentDTO]
+
+
+@dataclass(frozen=True, slots=True)
 class ComicDetailDTO(MediaDetailDTO):
     image: str
     pages: list[str]
@@ -69,13 +76,6 @@ class ComicDetailDTO(MediaDetailDTO):
 
 @dataclass(frozen=True, slots=True)
 class PictureDetailDTO(MediaDetailDTO):
-    image: str
-    comments: list[CommentDTO]
-
-
-@dataclass(frozen=True, slots=True)
-class BlogDetailDTO(MediaDetailDTO):
-    richtext: str
     image: str
     comments: list[CommentDTO]
 

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -17,6 +17,14 @@ class MusicIn(BaseModel):
     download: bool
 
 
+class BlogIn(BaseModel):
+    channel_ulid: str
+    publish: bool
+    title: str
+    content: str
+    richtext: str
+
+
 class ComicIn(BaseModel):
     channel_ulid: str
     publish: bool
@@ -29,14 +37,6 @@ class PictureIn(BaseModel):
     publish: bool
     title: str
     content: str
-
-
-class BlogIn(BaseModel):
-    channel_ulid: str
-    publish: bool
-    title: str
-    content: str
-    richtext: str
 
 
 class ChatIn(BaseModel):
@@ -61,6 +61,13 @@ class MusicUpdateIn(BaseModel):
     publish: bool
 
 
+class BlogUpdateIn(BaseModel):
+    title: str
+    content: str
+    richtext: str
+    publish: bool
+
+
 class ComicUpdateIn(BaseModel):
     title: str
     content: str
@@ -70,13 +77,6 @@ class ComicUpdateIn(BaseModel):
 class PictureUpdateIn(BaseModel):
     title: str
     content: str
-    publish: bool
-
-
-class BlogUpdateIn(BaseModel):
-    title: str
-    content: str
-    richtext: str
     publish: bool
 
 

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -52,17 +52,17 @@ class MusicOut(MediaOut):
     download: bool
 
 
+class BlogOut(MediaOut):
+    image: str
+    richtext: str
+
+
 class ComicOut(MediaOut):
     image: str
 
 
 class PictureOut(MediaOut):
     image: str
-
-
-class BlogOut(MediaOut):
-    image: str
-    richtext: str
 
 
 class ChatOut(MediaOut):
@@ -74,9 +74,9 @@ class ChatOut(MediaOut):
 class HomeOut(BaseModel):
     videos: list[VideoOut]
     musics: list[MusicOut]
+    blogs: list[BlogOut]
     comics: list[ComicOut]
     pictures: list[PictureOut]
-    blogs: list[BlogOut]
     chats: list[ChatOut]
 
 
@@ -94,6 +94,12 @@ class MusicDetailOut(MediaDetailOut):
     comments: list[CommentOut]
 
 
+class BlogDetailOut(MediaDetailOut):
+    richtext: str
+    image: str
+    comments: list[CommentOut]
+
+
 class ComicDetailOut(MediaDetailOut):
     image: str
     pages: list[str]
@@ -101,12 +107,6 @@ class ComicDetailOut(MediaDetailOut):
 
 
 class PictureDetailOut(MediaDetailOut):
-    image: str
-    comments: list[CommentOut]
-
-
-class BlogDetailOut(MediaDetailOut):
-    richtext: str
     image: str
     comments: list[CommentOut]
 
@@ -128,6 +128,11 @@ class MusicDetailsOut(BaseModel):
     list: list[MusicOut]
 
 
+class BlogDetailsOut(BaseModel):
+    detail: BlogDetailOut
+    list: list[BlogOut]
+
+
 class ComicDetailsOut(BaseModel):
     detail: ComicDetailOut
     list: list[ComicOut]
@@ -136,11 +141,6 @@ class ComicDetailsOut(BaseModel):
 class PictureDetailsOut(BaseModel):
     detail: PictureDetailOut
     list: list[PictureOut]
-
-
-class BlogDetailsOut(BaseModel):
-    detail: BlogDetailOut
-    list: list[BlogOut]
 
 
 class ChatDetailsOut(BaseModel):

--- a/myus/api/src/types/schema/userpage.py
+++ b/myus/api/src/types/schema/userpage.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pydantic import BaseModel
 from api.src.types.schema.channel import ChannelOut
-from api.src.types.schema.media.output import VideoOut, MusicOut, ComicOut, PictureOut, BlogOut, ChatOut
+from api.src.types.schema.media.output import VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut
 
 
 class UserPageOut(BaseModel):
@@ -20,7 +20,7 @@ class UserPageOut(BaseModel):
 class UserPageMediaOut(BaseModel):
     videos: list[VideoOut]
     musics: list[MusicOut]
+    blogs: list[BlogOut]
     comics: list[ComicOut]
     pictures: list[PictureOut]
-    blogs: list[BlogOut]
     chats: list[ChatOut]

--- a/myus/api/src/types/union/media.py
+++ b/myus/api/src/types/union/media.py
@@ -1,4 +1,4 @@
-from api.db.models import Video, Music, Comic, Picture, Blog, Chat
+from api.db.models import Video, Music, Blog, Comic, Picture, Chat
 
 
-type MediaModelType = Video | Music | Comic | Picture | Blog | Chat
+type MediaModelType = Video | Music | Blog | Comic | Picture | Chat

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -6,17 +6,17 @@ from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.music.data import MusicData
 from api.src.domain.interface.media.music.interface import MusicInterface
+from api.src.domain.interface.media.blog.data import BlogData
+from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.picture.interface import PictureInterface
-from api.src.domain.interface.media.blog.data import BlogData
-from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.schema.media.input import BlogUpdateIn, ChatUpdateIn, ComicUpdateIn, MusicUpdateIn, PictureUpdateIn, VideoUpdateIn
+from api.src.types.schema.media.input import VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
 from api.utils.enum.index import ImageUpload
 from api.utils.functions.index import create_url
 from api.utils.functions.media import save_upload

--- a/myus/api/src/usecase/media.py
+++ b/myus/api/src/usecase/media.py
@@ -4,20 +4,20 @@ from ninja import UploadedFile
 from api.modules.logger import log
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.music.data import MusicData
+from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.picture.data import PictureData
-from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.music.interface import MusicInterface
+from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.picture.interface import PictureInterface
-from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.media.index import FilterOption, SortOption, SortType, ExcludeOption
 from api.src.injectors.container import injector
-from api.src.types.dto.media import MediaCreateDTO, HomeDTO, VideoDetailDTO, MusicDetailDTO, ComicDetailDTO, PictureDetailDTO, BlogDetailDTO, ChatDetailDTO
-from api.src.types.schema.media.input import VideoIn, MusicIn, ComicIn, PictureIn, BlogIn, ChatIn
+from api.src.types.dto.media import MediaCreateDTO, HomeDTO, VideoDetailDTO, MusicDetailDTO, BlogDetailDTO, ComicDetailDTO, PictureDetailDTO, ChatDetailDTO
+from api.src.types.schema.media.input import VideoIn, MusicIn, BlogIn, ComicIn, PictureIn, ChatIn
 from api.src.usecase.channel import get_channel_data
 from api.src.usecase.comment import get_comments
 from api.src.usecase.message import get_messages
@@ -229,9 +229,9 @@ def get_home(limit: int, search: str) -> HomeDTO:
     data = HomeDTO(
         videos=get_videos(limit, search),
         musics=get_musics(limit, search),
+        blogs=get_blogs(limit, search),
         comics=get_comics(limit, search),
         pictures=get_pictures(limit, search),
-        blogs=get_blogs(limit, search),
         chats=get_chats(limit, search),
     )
     return data
@@ -241,9 +241,9 @@ def get_recommend(limit: int, search: str) -> HomeDTO:
     data = HomeDTO(
         videos=get_videos(limit, search, is_recommend=True),
         musics=get_musics(limit, search, is_recommend=True),
+        blogs=get_blogs(limit, search, is_recommend=True),
         comics=get_comics(limit, search, is_recommend=True),
         pictures=get_pictures(limit, search, is_recommend=True),
-        blogs=get_blogs(limit, search, is_recommend=True),
         chats=get_chats(limit, search, is_recommend=True),
     )
     return data

--- a/myus/api/src/usecase/userpage.py
+++ b/myus/api/src/usecase/userpage.py
@@ -1,16 +1,16 @@
 from api.src.domain.interface.follow.interface import FilterOption as FollowFilterOption, FollowInterface, SortOption as FollowSortOption
 from api.src.injectors.container import injector
 from api.src.types.dto.media import HomeDTO
-from api.src.usecase.media import get_videos, get_musics, get_comics, get_pictures, get_blogs, get_chats
+from api.src.usecase.media import get_videos, get_musics, get_blogs, get_comics, get_pictures, get_chats
 
 
 def get_userpage_media(limit: int, search: str, channel_id: int = 0) -> HomeDTO:
     data = HomeDTO(
         videos=get_videos(limit, search, channel_id=channel_id),
         musics=get_musics(limit, search, channel_id=channel_id),
+        blogs=get_blogs(limit, search, channel_id=channel_id),
         comics=get_comics(limit, search, channel_id=channel_id),
         pictures=get_pictures(limit, search, channel_id=channel_id),
-        blogs=get_blogs(limit, search, channel_id=channel_id),
         chats=get_chats(limit, search, channel_id=channel_id),
     )
     return data

--- a/myus/api/utils/constant.py
+++ b/myus/api/utils/constant.py
@@ -1,89 +1,89 @@
 from api.db.models.comment import Comment
-from api.db.models.media import Video, Music, Comic, Picture, Blog, Chat
+from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat
 from api.db.models.message import Message
 from api.db.models.users import Follow
 
 
-type MediaModel = Video | Music | Comic | Picture | Blog | Chat
+type MediaModel = Video | Music | Blog | Comic | Picture | Chat
 
 
 media_models: dict[str, type[MediaModel]] = {
     'Video': Video,
     'Music': Music,
+    'Blog': Blog,
     'Comic': Comic,
     'Picture': Picture,
-    'Blog': Blog,
     'Chat': Chat,
 }
 
-model_list = [Video, Music, Comic, Picture, Blog, Chat]
+model_list = [Video, Music, Blog, Comic, Picture, Chat]
 
 model_dict = {
     Video  : "video",
     Music  : "music",
+    Blog   : "blog",
     Comic  : "comic",
     Picture: "picture",
-    Blog   : "blog",
     Chat   : "chat",
 }
 
 model_pjax = {
     "media/video"  : Video,
     "media/music"  : Music,
+    "media/blog"   : Blog,
     "media/comic"  : Comic,
     "media/picture": Picture,
-    "media/blog"   : Blog,
     "media/chat"   : Chat,
 }
 
 model_create_pjax = (
     "media/video/create",
     "media/music/create",
+    "media/blog/create",
     "media/comic/create",
     "media/picture/create",
-    "media/blog/create",
     "media/chat/create",
 )
 
 model_like_dict = {
     "video/detail"  : Video,
     "music/detail"  : Music,
+    "blog/detail"   : Blog,
     "comic/detail"  : Comic,
     "picture/detail": Picture,
-    "blog/detail"   : Blog,
     "chat/detail"   : Chat,
 }
 
 model_media_comment_dict = {
     "video"  : Video,
     "music"  : Music,
+    "blog"   : Blog,
     "comic"  : Comic,
     "picture": Picture,
-    "blog"   : Blog,
 }
 
 model_media_comment_no_dict = {
     "video"  : 1,
     "music"  : 2,
+    "blog"   : 5,
     "comic"  : 3,
     "picture": 4,
-    "blog"   : 5,
 }
 
 model_comment_dict = {
     "video/detail"  : Video,
     "music/detail"  : Music,
+    "blog/detail"   : Blog,
     "comic/detail"  : Comic,
     "picture/detail": Picture,
-    "blog/detail"   : Blog,
 }
 
 notification_type_no = {
     "is_video"  : 1,
     "is_music"  : 2,
+    "is_blog"   : 5,
     "is_comic"  : 3,
     "is_picture": 4,
-    "is_blog"   : 5,
     "is_chat"   : 6,
     "is_follow" : 7,
     "is_like"   : 8,
@@ -94,9 +94,9 @@ notification_type_no = {
 notification_type_model = {
     "video"  : Video,
     "music"  : Music,
+    "blog"   : Blog,
     "comic"  : Comic,
     "picture": Picture,
-    "blog"   : Blog,
     "chat"   : Chat,
     "follow" : Follow,
     "comment": Comment,

--- a/myus/api/utils/constant.py
+++ b/myus/api/utils/constant.py
@@ -65,9 +65,9 @@ model_media_comment_dict = {
 model_media_comment_no_dict = {
     "video"  : 1,
     "music"  : 2,
-    "blog"   : 5,
-    "comic"  : 3,
-    "picture": 4,
+    "blog"   : 3,
+    "comic"  : 4,
+    "picture": 5,
 }
 
 model_comment_dict = {
@@ -81,9 +81,9 @@ model_comment_dict = {
 notification_type_no = {
     "is_video"  : 1,
     "is_music"  : 2,
-    "is_blog"   : 5,
-    "is_comic"  : 3,
-    "is_picture": 4,
+    "is_blog"   : 3,
+    "is_comic"  : 4,
+    "is_picture": 5,
     "is_chat"   : 6,
     "is_follow" : 7,
     "is_like"   : 8,

--- a/myus/api/utils/enum/index.py
+++ b/myus/api/utils/enum/index.py
@@ -10,18 +10,18 @@ class GenderType(str, Enum):
 class MediaType(str, Enum):
     VIDEO = "Video"
     MUSIC = "Music"
+    BLOG = "Blog"
     COMIC = "Comic"
     PICTURE = "Picture"
-    BLOG = "Blog"
     CHAT = "Chat"
 
 
 class NotificationType(str, Enum):
     VIDEO = "Video"
     MUSIC = "Music"
+    BLOG = "Blog"
     COMIC = "Comic"
     PICTURE = "Picture"
-    BLOG = "Blog"
     CHAT = "Chat"
     FOLLOW = "Follow"
     LIKE = "Like"
@@ -32,9 +32,9 @@ class NotificationType(str, Enum):
 class NotificationTypeNo(int, Enum):
     VIDEO = 1
     MUSIC = 2
-    COMIC = 3
-    PICTURE = 4
-    BLOG = 5
+    BLOG = 3
+    COMIC = 4
+    PICTURE = 5
     CHAT = 6
     FOLLOW = 7
     LIKE = 8
@@ -45,9 +45,9 @@ class NotificationTypeNo(int, Enum):
 class NotificationObjectType(str, Enum):
     VIDEO = "Video"
     MUSIC = "Music"
+    BLOG = "Blog"
     COMIC = "Comic"
     PICTURE = "Picture"
-    BLOG = "Blog"
     CHAT = "Chat"
     FOLLOW = "Follow"
     COMMENT = "Comment"
@@ -57,17 +57,17 @@ class NotificationObjectType(str, Enum):
 class CommentTypeNo(int, Enum):
     VIDEO = 1
     MUSIC = 2
-    COMIC = 3
-    PICTURE = 4
-    BLOG = 5
+    BLOG = 3
+    COMIC = 4
+    PICTURE = 5
 
 
 class CommentType(str, Enum):
     VIDEO = "Video"
     MUSIC = "Music"
+    BLOG = "Blog"
     COMIC = "Comic"
     PICTURE = "Picture"
-    BLOG = "Blog"
 
 
 class ImageUpload(str, Enum):
@@ -75,10 +75,10 @@ class ImageUpload(str, Enum):
     MYPAGE = "mypage"
     CHANNEL = "channel"
     VIDEO = "video"
+    BLOG = "blog"
     COMIC = "comic"
     COMIC_PAGE = "comic_page"
     PICTURE = "picture"
-    BLOG = "blog"
 
 
 class MediaUpload(str, Enum):

--- a/myus/api/utils/functions/media.py
+++ b/myus/api/utils/functions/media.py
@@ -1,19 +1,19 @@
 from typing import assert_never
 from django.core.files.storage import default_storage
 from ninja import UploadedFile
-from api.src.domain.interface.media.blog.interface import BlogInterface
-from api.src.domain.interface.media.chat.interface import ChatInterface
-from api.src.domain.interface.media.comic.interface import ComicInterface
-from api.src.domain.interface.media.music.interface import MusicInterface
-from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.video.interface import VideoInterface
+from api.src.domain.interface.media.music.interface import MusicInterface
+from api.src.domain.interface.media.blog.interface import BlogInterface
+from api.src.domain.interface.media.comic.interface import ComicInterface
+from api.src.domain.interface.media.picture.interface import PictureInterface
+from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.injectors.container import injector
 from api.utils.enum.index import MediaType, ImageUpload, MediaUpload
 from api.utils.functions.convert.audio_converter import is_conversion, save_converted_mp3
 from api.utils.functions.file import avatar_path, comic_path, image_path, musics_path, video_path
 
 
-type MediaInterfaceType = VideoInterface | MusicInterface | ComicInterface | PictureInterface | BlogInterface | ChatInterface
+type MediaInterfaceType = VideoInterface | MusicInterface | BlogInterface | ComicInterface | PictureInterface | ChatInterface
 type UploadType = ImageUpload | MediaUpload
 
 
@@ -23,12 +23,12 @@ def get_media_repository(media_type: MediaType) -> MediaInterfaceType:
             return injector.get(VideoInterface)
         case MediaType.MUSIC:
             return injector.get(MusicInterface)
+        case MediaType.BLOG:
+            return injector.get(BlogInterface)
         case MediaType.COMIC:
             return injector.get(ComicInterface)
         case MediaType.PICTURE:
             return injector.get(PictureInterface)
-        case MediaType.BLOG:
-            return injector.get(BlogInterface)
         case MediaType.CHAT:
             return injector.get(ChatInterface)
         case _:


### PR DESCRIPTION
## Summary
- BE 全体のメディア定義・列挙順を旧 `video / music / comic / picture / blog / chat` から新 `video / music / blog / comic / picture / chat` に統一
- FE 側の PR #724 / #726 と対になる BE 側のリオーダー
- schema / dto / ルーター / DI / 共通定数 / 変換関数 / usecase / adapter のすべてで同順に揃える
- `CommentTypeNo` や `notification_type_no` の既存数値（BE/FE 契約）は変えずに宣言順だけ並び替え

## 変更内容

### スキーマ・DTO
- `myus/api/src/types/schema/media/input.py`
  - `*In` / `*UpdateIn` 宣言順を新順序に
- `myus/api/src/types/schema/media/output.py`
  - `*Out` / `HomeOut` / `*DetailOut` / `*DetailsOut` 宣言順を新順序に
- `myus/api/src/types/dto/media.py`
  - `HomeDTO` のフィールド順と `*DetailDTO` 定義順を新順序に
- `myus/api/src/types/schema/userpage.py`
  - `UserPageMediaOut` のフィールド順と import 順を新順序に
- `myus/api/src/types/union/media.py`
  - `MediaModelType` union 順を新順序に

### ルーター・DI
- `myus/api/src/routers.py`
  - `ManageXxxAPI` / `XxxAPI` の import と `/manage/media/*` / `/media/*` 登録順を新順序に
- `myus/api/src/injectors/index.py`
  - `MediaModule` の `provide_*_repository` 定義順を新順序に、import 順も追随

### 変換・ルート adapter
- `myus/api/src/adapter/media.py`
  - import の interface/data/schema/usecase 順を新順序に
  - `HomeAPI.get` / `RecommendAPI.get` の `HomeOut` 構築順を新順序に
- `myus/api/src/adapter/user.py`
  - `convert_*` import を新順序に、`UserPageMediaOut` 構築順も新順序に
- `myus/api/src/adapter/manage.py`
  - import 順を新順序に（grouped import にして可読性向上）

### ユースケース
- `myus/api/src/usecase/media.py`
  - import 順、`get_home` / `get_recommend` の `HomeDTO` 構築順を新順序に
- `myus/api/src/usecase/manage/media.py`
  - import 順を新順序に
- `myus/api/src/usecase/userpage.py`
  - `get_userpage_media` の `HomeDTO` 構築順を新順序に

### ドメイン・定数
- `myus/api/src/domain/entity/notification/repository.py`
  - `from api.db.models.media import` の順
- `myus/api/src/domain/entity/user/_convert.py`
  - `get_media_model` の match 分岐と return 型 union の順
- `myus/api/src/domain/entity/user/repository.py`
  - `NOTIFICATION_FIELDS` 配列順
- `myus/api/utils/constant.py`
  - `model_list` / `media_models` / `model_dict` / `model_pjax` / `model_create_pjax` / `model_like_dict` / `model_media_comment_dict` / `model_comment_dict` / `notification_type_no` / `notification_type_model` のキー順
  - `model_media_comment_no_dict` / `notification_type_no` は既存の数値（1,2,3,4,5,6）を保持しつつ宣言順だけ並び替え（BE/FE 契約を破壊しないため）
- `myus/api/utils/functions/media.py`
  - `get_media_repository` の match 分岐、`MediaInterfaceType` union、import 順
- `myus/api/admin.py`
  - media model import 順

## 動作確認
- `uv run mypy`: 本 PR 起因のエラー 0（既存43件は `logger.py` / `video_converter.py` / `db/models/*` / `adapter/media.py` の `period` 型不整合などで変更前から発生しているもの）

## 備考
- 既存の数値契約（`CommentTypeNo`: Video=1, Music=2, Blog=5, Comic=3, Picture=4、`notification_type_no`: is_video=1, is_music=2, is_blog=5, is_comic=3, is_picture=4）は意図的に維持。宣言の見た目順は新順序だが、キーと数値の対応は旧バージョンと完全互換
- FE PR #724 / #726 と組み合わせて、FE/BE 間のメディア表示順が完全に統一される