### PR TITLE
【front】メディアカードのサイズ調整とコンテンツクリック領域の修正

### DIFF
--- a/frontend/src/components/widgets/Card/IndexList/CardIndexList.module.scss
+++ b/frontend/src/components/widgets/Card/IndexList/CardIndexList.module.scss
@@ -1,7 +1,7 @@
 .card_list {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(auto, 272px));
+  grid-template-columns: repeat(auto-fit, minmax(auto, 312px));
   grid-template-rows: 25px auto;
   grid-gap: 15px;
 

--- a/frontend/src/components/widgets/Card/List/CardList.module.scss
+++ b/frontend/src/components/widgets/Card/List/CardList.module.scss
@@ -1,7 +1,7 @@
 .card_list {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(auto, 272px));
+  grid-template-columns: repeat(auto-fit, minmax(auto, 312px));
   grid-template-rows: auto;
   grid-gap: 15px;
   margin-top: 16px;

--- a/frontend/src/components/widgets/Card/Media/Blog/Blog.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Blog/Blog.module.scss
@@ -1,9 +1,8 @@
 .card {
-  width: 272px;
-  height: 265px;
+  width: 312px;
   cursor: pointer;
-}
 
-.thumbnail {
-  border-radius: 6px 6px 0 0;
+  .thumbnail {
+    border-radius: 6px 6px 0 0;
+  }
 }

