### PR TITLE
【back】メディア一覧にサーバサイドページングを導入

### DIFF
--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -17,6 +17,7 @@ from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.comment import CommentOut, ReplyOut
 from api.src.types.schema.media.input import VideoIn, MusicIn, BlogIn, ComicIn, PictureIn, ChatIn
 from api.src.types.schema.media.output import HomeOut, VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut, MediaCreateOut, HashtagOut
+from api.src.types.schema.media.output import VideoListOut, MusicListOut, BlogListOut, ComicListOut, PictureListOut, ChatListOut
 from api.src.types.schema.media.output import VideoDetailOut, MusicDetailOut, BlogDetailOut, ComicDetailOut, PictureDetailOut, ChatDetailOut
 from api.src.types.schema.media.output import VideoDetailsOut, MusicDetailsOut, BlogDetailsOut, ComicDetailsOut, PictureDetailsOut, ChatDetailsOut
 from api.src.types.schema.message import MessageOut
@@ -99,11 +100,12 @@ class VideoAPI:
         return 201, data
 
     @staticmethod
-    @router.get("", response={200: list[VideoOut]})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("VideoAPI list", search=search)
-        objs = get_videos(50, search)
-        data = convert_videos(objs)
+    @router.get("", response={200: VideoListOut})
+    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+        log.info("VideoAPI list", search=search, limit=limit, offset=offset)
+        user_id = auth_check(request)
+        objs, total = get_videos(limit, offset, search, user_id=user_id)
+        data = VideoListOut(datas=convert_videos(objs), total=total)
         return 200, data
 
     @staticmethod
@@ -113,7 +115,7 @@ class VideoAPI:
 
         user_id = auth_check(request)
         obj = get_video_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs = get_videos(50, search, obj.id)
