### PR TITLE
【docs】frontendコーディング規約にProps配置・CSS空行ルールを追加

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -16,6 +16,8 @@
 
 ## プロパティ記述順序
 
+以下の順でプロパティを並べる。分類コメント（`// 1. レイアウト` 等）はこのドキュメント上での参照用であり、**実際のSCSSファイルには記述しない**。
+
 ```scss
 .element {
   // 1. レイアウト
@@ -23,25 +25,58 @@
   flex-direction: column;
   align-items: center;
   gap: 8px;
-
   // 2. ボックスモデル
   width: 100px;
   padding: 4px 8px;
   margin: 0;
-
   // 3. テキスト
   font-size: 13px;
   text-align: left;
   white-space: nowrap;
   color: rgb(80, 80, 80);
-
   // 4. 装飾
-  background: rgb(245, 245, 245);
   border: 1px solid rgb(220, 220, 220);
   border-radius: 5px;
-
+  background: rgb(245, 245, 245);
   // 5. その他
   cursor: pointer;
+}
+```
+
+## 空行ルール
+
+- **同一セレクタ内のプロパティ間は空行を入れない**
+- **異なるセレクタ（ネスト含む）の間は空行を1行入れる**
+
+実ファイルの例（分類コメントなし、セレクタ間のみ空行あり）:
+
+```scss
+.alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 13px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+
+  &.info {
+    color: rgb(30, 90, 180);
+    border-color: rgb(200, 220, 250);
+    background: rgb(235, 245, 255);
+  }
+
+  &.warning {
+    color: rgb(150, 100, 10);
+    border-color: rgb(240, 210, 120);
+    background: rgb(255, 248, 225);
+  }
+
+  .icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
 }
 ```
 
@@ -64,3 +99,4 @@
 
 ## 更新履歴
 - 2026-04-16: 初版作成
+- 2026-04-22: 空行ルール追加（同一セレクタ内は詰める、セレクタ間は改行）、分類コメントは実ファイルに書かない旨を明記

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -13,10 +13,37 @@
 - コンポーネント名はPascalCase、関数はcamelCase
 - カスタムフックは`use`プレフィックス
 - Propsは分割代入せず`props`で受け取り、内部で展開する
+- `interface Props`は`export default function`の直前に定義する（コンポーネントのシグネチャと型定義が視覚的に隣接するように）
 
 ```typescript
+interface Props {
+  value: string
+  onChange: (value: string) => void
+}
+
 export default function Component(props: Props): React.JSX.Element {
   const { value, onChange } = props
+}
+```
+
+他の型定義（ユニオン型・補助型など）は`interface Props`より上に書く。
+
+```typescript
+type AlertType = 'info' | 'warning' | 'error'
+
+const iconMap = {
+  info: IconInfo,
+  warning: IconWarning,
+  error: IconError,
+}
+
+interface Props {
+  type?: AlertType
+  children: React.ReactNode
+}
+
+export default function Alert(props: Props): React.JSX.Element {
+  // ...
 }
 ```
 
@@ -93,3 +120,4 @@ const [user, setUser] = useState<User | null>(null)
 - 2024-08-21: 初版作成
 - 2025-08-21: Props名統一、引数展開ルール、Linterチェック必須化
 - 2026-04-16: useState型引数必須、docs/に一元化、構成整理
+- 2026-04-22: `interface Props`はコンポーネント関数の直前配置ルール追加


### PR DESCRIPTION
## Summary
- `docs/frontend.md` に `interface Props` をComponent関数直前に配置するルールを追加
- `docs/css.md` に同一セレクタ内は詰める / セレクタ間は空行を入れる空行ルールを追加
- プロパティ分類コメント（`// 1. レイアウト` 等）は参照用であり実ファイルには記述しない旨を明記

## 変更内容

### `docs/frontend.md`
**React/Next.js セクション**に以下のルールを追加:
- `interface Props` は `export default function` の直前に定義する
- 他の型定義やヘルパー定数は `interface Props` より上に書く（AlertType / iconMap パターンを例示）
- コンポーネントのシグネチャと型定義が視覚的に隣接するようにする

### `docs/css.md`
**プロパティ記述順序 セクション**:
- 分類コメント（`// 1. レイアウト` 等）はドキュメント参照用であり、**実ファイルには記述しない** 旨を明記
- グループ間の空行も削除し、コメント付きでも空行なしで示す例に更新

**空行ルール セクション（新規追加）**:
- 同一セレクタ内のプロパティ間は空行を入れない
- 異なるセレクタ（ネスト含む）の間は空行を1行入れる
- 実ファイル形式（分類コメントなし、セレクタ間のみ空行あり）の例を掲載

## Test plan

- [ ] 既存ファイルが新しい空行ルールに則っているか、順次リファクタしていく
- [ ] 新規コンポーネント作成時にルールが守られるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)