### PR TITLE
【front】FollowCard/ChannelCardのサイズをメディアカードに統一

### DIFF
--- a/frontend/src/components/widgets/Card/Channel/Channel.module.scss
+++ b/frontend/src/components/widgets/Card/Channel/Channel.module.scss
@@ -1,10 +1,9 @@
 .card {
-  width: 272px;
-  height: 250px;
-  border: 1px solid rgba(0, 130, 255, 0.5);
+  width: 312px;
 
   &:hover {
     background: rgba(200, 230, 255, 0.1);
+    border: 1px solid rgba(0, 130, 255, 0.5);
   }
 
   .box {

--- a/frontend/src/components/widgets/Card/Follow/Follow.module.scss
+++ b/frontend/src/components/widgets/Card/Follow/Follow.module.scss
@@ -1,10 +1,9 @@
 .card {
-  width: 272px;
-  height: 250px;
-  border: 1px solid rgba(0, 130, 255, 0.5);
+  width: 312px;
 
   &:hover {
     background: rgba(200, 230, 255, 0.1);
+    border: 1px solid rgba(0, 130, 255, 0.5);
   }
 
   .box {


### PR DESCRIPTION
## Summary
- FollowCard/ChannelCardの幅をメディアカード(312px)に揃えた
- 固定高さを撤去してコンテンツに応じて可変に変更
- ボーダーはhover時のみ表示するように変更

## 変更内容

### frontend/src/components/widgets/Card/Channel/Channel.module.scss
- \`width: 272px\` → \`width: 312px\` にしてメディアカードの横幅に合わせた
- \`height: 250px\` を削除（コンテンツに応じた自然な高さに）
- 常時表示していた \`border: 1px solid rgba(0, 130, 255, 0.5)\` を \`&:hover\` 内へ移動

### frontend/src/components/widgets/Card/Follow/Follow.module.scss
- 同様に \`width: 272px\` → \`width: 312px\`、\`height: 250px\` 削除
- \`border\` を hover 時のみ表示するよう変更