+        objs, _ = get_videos(50, 0, search, obj.id)
 
         data = VideoDetailsOut(
             detail=VideoDetailOut(
@@ -159,11 +161,12 @@ class MusicAPI:
         return 201, data
 
     @staticmethod
-    @router.get("", response={200: list[MusicOut]})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("MusicAPI list", search=search)
-        objs = get_musics(50, search)
-        data = convert_musics(objs)
+    @router.get("", response={200: MusicListOut})
+    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+        log.info("MusicAPI list", search=search, limit=limit, offset=offset)
+        user_id = auth_check(request)
+        objs, total = get_musics(limit, offset, search, user_id=user_id)
+        data = MusicListOut(datas=convert_musics(objs), total=total)
         return 200, data
 
     @staticmethod
@@ -173,7 +176,7 @@ class MusicAPI:
 
         user_id = auth_check(request)
         obj = get_music_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs = get_musics(50, search, obj.id)
+        objs, _ = get_musics(50, 0, search, obj.id)
 
         data = MusicDetailsOut(
             detail=MusicDetailOut(
@@ -219,11 +222,12 @@ class BlogAPI:
         return 201, data
 
     @staticmethod
-    @router.get("", response={200: list[BlogOut]})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("BlogAPI list", search=search)
-        objs = get_blogs(50, search)
-        data = convert_blogs(objs)
+    @router.get("", response={200: BlogListOut})
+    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+        log.info("BlogAPI list", search=search, limit=limit, offset=offset)
+        user_id = auth_check(request)
+        objs, total = get_blogs(limit, offset, search, user_id=user_id)
+        data = BlogListOut(datas=convert_blogs(objs), total=total)
         return 200, data
 
     @staticmethod
@@ -233,7 +237,7 @@ class BlogAPI:
 
         user_id = auth_check(request)
         obj = get_blog_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs = get_blogs(50, search, obj.id)
+        objs, _ = get_blogs(50, 0, search, obj.id)
 
         data = BlogDetailsOut(
             detail=BlogDetailOut(
@@ -278,11 +282,12 @@ class ComicAPI:
         return 201, data
 
     @staticmethod
-    @router.get("", response={200: list[ComicOut]})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ComicAPI list", search=search)
-        objs = get_comics(50, search)
-        data = convert_comics(objs)
+    @router.get("", response={200: ComicListOut})
+    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+        log.info("ComicAPI list", search=search, limit=limit, offset=offset)
+        user_id = auth_check(request)
+        objs, total = get_comics(limit, offset, search, user_id=user_id)
+        data = ComicListOut(datas=convert_comics(objs), total=total)
         return 200, data
 
     @staticmethod
@@ -292,7 +297,7 @@ class ComicAPI:
 
         user_id = auth_check(request)
         obj = get_comic_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs = get_comics(50, search, obj.id)
+        objs, _ = get_comics(50, 0, search, obj.id)
 
         data = ComicDetailsOut(
             detail=ComicDetailOut(
@@ -337,11 +342,12 @@ class PictureAPI:
         return 201, data
 
     @staticmethod
-    @router.get("", response={200: list[PictureOut]})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("PictureAPI list", search=search)
-        objs = get_pictures(50, search)
-        data = convert_pictures(objs)
+    @router.get("", response={200: PictureListOut})
+    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+        log.info("PictureAPI list", search=search, limit=limit, offset=offset)
+        user_id = auth_check(request)
+        objs, total = get_pictures(limit, offset, search, user_id=user_id)
+        data = PictureListOut(datas=convert_pictures(objs), total=total)
         return 200, data
 
     @staticmethod
@@ -351,7 +357,7 @@ class PictureAPI:
 
         user_id = auth_check(request)
         obj = get_picture_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs = get_pictures(50, search, obj.id)
+        objs, _ = get_pictures(50, 0, search, obj.id)
 
         data = PictureDetailsOut(
             detail=PictureDetailOut(
@@ -395,11 +401,12 @@ class ChatAPI:
         return 201, data
 
     @staticmethod
-    @router.get("", response={200: list[ChatOut]})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ChatAPI list", search=search)
-        objs = get_chats(50, search)
-        data = convert_chats(objs)
+    @router.get("", response={200: ChatListOut})
+    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+        log.info("ChatAPI list", search=search, limit=limit, offset=offset)
+        user_id = auth_check(request)
+        objs, total = get_chats(limit, offset, search, user_id=user_id)
+        data = ChatListOut(datas=convert_chats(objs), total=total)
         return 200, data
 
     @staticmethod
@@ -409,7 +416,7 @@ class ChatAPI:
 
         user_id = auth_check(request)
         obj = get_chat_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs = get_chats(50, search, obj.id)
+        objs, _ = get_chats(50, 0, search, obj.id)
 
         data = ChatDetailsOut(
             detail=ChatDetailOut(

--- a/myus/api/src/domain/entity/media/blog/repository.py
+++ b/myus/api/src/domain/entity/media/blog/repository.py
@@ -1,12 +1,11 @@
-from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.media import Blog
 from api.src.domain.entity.media.blog._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_recommend, filter_search, sort_queryset
+from api.src.domain.entity.media.index import filter_q_list, sort_queryset
 from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.blog.interface import BlogInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 
 
 BLOG_FIELDS = ["channel_id", "title", "content", "richtext", "image", "read", "publish"]
@@ -16,32 +15,11 @@ class BlogRepository(BlogInterface):
     def queryset(self) -> QuerySet[Blog]:
         return Blog.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
-        q_list: list[Q] = []
-        if filter.ulid:
-            q_list.append(Q(ulid=filter.ulid))
-        if filter.publish is not None:
-            q_list.append(Q(publish=filter.publish))
-        if filter.owner_id:
-            q_list.append(Q(channel__owner_id=filter.owner_id))
-        if filter.channel_id:
-            q_list.append(Q(channel_id=filter.channel_id))
-        if filter.category_id:
-            q_list.append(Q(category__id=filter.category_id))
-        if filter.is_recommend:
-            q_list.append(filter_recommend())
-        if filter.search:
-            q_list.append(filter_search(filter.search))
-        if exclude.id:
-            q_list.append(~Q(id=exclude.id))
-
-        qs = Blog.objects.filter(*q_list).distinct()
-        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend)
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
+        qs = Blog.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
-
-        if limit is not None:
-            qs = qs[:limit]
-
+        qs = qs[page.offset:page.offset + page.limit]
         return list(qs.values_list("id", flat=True))
 
     def bulk_get(self, ids: list[int]) -> list[BlogData]:
@@ -69,6 +47,9 @@ class BlogRepository(BlogInterface):
 
     def bulk_delete(self, ids: list[int]) -> None:
         Blog.objects.filter(id__in=ids).delete()
+
+    def count(self, filter: FilterOption) -> int:
+        return Blog.objects.filter(*filter_q_list(filter)).distinct().count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Blog.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/chat/repository.py
+++ b/myus/api/src/domain/entity/media/chat/repository.py
@@ -1,12 +1,11 @@
-from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.media import Chat
 from api.src.domain.entity.media.chat._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_recommend, filter_search, sort_queryset
+from api.src.domain.entity.media.index import filter_q_list, sort_queryset
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.domain.interface.media.chat.interface import ChatInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 
 
 CHAT_FIELDS = ["channel_id", "title", "content", "read", "period", "publish"]
@@ -16,32 +15,11 @@ class ChatRepository(ChatInterface):
     def queryset(self) -> QuerySet[Chat]:
         return Chat.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
-        q_list: list[Q] = []
-        if filter.ulid:
-            q_list.append(Q(ulid=filter.ulid))
-        if filter.publish is not None:
-            q_list.append(Q(publish=filter.publish))
-        if filter.owner_id:
-            q_list.append(Q(channel__owner_id=filter.owner_id))
-        if filter.channel_id:
-            q_list.append(Q(channel_id=filter.channel_id))
-        if filter.category_id:
-            q_list.append(Q(category__id=filter.category_id))
-        if filter.is_recommend:
-            q_list.append(filter_recommend())
-        if filter.search:
-            q_list.append(filter_search(filter.search))
-        if exclude.id:
-            q_list.append(~Q(id=exclude.id))
-
-        qs = Chat.objects.filter(*q_list).distinct()
-        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend)
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
+        qs = Chat.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
-
-        if limit is not None:
-            qs = qs[:limit]
-
+        qs = qs[page.offset:page.offset + page.limit]
         return list(qs.values_list("id", flat=True))
 
     def bulk_get(self, ids: list[int]) -> list[ChatData]:
@@ -69,6 +47,9 @@ class ChatRepository(ChatInterface):
 
     def bulk_delete(self, ids: list[int]) -> None:
         Chat.objects.filter(id__in=ids).delete()
+
+    def count(self, filter: FilterOption) -> int:
+        return Chat.objects.filter(*filter_q_list(filter)).distinct().count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Chat.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/comic/repository.py
+++ b/myus/api/src/domain/entity/media/comic/repository.py
@@ -1,13 +1,13 @@
 from django.db import transaction
-from django.db.models import Prefetch, Q
+from django.db.models import Prefetch
 from django.db.models.query import QuerySet
 from api.db.models.media import Comic, ComicPage
 from api.src.domain.entity.media.comic._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_recommend, filter_search, sort_queryset
+from api.src.domain.entity.media.index import filter_q_list, sort_queryset
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.comic.interface import ComicInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 
 
 COMIC_FIELDS = ["channel_id", "title", "content", "image", "read", "publish"]
@@ -18,32 +18,11 @@ class ComicRepository(ComicInterface):
         pages_prefetch = Prefetch("comic", queryset=ComicPage.objects.order_by("sequence"))
         return Comic.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", pages_prefetch)
 
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
-        q_list: list[Q] = []
-        if filter.ulid:
-            q_list.append(Q(ulid=filter.ulid))
-        if filter.publish is not None:
-            q_list.append(Q(publish=filter.publish))
-        if filter.owner_id:
-            q_list.append(Q(channel__owner_id=filter.owner_id))
-        if filter.channel_id:
-            q_list.append(Q(channel_id=filter.channel_id))
-        if filter.category_id:
-            q_list.append(Q(category__id=filter.category_id))
-        if filter.is_recommend:
-            q_list.append(filter_recommend())
-        if filter.search:
-            q_list.append(filter_search(filter.search))
-        if exclude.id:
-            q_list.append(~Q(id=exclude.id))
-
-        qs = Comic.objects.filter(*q_list).distinct()
-        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend)
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
+        qs = Comic.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
-
-        if limit is not None:
-            qs = qs[:limit]
-
+        qs = qs[page.offset:page.offset + page.limit]
         return list(qs.values_list("id", flat=True))
 
     def bulk_get(self, ids: list[int]) -> list[ComicData]:
@@ -79,6 +58,9 @@ class ComicRepository(ComicInterface):
 
     def bulk_delete(self, ids: list[int]) -> None:
         Comic.objects.filter(id__in=ids).delete()
+
+    def count(self, filter: FilterOption) -> int:
+        return Comic.objects.filter(*filter_q_list(filter)).distinct().count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Comic.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/index.py
+++ b/myus/api/src/domain/entity/media/index.py
@@ -1,10 +1,11 @@
 from datetime import timedelta
 from typing import TypeVar
-from django.db.models import Count, ExpressionWrapper, F, FloatField, Func, Model, Q
+from django.db.models import Case, Count, Exists, ExpressionWrapper, F, FloatField, Func, Model, OuterRef, Q, Value, When
 from django.db.models.functions import Now
 from django.db.models.query import QuerySet
 from django.utils import timezone
-from api.src.domain.interface.media.index import RECOMMEND_DAYS, SortOption, SortType
+from api.db.models.subscribe import Subscribe
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, RECOMMEND_DAYS, SortOption, SortType
 
 T = TypeVar("T", bound=Model)
 
@@ -23,20 +24,45 @@ def filter_search(search: str) -> Q:
     return Q(title__icontains=search) | Q(hashtag__jp_name=search)
 
 
-def sort_queryset(qs: QuerySet[T], sort: SortOption, is_recommend: bool = False) -> tuple[QuerySet[T], str]:
+def filter_q_list(filter: FilterOption, exclude: ExcludeOption | None = None) -> list[Q]:
+    q_list: list[Q] = []
+    if filter.ulid:
+        q_list.append(Q(ulid=filter.ulid))
+    if filter.publish is not None:
+        q_list.append(Q(publish=filter.publish))
+    if filter.owner_id:
+        q_list.append(Q(channel__owner_id=filter.owner_id))
+    if filter.channel_id:
+        q_list.append(Q(channel_id=filter.channel_id))
+    if filter.category_id:
+        q_list.append(Q(category__id=filter.category_id))
+    if filter.is_recommend:
+        q_list.append(filter_recommend())
+    if filter.search:
+        q_list.append(filter_search(filter.search))
+    if exclude and exclude.id:
+        q_list.append(~Q(id=exclude.id))
+    return q_list
+
+
+def sort_queryset(qs: QuerySet[T], sort: SortOption, is_recommend: bool = False, user_id: int | None = None) -> tuple[QuerySet[T], str]:
     if sort.sort_type == SortType.SCORE:
         like_count = Count("like")
         if is_recommend:
             days_since = DaysSince(F("created"), Now())
-            qs = qs.annotate(
-                score=ExpressionWrapper(like_count * 1000.0 / (F("read") + 1) / days_since, output_field=FloatField()),
-            )
+            score_expr = ExpressionWrapper(like_count * 1000.0 / (F("read") + 1) / days_since, output_field=FloatField())
         else:
-            qs = qs.annotate(
-                score=ExpressionWrapper(F("read") + like_count * 10 + F("read") * like_count / (F("read") + 1) * 20, output_field=FloatField()),
-            )
-        order_by_key = "score" if sort.is_asc else "-score"
+            base = F("read") + like_count * 10 + F("read") * like_count / (F("read") + 1) * 20
+            if user_id is not None:
+                is_subscribed = Exists(Subscribe.objects.filter(user_id=user_id, channel=OuterRef("channel"), is_subscribe=True))
+                multiplier = Case(When(is_subscribed, then=Value(2.0)), default=Value(1.0), output_field=FloatField())
+                score_expr = ExpressionWrapper(base * multiplier, output_field=FloatField())
+            else:
+                score_expr = ExpressionWrapper(base, output_field=FloatField())
+        qs = qs.annotate(score=score_expr)
+        key = "score"
     else:
-        field_name = sort.sort_type.name.lower()
-        order_by_key = field_name if sort.is_asc else f"-{field_name}"
+        key = sort.sort_type.name.lower()
+
+    order_by_key = key if sort.is_asc else f"-{key}"
     return qs, order_by_key

--- a/myus/api/src/domain/entity/media/music/repository.py
+++ b/myus/api/src/domain/entity/media/music/repository.py
@@ -1,12 +1,11 @@
-from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.media import Music
 from api.src.domain.entity.media.music._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_recommend, filter_search, sort_queryset
+from api.src.domain.entity.media.index import filter_q_list, sort_queryset
 from api.src.domain.interface.media.music.data import MusicData
 from api.src.domain.interface.media.music.interface import MusicInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 
 
 MUSIC_FIELDS = ["channel_id", "title", "content", "lyric", "music", "read", "download", "publish"]
@@ -16,32 +15,11 @@ class MusicRepository(MusicInterface):
     def queryset(self) -> QuerySet[Music]:
         return Music.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
-        q_list: list[Q] = []
-        if filter.ulid:
-            q_list.append(Q(ulid=filter.ulid))
-        if filter.publish is not None:
-            q_list.append(Q(publish=filter.publish))
-        if filter.owner_id:
-            q_list.append(Q(channel__owner_id=filter.owner_id))
-        if filter.channel_id:
-            q_list.append(Q(channel_id=filter.channel_id))
-        if filter.category_id:
-            q_list.append(Q(category__id=filter.category_id))
-        if filter.is_recommend:
-            q_list.append(filter_recommend())
-        if filter.search:
-            q_list.append(filter_search(filter.search))
-        if exclude.id:
-            q_list.append(~Q(id=exclude.id))
-
-        qs = Music.objects.filter(*q_list).distinct()
-        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend)
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
+        qs = Music.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
-
-        if limit is not None:
-            qs = qs[:limit]
-
+        qs = qs[page.offset:page.offset + page.limit]
         return list(qs.values_list("id", flat=True))
 
     def bulk_get(self, ids: list[int]) -> list[MusicData]:
@@ -69,6 +47,9 @@ class MusicRepository(MusicInterface):
 
     def bulk_delete(self, ids: list[int]) -> None:
         Music.objects.filter(id__in=ids).delete()
+
+    def count(self, filter: FilterOption) -> int:
+        return Music.objects.filter(*filter_q_list(filter)).distinct().count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Music.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/picture/repository.py
+++ b/myus/api/src/domain/entity/media/picture/repository.py
@@ -1,12 +1,11 @@
-from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.media import Picture
 from api.src.domain.entity.media.picture._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_recommend, filter_search, sort_queryset
+from api.src.domain.entity.media.index import filter_q_list, sort_queryset
 from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.picture.interface import PictureInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 
 
 PICTURE_FIELDS = ["channel_id", "title", "content", "image", "read", "publish"]
@@ -16,32 +15,11 @@ class PictureRepository(PictureInterface):
     def queryset(self) -> QuerySet[Picture]:
         return Picture.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
-        q_list: list[Q] = []
-        if filter.ulid:
-            q_list.append(Q(ulid=filter.ulid))
-        if filter.publish is not None:
-            q_list.append(Q(publish=filter.publish))
-        if filter.owner_id:
-            q_list.append(Q(channel__owner_id=filter.owner_id))
-        if filter.channel_id:
-            q_list.append(Q(channel_id=filter.channel_id))
-        if filter.category_id:
-            q_list.append(Q(category__id=filter.category_id))
-        if filter.is_recommend:
-            q_list.append(filter_recommend())
-        if filter.search:
-            q_list.append(filter_search(filter.search))
-        if exclude.id:
-            q_list.append(~Q(id=exclude.id))
-
-        qs = Picture.objects.filter(*q_list).distinct()
-        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend)
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
+        qs = Picture.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
-
-        if limit is not None:
-            qs = qs[:limit]
-
+        qs = qs[page.offset:page.offset + page.limit]
         return list(qs.values_list("id", flat=True))
 
     def bulk_get(self, ids: list[int]) -> list[PictureData]:
@@ -69,6 +47,9 @@ class PictureRepository(PictureInterface):
 
     def bulk_delete(self, ids: list[int]) -> None:
         Picture.objects.filter(id__in=ids).delete()
+
+    def count(self, filter: FilterOption) -> int:
+        return Picture.objects.filter(*filter_q_list(filter)).distinct().count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Picture.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -1,12 +1,11 @@
-from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.media import Video
 from api.src.domain.entity.media.video._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_recommend, filter_search, sort_queryset
+from api.src.domain.entity.media.index import filter_q_list, sort_queryset
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 
 
 VIDEO_FIELDS = ["channel_id", "title", "content", "image", "video", "convert", "read", "publish"]
@@ -16,32 +15,11 @@ class VideoRepository(VideoInterface):
     def queryset(self) -> QuerySet[Video]:
         return Video.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
-        q_list: list[Q] = []
-        if filter.ulid:
-            q_list.append(Q(ulid=filter.ulid))
-        if filter.publish is not None:
-            q_list.append(Q(publish=filter.publish))
-        if filter.owner_id:
-            q_list.append(Q(channel__owner_id=filter.owner_id))
-        if filter.channel_id:
-            q_list.append(Q(channel_id=filter.channel_id))
-        if filter.category_id:
-            q_list.append(Q(category__id=filter.category_id))
-        if filter.is_recommend:
-            q_list.append(filter_recommend())
-        if filter.search:
-            q_list.append(filter_search(filter.search))
-        if exclude.id:
-            q_list.append(~Q(id=exclude.id))
-
-        qs = Video.objects.filter(*q_list).distinct()
-        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend)
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
+        qs = Video.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
-
-        if limit is not None:
-            qs = qs[:limit]
-
+        qs = qs[page.offset:page.offset + page.limit]
         return list(qs.values_list("id", flat=True))
 
     def bulk_get(self, ids: list[int]) -> list[VideoData]:
@@ -69,6 +47,9 @@ class VideoRepository(VideoInterface):
 
     def bulk_delete(self, ids: list[int]) -> None:
         Video.objects.filter(id__in=ids).delete()
+
+    def count(self, filter: FilterOption) -> int:
+        return Video.objects.filter(*filter_q_list(filter)).distinct().count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Video.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/interface/media/blog/interface.py
+++ b/myus/api/src/domain/interface/media/blog/interface.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.media.blog.data import BlogData
 
 
 class BlogInterface(ABC):
     @abstractmethod
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         ...
 
     @abstractmethod
@@ -18,6 +18,10 @@ class BlogInterface(ABC):
 
     @abstractmethod
     def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
+    def count(self, filter: FilterOption) -> int:
         ...
 
     @abstractmethod

--- a/myus/api/src/domain/interface/media/chat/interface.py
+++ b/myus/api/src/domain/interface/media/chat/interface.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.media.chat.data import ChatData
 
 
 class ChatInterface(ABC):
     @abstractmethod
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         ...
 
     @abstractmethod
@@ -18,6 +18,10 @@ class ChatInterface(ABC):
 
     @abstractmethod
     def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
+    def count(self, filter: FilterOption) -> int:
         ...
 
     @abstractmethod

--- a/myus/api/src/domain/interface/media/comic/interface.py
+++ b/myus/api/src/domain/interface/media/comic/interface.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.media.comic.data import ComicData
 
 
 class ComicInterface(ABC):
     @abstractmethod
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         ...
 
     @abstractmethod
@@ -18,6 +18,10 @@ class ComicInterface(ABC):
 
     @abstractmethod
     def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
+    def count(self, filter: FilterOption) -> int:
         ...
 
     @abstractmethod

--- a/myus/api/src/domain/interface/media/index.py
+++ b/myus/api/src/domain/interface/media/index.py
@@ -32,3 +32,9 @@ class SortOption:
 @dataclass(frozen=True, slots=True)
 class ExcludeOption:
     id: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class PageOption:
+    limit: int = 50
+    offset: int = 0

--- a/myus/api/src/domain/interface/media/music/interface.py
+++ b/myus/api/src/domain/interface/media/music/interface.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.media.music.data import MusicData
 
 
 class MusicInterface(ABC):
     @abstractmethod
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         ...
 
     @abstractmethod
@@ -18,6 +18,10 @@ class MusicInterface(ABC):
 
     @abstractmethod
     def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
+    def count(self, filter: FilterOption) -> int:
         ...
 
     @abstractmethod

--- a/myus/api/src/domain/interface/media/picture/interface.py
+++ b/myus/api/src/domain/interface/media/picture/interface.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.media.picture.data import PictureData
 
 
 class PictureInterface(ABC):
     @abstractmethod
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         ...
 
     @abstractmethod
@@ -18,6 +18,10 @@ class PictureInterface(ABC):
 
     @abstractmethod
     def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
+    def count(self, filter: FilterOption) -> int:
         ...
 
     @abstractmethod

--- a/myus/api/src/domain/interface/media/video/interface.py
+++ b/myus/api/src/domain/interface/media/video/interface.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, SortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.media.video.data import VideoData
 
 
 class VideoInterface(ABC):
     @abstractmethod
-    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, limit: int | None = None) -> list[int]:
+    def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         ...
 
     @abstractmethod
@@ -18,6 +18,10 @@ class VideoInterface(ABC):
 
     @abstractmethod
     def bulk_delete(self, ids: list[int]) -> None:
+        ...
+
+    @abstractmethod
+    def count(self, filter: FilterOption) -> int:
         ...
 
     @abstractmethod

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -71,6 +71,36 @@ class ChatOut(MediaOut):
     period: datetime
 
 
+class VideoListOut(BaseModel):
+    datas: list[VideoOut]
+    total: int
+
+
+class MusicListOut(BaseModel):
+    datas: list[MusicOut]
+    total: int
+
+
+class BlogListOut(BaseModel):
+    datas: list[BlogOut]
+    total: int
+
+
+class ComicListOut(BaseModel):
+    datas: list[ComicOut]
+    total: int
+
+
+class PictureListOut(BaseModel):
+    datas: list[PictureOut]
+    total: int
+
+
+class ChatListOut(BaseModel):
+    datas: list[ChatOut]
+    total: int
+
+
 class HomeOut(BaseModel):
     videos: list[VideoOut]
     musics: list[MusicOut]

--- a/myus/api/src/usecase/media.py
+++ b/myus/api/src/usecase/media.py
@@ -14,7 +14,7 @@ from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.chat.interface import ChatInterface
-from api.src.domain.interface.media.index import FilterOption, SortOption, SortType, ExcludeOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption, SortType
 from api.src.injectors.container import injector
 from api.src.types.dto.media import MediaCreateDTO, HomeDTO, VideoDetailDTO, MusicDetailDTO, BlogDetailDTO, ComicDetailDTO, PictureDetailDTO, ChatDetailDTO
 from api.src.types.schema.media.input import VideoIn, MusicIn, BlogIn, ComicIn, PictureIn, ChatIn
@@ -226,34 +226,31 @@ def create_chat(input: ChatIn) -> MediaCreateDTO | None:
 
 
 def get_home(limit: int, search: str) -> HomeDTO:
-    data = HomeDTO(
-        videos=get_videos(limit, search),
-        musics=get_musics(limit, search),
-        blogs=get_blogs(limit, search),
-        comics=get_comics(limit, search),
-        pictures=get_pictures(limit, search),
-        chats=get_chats(limit, search),
-    )
-    return data
+    videos, _ = get_videos(limit, 0, search)
+    musics, _ = get_musics(limit, 0, search)
+    blogs, _ = get_blogs(limit, 0, search)
+    comics, _ = get_comics(limit, 0, search)
+    pictures, _ = get_pictures(limit, 0, search)
+    chats, _ = get_chats(limit, 0, search)
+    return HomeDTO(videos=videos, musics=musics, blogs=blogs, comics=comics, pictures=pictures, chats=chats)
 
 
 def get_recommend(limit: int, search: str) -> HomeDTO:
-    data = HomeDTO(
-        videos=get_videos(limit, search, is_recommend=True),
-        musics=get_musics(limit, search, is_recommend=True),
-        blogs=get_blogs(limit, search, is_recommend=True),
-        comics=get_comics(limit, search, is_recommend=True),
-        pictures=get_pictures(limit, search, is_recommend=True),
-        chats=get_chats(limit, search, is_recommend=True),
-    )
-    return data
+    videos, _ = get_videos(limit, 0, search, is_recommend=True)
+    musics, _ = get_musics(limit, 0, search, is_recommend=True)
+    blogs, _ = get_blogs(limit, 0, search, is_recommend=True)
+    comics, _ = get_comics(limit, 0, search, is_recommend=True)
+    pictures, _ = get_pictures(limit, 0, search, is_recommend=True)
+    chats, _ = get_chats(limit, 0, search, is_recommend=True)
+    return HomeDTO(videos=videos, musics=musics, blogs=blogs, comics=comics, pictures=pictures, chats=chats)
 
 
-def get_videos(limit: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False) -> list[VideoData]:
+def get_videos(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[VideoData], int]:
     repository = injector.get(VideoInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
-    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, limit)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, PageOption(limit=limit, offset=offset), user_id)
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o,
@@ -262,34 +259,37 @@ def get_videos(limit: int, search: str, id: int = 0, channel_id: int = 0, is_rec
         convert=create_url(o.convert),
     ) for o in objs]
 
-    return data
+    return data, total
 
 
-def get_musics(limit: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False) -> list[MusicData]:
+def get_musics(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[MusicData], int]:
     repository = injector.get(MusicInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
-    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, limit)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, PageOption(limit=limit, offset=offset), user_id)
     objs = repository.bulk_get(ids=ids)
     data = [replace(o, music=create_url(o.music)) for o in objs]
-    return data
+    return data, total
 
 
-def get_blogs(limit: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False) -> list[BlogData]:
+def get_blogs(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[BlogData], int]:
     repository = injector.get(BlogInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
-    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, limit)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, PageOption(limit=limit, offset=offset), user_id)
     objs = repository.bulk_get(ids=ids)
     data = [replace(o, image=create_url(o.image)) for o in objs]
-    return data
+    return data, total
 
 
-def get_comics(limit: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False) -> list[ComicData]:
+def get_comics(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[ComicData], int]:
     repository = injector.get(ComicInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
-    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, limit)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, PageOption(limit=limit, offset=offset), user_id)
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o,
@@ -297,31 +297,33 @@ def get_comics(limit: int, search: str, id: int = 0, channel_id: int = 0, is_rec
         pages=[create_url(p) for p in o.pages],
     ) for o in objs]
 
