### PR TITLE
【front】メディア一覧のページネーションに useServerPagination フックを導入

### DIFF
--- a/frontend/src/components/hooks/useServerPagination.ts
+++ b/frontend/src/components/hooks/useServerPagination.ts
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router'
+import { PAGE_SIZE } from 'utils/functions/common'
+
+interface ServerPagination {
+  currentPage: number
+  totalPages: number
+  handlePage: (page: number) => void
+}
+
+export function useServerPagination(total: number, page: number): ServerPagination {
+  const router = useRouter()
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.min(page, totalPages)
+
+  const handlePage = (p: number) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return { currentPage, totalPages, handlePage }
+}

--- a/frontend/src/components/templates/media/blog/list.tsx
+++ b/frontend/src/components/templates/media/blog/list.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
 import { Blog } from 'types/internal/media/output'
-import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
+import { useServerPagination } from 'components/hooks/useServerPagination'
 import Main from 'components/layout/Main'
 import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
@@ -16,18 +15,13 @@ interface Props {
 export default function Blogs(props: Props): React.JSX.Element {
   const { datas, total, page } = props
 
-  const router = useRouter()
   const search = useSearch(total)
-  const totalPages = Math.ceil(total / PAGE_SIZE)
-
-  const handlePage = (p: number) => {
-    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
-  }
+  const { currentPage, totalPages, handlePage } = useServerPagination(total, page)
 
   return (
     <Main title="Blog" search={search}>
       <CardList items={datas} Content={BlogCard} />
-      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/chat/list.tsx
+++ b/frontend/src/components/templates/media/chat/list.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
 import { Chat } from 'types/internal/media/output'
-import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
+import { useServerPagination } from 'components/hooks/useServerPagination'
 import Main from 'components/layout/Main'
 import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
@@ -16,18 +15,13 @@ interface Props {
 export default function Chats(props: Props): React.JSX.Element {
   const { datas, total, page } = props
 
-  const router = useRouter()
   const search = useSearch(total)
-  const totalPages = Math.ceil(total / PAGE_SIZE)
-
-  const handlePage = (p: number) => {
-    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
-  }
+  const { currentPage, totalPages, handlePage } = useServerPagination(total, page)
 
   return (
     <Main title="Chat" search={search}>
       <CardList items={datas} Content={ChatCard} />
-      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/comic/list.tsx
+++ b/frontend/src/components/templates/media/comic/list.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
 import { Comic } from 'types/internal/media/output'
-import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
+import { useServerPagination } from 'components/hooks/useServerPagination'
 import Main from 'components/layout/Main'
 import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
@@ -16,18 +15,13 @@ interface Props {
 export default function Comics(props: Props): React.JSX.Element {
   const { datas, total, page } = props
 
-  const router = useRouter()
   const search = useSearch(total)
-  const totalPages = Math.ceil(total / PAGE_SIZE)
-
-  const handlePage = (p: number) => {
-    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
-  }
+  const { currentPage, totalPages, handlePage } = useServerPagination(total, page)
 
   return (
     <Main title="Comic" search={search}>
       <CardList items={datas} Content={ComicCard} />
-      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/music/list.tsx
+++ b/frontend/src/components/templates/media/music/list.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
 import { Music } from 'types/internal/media/output'
-import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
+import { useServerPagination } from 'components/hooks/useServerPagination'
 import Main from 'components/layout/Main'
 import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
@@ -16,18 +15,13 @@ interface Props {
 export default function Musics(props: Props): React.JSX.Element {
   const { datas, total, page } = props
 
-  const router = useRouter()
   const search = useSearch(total)
-  const totalPages = Math.ceil(total / PAGE_SIZE)
-
-  const handlePage = (p: number) => {
-    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
-  }
+  const { currentPage, totalPages, handlePage } = useServerPagination(total, page)
 
   return (
     <Main title="Music" search={search}>
       <CardList items={datas} Content={MusicCard} />
-      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/picture/list.tsx
+++ b/frontend/src/components/templates/media/picture/list.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
 import { Picture } from 'types/internal/media/output'
-import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
+import { useServerPagination } from 'components/hooks/useServerPagination'
 import Main from 'components/layout/Main'
 import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
@@ -16,18 +15,13 @@ interface Props {
 export default function Pictures(props: Props): React.JSX.Element {
   const { datas, total, page } = props
 
-  const router = useRouter()
   const search = useSearch(total)
-  const totalPages = Math.ceil(total / PAGE_SIZE)
-
-  const handlePage = (p: number) => {
-    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
-  }
+  const { currentPage, totalPages, handlePage } = useServerPagination(total, page)
 
   return (
     <Main title="Picture" search={search}>
       <CardList items={datas} Content={PictureCard} />
-      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/video/list.tsx
+++ b/frontend/src/components/templates/media/video/list.tsx
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
 import { Video } from 'types/internal/media/output'
-import { PAGE_SIZE } from 'utils/functions/common'
 import { useSearch } from 'components/hooks/useSearch'
+import { useServerPagination } from 'components/hooks/useServerPagination'
 import Main from 'components/layout/Main'
 import Pagination from 'components/parts/Pagination'
 import CardList from 'components/widgets/Card/List'
@@ -16,18 +15,13 @@ interface Props {
 export default function Videos(props: Props): React.JSX.Element {
   const { datas, total, page } = props
 
-  const router = useRouter()
   const search = useSearch(total)
-  const totalPages = Math.ceil(total / PAGE_SIZE)
-
-  const handlePage = (p: number) => {
-    router.push({ pathname: router.pathname, query: { ...router.query, page: p } })
-  }
+  const { currentPage, totalPages, handlePage } = useServerPagination(total, page)
 
   return (
     <Main title="Video" search={search}>
       <CardList items={datas} Content={VideoCard} />
-      <Pagination currentPage={page} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
     </Main>
   )
 }


### PR DESCRIPTION
## Summary
- PR #736 のレビュー指摘対応。サーバサイドページング用の \`useServerPagination\` フックを新設して 6 メディア一覧テンプレートから重複ロジックを集約
- ページ切替時の scroll to top、0 件時の表示崩れ、URL 範囲外 page のクランプを修正

## 変更内容

### 新規ファイル
- **\`components/hooks/useServerPagination.ts\`**
  - \`(total, page)\` を受け取り \`{ currentPage, totalPages, handlePage }\` を返す
  - \`handlePage\`: \`router.push\` でページ遷移 + \`window.scrollTo({ top: 0, behavior: 'smooth' })\` で先頭へスクロール
  - \`totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))\` で下限 1 を保証
  - \`currentPage = Math.min(page, totalPages)\` で URL に範囲外 page が来た場合も最終ページにクランプ

### 6 テンプレート更新 (video / music / blog / comic / picture / chat)
- インラインだった \`handlePage\` / \`totalPages\` / \`currentPage\` 計算をフックに集約
- \`useRouter\` / \`PAGE_SIZE\` の import を削除
- Pagination は常時表示（0 件時も「1 / 1」で矢印 disabled）

## レビュー指摘対応マップ (PR #736)

| 指摘 | 対応 |
|---|---|
| #3 ページ切替でスクロール位置が維持 | \`useServerPagination\` 内で \`window.scrollTo({ top: 0, behavior: 'smooth' })\` |
| #4 totalPages 0 時に「ページ 1 / 0」表示 | \`Math.max(1, ...)\` で下限 1 にし右矢印 disabled を保証 |
| #5 範囲外 page のフォールバック | \`Math.min(page, totalPages)\` で currentPage クランプ |
| #6 search 変更時の page リセット | 既に \`Search/index.tsx\` が新規 query を構築しているため対応不要と確認 |
| #1 PAGE_SIZE BE/FE 整合 | BE default 50 / FE PAGE_SIZE 50 で一致しているため対応不要 |
| #2 useSearch 挙動変更 | 意図した改善（検索結果件数の正しい表示）と確認 |

## 対比: \`usePagination\` ↔ \`useServerPagination\`
| | usePagination（既存） | useServerPagination（新規） |
|---|---|---|
| 用途 | クライアントサイド（manage 系） | サーバサイド（media 系） |
| 状態管理 | \`useState\` | URL クエリ |
| ページ切替 | \`setState\` | \`router.push\` + scroll to top |
| 入力 | \`(datas, pageSize)\` | \`(total, page)\` |
| 戻り値 | \`{ currentPage, totalPages, pageDatas, handlePage }\` | \`{ currentPage, totalPages, handlePage }\` |