### PR TITLE
【front】メディア一覧にサーバサイドページングを導入

### DIFF
--- a/frontend/src/api/internal/media/list.ts
+++ b/frontend/src/api/internal/media/list.ts
@@ -2,7 +2,7 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
-import { SearchParams, MediaHome, Video, Music, Blog, Comic, Picture, Chat } from 'types/internal/media/output'
+import { SearchParams, MediaHome, VideoList, MusicList, BlogList, ComicList, PictureList, ChatList } from 'types/internal/media/output'
 import { apiHome, apiRecommend, apiVideos, apiMusics, apiBlogs, apiComics, apiPictures, apiChats } from 'api/uri'
 
 export const getHome = async (params: SearchParams, req?: Req): Promise<ApiOut<MediaHome>> => {
@@ -13,26 +13,26 @@ export const getRecommend = async (params: SearchParams, req?: Req): Promise<Api
   return await apiOut(apiClient('json').get(apiRecommend, cookieHeader(req, params)))
 }
 
-export const getVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<Video[]>> => {
+export const getVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<VideoList>> => {
   return await apiOut(apiClient('json').get(apiVideos, cookieHeader(req, params)))
 }
 
-export const getMusics = async (params: SearchParams, req?: Req): Promise<ApiOut<Music[]>> => {
+export const getMusics = async (params: SearchParams, req?: Req): Promise<ApiOut<MusicList>> => {
   return await apiOut(apiClient('json').get(apiMusics, cookieHeader(req, params)))
 }
 
-export const getBlogs = async (params: SearchParams, req?: Req): Promise<ApiOut<Blog[]>> => {
+export const getBlogs = async (params: SearchParams, req?: Req): Promise<ApiOut<BlogList>> => {
   return await apiOut(apiClient('json').get(apiBlogs, cookieHeader(req, params)))
 }
 
-export const getComics = async (params: SearchParams, req?: Req): Promise<ApiOut<Comic[]>> => {
+export const getComics = async (params: SearchParams, req?: Req): Promise<ApiOut<ComicList>> => {
   return await apiOut(apiClient('json').get(apiComics, cookieHeader(req, params)))
 }
 
-export const getPictures = async (params: SearchParams, req?: Req): Promise<ApiOut<Picture[]>> => {
+export const getPictures = async (params: SearchParams, req?: Req): Promise<ApiOut<PictureList>> => {
   return await apiOut(apiClient('json').get(apiPictures, cookieHeader(req, params)))
 }
 
-export const getChats = async (params: SearchParams, req?: Req): Promise<ApiOut<Chat[]>> => {
+export const getChats = async (params: SearchParams, req?: Req): Promise<ApiOut<ChatList>> => {
   return await apiOut(apiClient('json').get(apiChats, cookieHeader(req, params)))
 }

--- a/frontend/src/components/hooks/useSearch.tsx
+++ b/frontend/src/components/hooks/useSearch.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router'
 import { Search } from 'types/internal/media/output'
 
-export function useSearch(datas: unknown[]): Search {
+export function useSearch(count: number): Search {
   const router = useRouter()
   const query = router.query
   const name = typeof query.search === 'string' && query.search ? query.search : ''
-  return { name, count: datas.length }
+  return { name, count }
 }

--- a/frontend/src/components/templates/media/blog/list.tsx
+++ b/frontend/src/components/templates/media/blog/list.tsx
@@ -1,21 +1,33 @@
+import { useRouter } from 'next/router'
 import { Blog } from 'types/internal/media/output'
+import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
 import Main from 'components/layout/Main'
+import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
 import BlogCard from 'components/widgets/Card/Media/Blog'
 
 interface Props {
   datas: Blog[]
+  total: number
+  page: number
 }
 
 export default function Blogs(props: Props): React.JSX.Element {
-  const { datas } = props
+  const { datas, total, page } = props
 
-  const search = useSearch(datas)
+  const router = useRouter()
+  const search = useSearch(total)
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+  }
 
   return (
     <Main title="Blog" search={search}>
       <CardList items={datas} Content={BlogCard} />
+      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/chat/list.tsx
+++ b/frontend/src/components/templates/media/chat/list.tsx
@@ -1,21 +1,33 @@
+import { useRouter } from 'next/router'
 import { Chat } from 'types/internal/media/output'
+import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
 import Main from 'components/layout/Main'
+import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
 import ChatCard from 'components/widgets/Card/Media/Chat'
 
 interface Props {
   datas: Chat[]
+  total: number
+  page: number
 }
 
 export default function Chats(props: Props): React.JSX.Element {
-  const { datas } = props
+  const { datas, total, page } = props
 
-  const search = useSearch(datas)
+  const router = useRouter()
+  const search = useSearch(total)
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+  }
 
   return (
     <Main title="Chat" search={search}>
       <CardList items={datas} Content={ChatCard} />
+      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/comic/list.tsx
+++ b/frontend/src/components/templates/media/comic/list.tsx
@@ -1,21 +1,33 @@
+import { useRouter } from 'next/router'
 import { Comic } from 'types/internal/media/output'
+import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
 import Main from 'components/layout/Main'
+import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
 import ComicCard from 'components/widgets/Card/Media/Comic'
 
 interface Props {
   datas: Comic[]
+  total: number
+  page: number
 }
 
 export default function Comics(props: Props): React.JSX.Element {
-  const { datas } = props
+  const { datas, total, page } = props
 
-  const search = useSearch(datas)
+  const router = useRouter()
+  const search = useSearch(total)
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+  }
 
   return (
     <Main title="Comic" search={search}>
       <CardList items={datas} Content={ComicCard} />
+      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/home/list.tsx
+++ b/frontend/src/components/templates/media/home/list.tsx
@@ -19,7 +19,8 @@ export default function Homes(props: Props): React.JSX.Element {
   const { title, mediaHome } = props
   const { videos, musics, blogs, comics, pictures, chats } = mediaHome
 
-  const search = useSearch([videos, musics, blogs, comics, pictures, chats])
+  const count = videos.length + musics.length + blogs.length + comics.length + pictures.length + chats.length
+  const search = useSearch(count)
 
   return (
     <Main title={title} search={search}>

--- a/frontend/src/components/templates/media/music/list.tsx
+++ b/frontend/src/components/templates/media/music/list.tsx
@@ -1,21 +1,33 @@
+import { useRouter } from 'next/router'
 import { Music } from 'types/internal/media/output'
+import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
 import Main from 'components/layout/Main'
+import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
 import MusicCard from 'components/widgets/Card/Media/Music'
 
 interface Props {
   datas: Music[]
+  total: number
+  page: number
 }
 
 export default function Musics(props: Props): React.JSX.Element {
-  const { datas } = props
+  const { datas, total, page } = props
 
-  const search = useSearch(datas)
+  const router = useRouter()
+  const search = useSearch(total)
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+  }
 
   return (
     <Main title="Music" search={search}>
       <CardList items={datas} Content={MusicCard} />
+      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/picture/list.tsx
+++ b/frontend/src/components/templates/media/picture/list.tsx
@@ -1,21 +1,33 @@
+import { useRouter } from 'next/router'
 import { Picture } from 'types/internal/media/output'
+import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
 import Main from 'components/layout/Main'
+import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
 import PictureCard from 'components/widgets/Card/Media/Picture'
 
 interface Props {
   datas: Picture[]
+  total: number
+  page: number
 }
 
 export default function Pictures(props: Props): React.JSX.Element {
-  const { datas } = props
+  const { datas, total, page } = props
 
-  const search = useSearch(datas)
+  const router = useRouter()
+  const search = useSearch(total)
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+  }
 
   return (
     <Main title="Picture" search={search}>
       <CardList items={datas} Content={PictureCard} />
+      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/video/list.tsx
+++ b/frontend/src/components/templates/media/video/list.tsx
@@ -1,21 +1,33 @@
+import { useRouter } from 'next/router'
 import { Video } from 'types/internal/media/output'
+import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
 import Main from 'components/layout/Main'
+import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
 import VideoCard from 'components/widgets/Card/Media/Video'
 
 interface Props {
   datas: Video[]
+  total: number
+  page: number
 }
 
 export default function Videos(props: Props): React.JSX.Element {
-  const { datas } = props
+  const { datas, total, page } = props
 
-  const search = useSearch(datas)
+  const router = useRouter()
+  const search = useSearch(total)
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+  }
 
   return (
     <Main title="Video" search={search}>
       <CardList items={datas} Content={VideoCard} />
+      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/menu/follow.tsx
+++ b/frontend/src/components/templates/menu/follow.tsx
@@ -14,7 +14,7 @@ export default function Follows(props: Props): React.JSX.Element {
   const { datas } = props
 
   const router = useRouter()
-  const search = useSearch(datas)
+  const search = useSearch(datas.length)
 
   return (
     <Main title="Follow" search={search}>

--- a/frontend/src/components/templates/menu/follower.tsx
+++ b/frontend/src/components/templates/menu/follower.tsx
@@ -14,7 +14,7 @@ export default function Followers(props: Props): React.JSX.Element {
   const { datas } = props
 
   const router = useRouter()
-  const search = useSearch(datas)
+  const search = useSearch(datas.length)
 
   return (
     <Main title="Follower" search={search}>

--- a/frontend/src/pages/media/blog/index.tsx
+++ b/frontend/src/pages/media/blog/index.tsx
@@ -2,22 +2,24 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { Blog } from 'types/internal/media/output'
 import { getBlogs } from 'api/internal/media/list'
-import { searchParams } from 'utils/functions/common'
+import { pageParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Blogs from 'components/templates/media/blog/list'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const params = searchParams(query)
-  const ret = await getBlogs(params)
+  const { search, limit, offset, page } = pageParams(query)
+  const ret = await getBlogs({ search, limit, offset })
   if (ret.isErr()) return { props: { status: ret.error.status } }
-  const datas = ret.value
-  return { props: { ...translations, datas } }
+  const { datas, total } = ret.value
+  return { props: { ...translations, datas, total, page } }
 }
 
 interface Props {
   status: number
   datas: Blog[]
+  total: number
+  page: number
 }
 
 export default function BlogsPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/media/chat/index.tsx
+++ b/frontend/src/pages/media/chat/index.tsx
@@ -2,22 +2,24 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { Chat } from 'types/internal/media/output'
 import { getChats } from 'api/internal/media/list'
-import { searchParams } from 'utils/functions/common'
+import { pageParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Chats from 'components/templates/media/chat/list'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const params = searchParams(query)
-  const ret = await getChats(params)
+  const { search, limit, offset, page } = pageParams(query)
+  const ret = await getChats({ search, limit, offset })
   if (ret.isErr()) return { props: { status: ret.error.status } }
-  const datas = ret.value
-  return { props: { ...translations, datas } }
+  const { datas, total } = ret.value
+  return { props: { ...translations, datas, total, page } }
 }
 
 interface Props {
   status: number
   datas: Chat[]
+  total: number
+  page: number
 }
 
 export default function ChatsPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/media/comic/index.tsx
+++ b/frontend/src/pages/media/comic/index.tsx
@@ -2,22 +2,24 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { Comic } from 'types/internal/media/output'
 import { getComics } from 'api/internal/media/list'
-import { searchParams } from 'utils/functions/common'
+import { pageParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Comics from 'components/templates/media/comic/list'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const params = searchParams(query)
-  const ret = await getComics(params)
+  const { search, limit, offset, page } = pageParams(query)
+  const ret = await getComics({ search, limit, offset })
   if (ret.isErr()) return { props: { status: ret.error.status } }
-  const datas = ret.value
-  return { props: { ...translations, datas } }
+  const { datas, total } = ret.value
+  return { props: { ...translations, datas, total, page } }
 }
 
 interface Props {
   status: number
   datas: Comic[]
+  total: number
+  page: number
 }
 
 export default function ComicsPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/media/music/index.tsx
+++ b/frontend/src/pages/media/music/index.tsx
@@ -2,22 +2,24 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { Music } from 'types/internal/media/output'
 import { getMusics } from 'api/internal/media/list'
-import { searchParams } from 'utils/functions/common'
+import { pageParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Musics from 'components/templates/media/music/list'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const params = searchParams(query)
-  const ret = await getMusics(params)
+  const { search, limit, offset, page } = pageParams(query)
+  const ret = await getMusics({ search, limit, offset })
   if (ret.isErr()) return { props: { status: ret.error.status } }
-  const datas = ret.value
-  return { props: { ...translations, datas } }
+  const { datas, total } = ret.value
+  return { props: { ...translations, datas, total, page } }
 }
 
 interface Props {
   status: number
   datas: Music[]
+  total: number
+  page: number
 }
 
 export default function MusicsPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/media/picture/index.tsx
+++ b/frontend/src/pages/media/picture/index.tsx
@@ -2,22 +2,24 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { Picture } from 'types/internal/media/output'
 import { getPictures } from 'api/internal/media/list'
-import { searchParams } from 'utils/functions/common'
+import { pageParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Pictures from 'components/templates/media/picture/list'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const params = searchParams(query)
-  const ret = await getPictures(params)
+  const { search, limit, offset, page } = pageParams(query)
+  const ret = await getPictures({ search, limit, offset })
   if (ret.isErr()) return { props: { status: ret.error.status } }
-  const datas = ret.value
-  return { props: { ...translations, datas } }
+  const { datas, total } = ret.value
+  return { props: { ...translations, datas, total, page } }
 }
 
 interface Props {
   status: number
   datas: Picture[]
+  total: number
+  page: number
 }
 
 export default function PicturesPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/media/video/index.tsx
+++ b/frontend/src/pages/media/video/index.tsx
@@ -2,22 +2,24 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { Video } from 'types/internal/media/output'
 import { getVideos } from 'api/internal/media/list'
-import { searchParams } from 'utils/functions/common'
+import { pageParams } from 'utils/functions/common'
 import ErrorCheck from 'components/widgets/Error/Check'
 import Videos from 'components/templates/media/video/list'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, query }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const params = searchParams(query)
-  const ret = await getVideos(params)
+  const { search, limit, offset, page } = pageParams(query)
+  const ret = await getVideos({ search, limit, offset })
   if (ret.isErr()) return { props: { status: ret.error.status } }
-  const datas = ret.value
-  return { props: { ...translations, datas } }
+  const { datas, total } = ret.value
+  return { props: { ...translations, datas, total, page } }
 }
 
 interface Props {
   status: number
   datas: Video[]
+  total: number
+  page: number
 }
 
 export default function VideosPage(props: Props): React.JSX.Element {

--- a/frontend/src/types/internal/media/output.d.ts
+++ b/frontend/src/types/internal/media/output.d.ts
@@ -9,6 +9,8 @@ export interface Search {
 
 export interface SearchParams {
   search?: string
+  limit?: number
+  offset?: number
 }
 
 export interface MediaUser {
@@ -86,6 +88,36 @@ export interface MediaHome {
   comics: Comic[]
   pictures: Picture[]
   chats: Chat[]
+}
+
+export interface VideoList {
+  datas: Video[]
+  total: number
+}
+
+export interface MusicList {
+  datas: Music[]
+  total: number
+}
+
+export interface BlogList {
+  datas: Blog[]
+  total: number
+}
+
+export interface ComicList {
+  datas: Comic[]
+  total: number
+}
+
+export interface PictureList {
+  datas: Picture[]
+  total: number
+}
+
+export interface ChatList {
+  datas: Chat[]
+  total: number
 }
 
 export interface VideoDetail extends MediaDetail {

--- a/frontend/src/utils/functions/common.ts
+++ b/frontend/src/utils/functions/common.ts
@@ -1,10 +1,19 @@
 import { ParsedUrlQuery } from 'querystring'
 
+export const PAGE_SIZE = 50
+
 export const isActive = (isbool: boolean) => (isbool ? 'active' : '')
 
 export const searchParams = (query: ParsedUrlQuery): { search?: string } => ({
   search: typeof query.search === 'string' && query.search ? query.search : undefined,
 })
+
+export const pageParams = (query: ParsedUrlQuery): { search?: string; limit: number; offset: number; page: number } => {
+  const search = typeof query.search === 'string' && query.search ? query.search : undefined
+  const raw = typeof query.page === 'string' ? Number(query.page) : 1
+  const page = Number.isInteger(raw) && raw > 0 ? raw : 1
+  return { search, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE, page }
+}
 
 export const capitalize = (str: string): string => {
   if (!str) return str


### PR DESCRIPTION
## Summary
- メディア一覧（video / music / blog / comic / picture / chat）に \`limit\` / \`offset\` 形式のサーバサイドページングを実装
- \`GET /api/media/{type}/\` のレスポンスを \`{ datas, total }\` に対応させ、URL の \`?page=N\` でページを管理
- ページネーション UI は manage と共通の \`<Pagination>\` コンポーネントを再利用

## 変更内容

### 型 / 共通ユーティリティ
- **types/internal/media/output.d.ts**
  - \`SearchParams\` に \`limit?\` / \`offset?\` を追加
  - \`VideoList\` / \`MusicList\` / \`BlogList\` / \`ComicList\` / \`PictureList\` / \`ChatList\`（\`{ datas, total }\`）を追加
- **utils/functions/common.ts**
  - \`PAGE_SIZE = 50\` 定数を追加
  - \`pageParams(query)\` ヘルパーを追加（URL クエリ → \`{ search, limit, offset, page }\`）

### API クライアント
- **api/internal/media/list.ts** — \`getVideos\` 等 6 関数のレスポンス型を \`VideoList\`〜\`ChatList\` に更新

### hooks
- **hooks/useSearch.tsx** — シグネチャを \`(datas: unknown[]) → (count: number)\` に変更し、総件数を表示できるように

### ページ（getServerSideProps）
- **pages/media/{video,music,blog,comic,picture,chat}/index.tsx**
  - \`pageParams(query)\` で URL を解釈
  - \`{ search, limit, offset }\` を API に送信
  - \`{ datas, total, page }\` をテンプレートへ渡す

### テンプレート
- **templates/media/{video,music,blog,comic,picture,chat}/list.tsx**
  - クライアント側 \`usePagination\` を廃止し、サーバサイドページング対応
  - \`Math.ceil(total / PAGE_SIZE)\` で総ページ数を算出
  - \`router.push({ query: { ...query, page: p } })\` でページ遷移
- **templates/media/home/list.tsx** / **templates/menu/{follow,follower}.tsx**
  - \`useSearch\` のシグネチャ変更に追従

## 備考
- BE 側（\`GET /api/media/{type}/\` を \`{ datas, total }\` に変更、\`limit\` / \`offset\` を受け付け、\`count()\` メソッドで総件数を取得）は別 PR で対応予定
- BE が未対応の状態だとレスポンス不一致になるため、BE PR とセットでマージする想定