-    return data
+    return data, total
 
 
-def get_pictures(limit: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False) -> list[PictureData]:
+def get_pictures(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[PictureData], int]:
     repository = injector.get(PictureInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
-    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, limit)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, PageOption(limit=limit, offset=offset), user_id)
     objs = repository.bulk_get(ids=ids)
     data = [replace(o, image=create_url(o.image)) for o in objs]
-    return data
+    return data, total
 
 
-def get_chats(limit: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False) -> list[ChatData]:
+def get_chats(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[ChatData], int]:
     repository = injector.get(ChatInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
-    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, limit)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(id=id), sort, PageOption(limit=limit, offset=offset), user_id)
     objs = repository.bulk_get(ids=ids)
-    return objs
+    return objs, total
 
 
 def get_video_detail(user_id: int | None, ulid: str, publish: bool = True) -> VideoDetailDTO:
     repository = injector.get(VideoInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption(), PageOption(limit=1))
     assert len(ids) == 1, "データが見つかりませんでした"
     objs = repository.bulk_get(ids=ids)
     obj = objs[0]
@@ -354,7 +356,7 @@ def get_video_detail(user_id: int | None, ulid: str, publish: bool = True) -> Vi
 
 def get_music_detail(user_id: int | None, ulid: str, publish: bool = True) -> MusicDetailDTO:
     repository = injector.get(MusicInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption(), PageOption(limit=1))
     assert len(ids) == 1, "データが見つかりませんでした"
     objs = repository.bulk_get(ids=ids)
     obj = objs[0]