--- a/frontend/src/components/widgets/Card/Media/Blog/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Blog/index.tsx
@@ -16,7 +16,7 @@ export default function BlogCard(props: Props): React.JSX.Element {
   return (
     <Card className={style.card}>
       <Link href={`/media/blog/${ulid}`}>
-        <ExImage src={image} width="270" height="153" className={style.thumbnail} />
+        <ExImage src={image} width="312" height="195" className={style.thumbnail} />
       </Link>
       <CardMediaContent href={`/media/blog/${ulid}`} media={item} />
     </Card>

--- a/frontend/src/components/widgets/Card/Media/Chat/Chat.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Chat/Chat.module.scss
@@ -1,4 +1,3 @@
 .card {
-  width: 272px;
-  height: 132px;
+  width: 312px;
 }

--- a/frontend/src/components/widgets/Card/Media/Comic/Comic.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Comic/Comic.module.scss
@@ -1,9 +1,8 @@
 .card {
-  width: 272px;
-  height: 265px;
+  width: 312px;
   cursor: pointer;
-}
 
-.thumbnail {
-  border-radius: 6px 6px 0 0;
+  .thumbnail {
+    border-radius: 6px 6px 0 0;
+  }
 }

--- a/frontend/src/components/widgets/Card/Media/Comic/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Comic/index.tsx
@@ -16,7 +16,7 @@ export default function ComicCard(props: Props): React.JSX.Element {
   return (
     <Card className={style.card}>
       <Link href={`/media/comic/${ulid}`}>
-        <ExImage src={image} width="270" height="153" className={style.thumbnail} />
+        <ExImage src={image} width="312" height="195" className={style.thumbnail} />
       </Link>
       <CardMediaContent href={`/media/comic/${ulid}`} media={item} />
     </Card>

--- a/frontend/src/components/widgets/Card/Media/Content/Base.tsx
+++ b/frontend/src/components/widgets/Card/Media/Content/Base.tsx
@@ -5,7 +5,7 @@ import IconCaret from 'components/parts/Icon/Caret'
 import IconHand from 'components/parts/Icon/Hand'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
-import style from './Content.module.scss'
+import style from './ContentBase.module.scss'
 
 interface Props {
   media: Media
@@ -17,7 +17,7 @@ export default function CardMediaContentBase(props: Props) {
   const { name } = channel
 
   return (
-    <VStack gap="1">
+    <VStack className={style.content_base}>
       <div title={title} className={style.media_title}>
         {title}
       </div>

--- a/frontend/src/components/widgets/Card/Media/Content/Chat/Base.tsx
+++ b/frontend/src/components/widgets/Card/Media/Content/Chat/Base.tsx
@@ -7,7 +7,7 @@ import IconHand from 'components/parts/Icon/Hand'
 import IconPerson from 'components/parts/Icon/Person'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
-import style from '../Content.module.scss'
+import style from '../ContentBase.module.scss'
 
 interface Props {
   media: Chat
@@ -19,7 +19,7 @@ export default function CardChatMediaContentBase(props: Props): React.JSX.Elemen
   const { name } = channel
 
   return (
-    <VStack gap="1">
+    <VStack className={style.content_base}>
       <div title={title} className={style.media_title}>
         {title}
       </div>

--- a/frontend/src/components/widgets/Card/Media/Content/Chat/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Content/Chat/index.tsx
@@ -16,11 +16,11 @@ export default function CardChatMediaContent(props: Props): React.JSX.Element {
   const { avatar, ownerUlid, name } = channel
 
   return (
-    <Link href={href} className={style.content}>
-      <HStack gap="4" align="start">
-        <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
+    <HStack gap="4" align="start" className={style.content}>
+      <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
+      <Link href={href} className={style.main}>
         <CardChatMediaContentBase media={media} />
-      </HStack>
-    </Link>
+      </Link>
+    </HStack>
   )
 }

--- a/frontend/src/components/widgets/Card/Media/Content/Chat/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Content/Chat/index.tsx
@@ -16,14 +16,11 @@ export default function CardChatMediaContent(props: Props): React.JSX.Element {
   const { avatar, ownerUlid, name } = channel
 
   return (
-    <div>
-      <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
-      <Link href={href} className={style.link}>
-        <HStack gap="4" className="p_6">
-          <div className="mr_36" />
-          <CardChatMediaContentBase media={media} />
-        </HStack>
-      </Link>
-    </div>
+    <Link href={href} className={style.content}>
+      <HStack gap="4" align="start">
+        <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
+        <CardChatMediaContentBase media={media} />
+      </HStack>
+    </Link>
   )
 }

--- a/frontend/src/components/widgets/Card/Media/Content/Content.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Content/Content.module.scss
@@ -1,46 +1,6 @@
-.avatar {
-  position: absolute;
-  margin: 6px;
-}
-
-.link {
-  width: 100%;
-  text-decoration: none;
-}
-
-.media_title {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  grid-column: 2/3;
-  grid-row: 1/2;
-  height: 42px;
-  margin: -3px 0 0 0;
-  font-size: 14px;
-  color: rgb(3, 3, 3);
-  overflow: hidden;
-  word-break: break-all;
-}
-
 .content {
+  display: block;
   width: 100%;
-  white-space: nowrap;
-
-  .font {
-    height: 16px;
-    font-size: 13px;
-    color: rgb(40, 70, 150);
-  }
-
-  .nickname {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
-    margin: 0;
-    overflow: hidden;
-  }
-
-  .margin {
-    margin: 0 8px 3px 0;
-  }
+  padding: 6px;
+  text-decoration: none;
 }

--- a/frontend/src/components/widgets/Card/Media/Content/Content.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Content/Content.module.scss
@@ -1,6 +1,10 @@
 .content {
-  display: block;
   width: 100%;
   padding: 6px;
-  text-decoration: none;
+
+  .main {
+    flex: 1;
+    min-width: 0;
+    text-decoration: none;
+  }
 }

--- a/frontend/src/components/widgets/Card/Media/Content/ContentBase.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Content/ContentBase.module.scss
@@ -1,0 +1,36 @@
+.content_base {
+  .media_title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    height: 42px;
+    font-size: 14px;
+    color: rgb(3, 3, 3);
+    word-break: break-all;
+    overflow: hidden;
+  }
+
+  .content {
+    width: 100%;
+    white-space: nowrap;
+
+    .font {
+      height: 16px;
+      line-height: 1;
+      font-size: 13px;
+      color: rgb(40, 70, 150);
+    }
+
+    .nickname {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 1;
+      margin: 0;
+      overflow: hidden;
+    }
+
+    .margin {
+      margin: 0 8px 3px 0;
+    }
+  }
+}

--- a/frontend/src/components/widgets/Card/Media/Content/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Content/index.tsx
@@ -16,11 +16,11 @@ export default function CardMediaContent(props: Props<Media>) {
   const { avatar, ownerUlid, name } = channel
 
   return (
-    <Link href={href} className={style.content}>
-      <HStack gap="4" align="start">
-        <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
+    <HStack gap="4" align="start" className={style.content}>
+      <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
+      <Link href={href} className={style.main}>
         <CardMediaContentBase media={media} />
-      </HStack>
-    </Link>
+      </Link>
+    </HStack>
   )
 }

--- a/frontend/src/components/widgets/Card/Media/Content/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Content/index.tsx
@@ -16,14 +16,11 @@ export default function CardMediaContent(props: Props<Media>) {
   const { avatar, ownerUlid, name } = channel
 
   return (
-    <div>
-      <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
-      <Link href={href} className={style.link}>
-        <HStack gap="4" className="p_6">
-          <div className="mr_36" />
-          <CardMediaContentBase media={media} />
-        </HStack>
-      </Link>
-    </div>
+    <Link href={href} className={style.content}>
+      <HStack gap="4" align="start">
+        <AvatarLink src={avatar} ulid={ownerUlid} title={name} className={style.avatar} />
+        <CardMediaContentBase media={media} />
+      </HStack>
+    </Link>
   )
 }

--- a/frontend/src/components/widgets/Card/Media/Music/Music.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Music/Music.module.scss
@@ -1,6 +1,5 @@
 .card {
-  width: 272px;
-  height: 160px;
+  width: 312px;
 
   .player {
     border-radius: 5px 5px 0 0;

--- a/frontend/src/components/widgets/Card/Media/Picture/Picture.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Picture/Picture.module.scss
@@ -1,9 +1,8 @@
 .card {
-  width: 272px;
-  height: 265px;
+  width: 312px;
   cursor: pointer;
-}
 
-.thumbnail {
-  border-radius: 6px 6px 0 0;
+  .thumbnail {
+    border-radius: 6px 6px 0 0;
+  }
 }

--- a/frontend/src/components/widgets/Card/Media/Picture/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Picture/index.tsx
@@ -16,7 +16,7 @@ export default function PictureCard(props: Props): React.JSX.Element {
   return (
     <Card className={style.card}>
       <Link href={`/media/picture/${ulid}`}>
-        <ExImage src={image} width="270" height="153" className={style.thumbnail} />
+        <ExImage src={image} width="312" height="195" className={style.thumbnail} />
       </Link>
       <CardMediaContent href={`/media/picture/${ulid}`} media={item} />
     </Card>

--- a/frontend/src/components/widgets/Card/Media/Video/Video.module.scss
+++ b/frontend/src/components/widgets/Card/Media/Video/Video.module.scss
@@ -1,5 +1,4 @@
 .card {
-  width: 272px;
-  height: 265px;
+  width: 312px;
   cursor: pointer;
 }

--- a/frontend/src/components/widgets/Card/Media/Video/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Video/index.tsx
@@ -55,8 +55,8 @@ export default function VideoCard(props: Props): React.JSX.Element {
           options={{
             src: convert,
             poster: image,
-            width: 272,
-            height: 153,
+            width: 312,
+            height: 195,
             muted: true,
             controls: false,
             autoplay: false,

--- a/frontend/src/components/widgets/Card/Media/Video/index.tsx
+++ b/frontend/src/components/widgets/Card/Media/Video/index.tsx
@@ -64,8 +64,8 @@ export default function VideoCard(props: Props): React.JSX.Element {
             preload: 'metadata',
           }}
         />
-        <CardMediaContent href={`/media/video/${ulid}`} media={item} />
       </div>
+      <CardMediaContent href={`/media/video/${ulid}`} media={item} />
     </Card>
   )
 }


### PR DESCRIPTION
## Summary
- 1440×900 画面でメディアカードが 4 枚ちょうど並ぶよう幅を 272px → 312px に調整
- サムネイル画像を 16:10 比率（312×195）に統一、カード高さは明示せずコンテンツに追従
- コンテンツ部の視覚フレームとクリック可能領域を完全一致するようリンク構造を再編

## 変更内容

### カード幅・グリッドの調整
- `CardList` / `CardIndexList` の `grid-template-columns` を `minmax(auto, 272px)` → `minmax(auto, 312px)` に変更
- 全メディアカード（Blog/Comic/Picture/Video/Music/Chat）の `.card` 幅を 312px に統一
- サムネイル持ちカードは `height` 指定を撤廃し、コンテンツに応じて自動決定
- 1440×900 検証: `4×312 + 3×15(gap) = 1293px` で 4 枚収まり、5 枚目は溢れる

### サムネイル画像の 16:10 化
- Blog / Comic / Picture: `ExImage` を 272×170 → 312×195 に
- Video: `VideoJS` の width/height を 312×195 に
- アスペクト比 16:10（= 8:5）を全サムネイルで維持

### コンテンツ部のクリック領域修正
- `CardMediaContent` / `CardChatMediaContent` の構造を刷新
  - 旧: 外側 `<div>` + 絶対配置 `AvatarLink` + インラインの `<Link>`（width:100% が効かずクリック領域不一致）
  - 新: `<Link class=\"content\">` を最上位のブロック要素にし、`HStack` でアバターと本文を横並び
- `.content` を `display: block; width: 100%; padding: 6px` とし、視覚フレーム = クリック可能領域に
- Music / Chat も同じ `.content` クラスを共有するため同時に修正される

### CSS の責務分離
- 旧 `Content.module.scss` からタイトル・本文のスタイルを分離し `ContentBase.module.scss` を新設
- `Content.module.scss` は外側ラッパー（`.content`）のみを担当
- `Base.tsx` / `Chat/Base.tsx` はそれぞれ `ContentBase.module.scss` を参照するように更新