@@ -387,7 +389,7 @@ def get_music_detail(user_id: int | None, ulid: str, publish: bool = True) -> Mu
 
 def get_blog_detail(user_id: int | None, ulid: str, publish: bool = True) -> BlogDetailDTO:
     repository = injector.get(BlogInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption(), PageOption(limit=1))
     assert len(ids) == 1, "データが見つかりませんでした"
     objs = repository.bulk_get(ids=ids)
     obj = objs[0]
@@ -419,7 +421,7 @@ def get_blog_detail(user_id: int | None, ulid: str, publish: bool = True) -> Blo
 
 def get_comic_detail(user_id: int | None, ulid: str, publish: bool = True) -> ComicDetailDTO:
     repository = injector.get(ComicInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption(), PageOption(limit=1))
     assert len(ids) == 1, "データが見つかりませんでした"
     objs = repository.bulk_get(ids=ids)
     obj = objs[0]
@@ -451,7 +453,7 @@ def get_comic_detail(user_id: int | None, ulid: str, publish: bool = True) -> Co
 
 def get_picture_detail(user_id: int | None, ulid: str, publish: bool = True) -> PictureDetailDTO:
     repository = injector.get(PictureInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption(), PageOption(limit=1))
     assert len(ids) == 1, "データが見つかりませんでした"
     objs = repository.bulk_get(ids=ids)
     obj = objs[0]
@@ -482,7 +484,7 @@ def get_picture_detail(user_id: int | None, ulid: str, publish: bool = True) -> 
 
 def get_chat_detail(user_id: int | None, ulid: str, publish: bool = True) -> ChatDetailDTO:
     repository = injector.get(ChatInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=publish), ExcludeOption(), SortOption(), PageOption(limit=1))
     assert len(ids) == 1, "データが見つかりませんでした"
     objs = repository.bulk_get(ids=ids)
     obj = objs[0]


### PR DESCRIPTION
## Summary
- メディア一覧 API (\`/api/media/{type}/\`) に \`limit\` / \`offset\` + レスポンスに \`total\` を追加したサーバサイドページング実装
- ログインユーザーがチャンネル登録しているコンテンツは Normal モードで score × 2 ブーストされるように
- 横断する共通ロジック（フィルタ Q 構築・ソート・ページング）を \`domain/entity/media/index.py\` のヘルパーに集約

## API 契約
\`\`\`
GET /api/media/{type}/?search=...&limit=50&offset=0
→ { datas: [...], total: N }
\`\`\`

## 変更内容

### Domain 層
- **interface/media/index.py** — \`PageOption(limit: int = 50, offset: int = 0)\` を追加
- **entity/media/index.py**
  - \`filter_q_list(filter, exclude=None) -> list[Q]\` を追加（各 repo に散らばっていた Q 構築を一本化）
  - \`sort_queryset\` に \`user_id: int | None\` を追加。Normal スコアで Subscribe EXISTS を使った **× 2 倍率ブースト**を適用
  - \`score\` 式の \`qs.annotate()\` 呼び出しを 1 箇所に集約、降順／昇順の \`-\` 付与も末尾で統一
- **interface/media/\*/interface.py** (6 ファイル) — \`get_ids\` シグネチャを \`(filter, exclude, sort, page, user_id)\` に統一、\`count(filter)\` を追加
- **entity/media/\*/repository.py** (6 ファイル)
  - \`get_ids\` / \`count\` を \`filter_q_list\` 利用形にリファクタ（約 190 行削減）
  - LIMIT/OFFSET は \`qs[page.offset:page.offset + page.limit]\` にインライン化
  - メソッド並び順を統一（\`get_ids → bulk_get → bulk_save → bulk_delete → count → is_liked\`）

### Usecase 層
- **usecase/media.py**
  - \`get_xxx(limit, search, ..., offset=0, user_id=None) -> tuple[list, int]\` に統一
  - 以前あった \`list_xxx\` は削除（\`get_xxx\` に機能統合）
  - \`get_home\` / \`get_recommend\` / detail 系は tuple unpack に追従（\`_\` で total を破棄）

### Adapter 層
- **adapter/media.py**
  - 6 list エンドポイントで \`auth_check(request)\` から \`user_id\` 取得、\`get_xxx\` に渡してブースト適用
  - レスポンスを \`VideoListOut { datas, total }\` 形式に変更
  - detail 系は \`get_videos(50, search, obj.id)\` のように tuple unpack に更新

### Schema 層
- **types/schema/media/output.py** — \`VideoListOut\`, \`MusicListOut\`, \`BlogListOut\`, \`ComicListOut\`, \`PictureListOut\`, \`ChatListOut\` を追加（\`{ datas, total }\`）

## 備考
- FE 側は別 PR で対応済み (#736)。両 PR が揃うまでは FE と BE のレスポンス形式が合わないためマージ順序に注意
- \`period\` 関連の pre-existing な mypy エラー 2 件は本 PR 対象外（元から存在）