### PR TITLE
【back】メディア一覧の DISTINCT 条件化と定数の共通化

### DIFF
--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -23,7 +23,7 @@ from api.src.types.schema.media.output import VideoDetailsOut, MusicDetailsOut, 
 from api.src.types.schema.message import MessageOut
 from api.src.types.schema.channel import ChannelOut
 from api.src.types.schema.user import AuthorOut, MediaUserOut
-from api.src.domain.interface.media.index import DEFAULT_PAGE_SIZE
+from api.src.domain.interface.media.index import PAGE_SIZE
 from api.src.usecase.auth import auth_check
 from api.src.usecase.media import create_video, create_music, create_blog, create_comic, create_picture, create_chat
 from api.src.usecase.media import get_home, get_recommend, get_videos, get_musics, get_blogs, get_comics, get_pictures, get_chats
@@ -102,7 +102,7 @@ class VideoAPI:
 
     @staticmethod
     @router.get("", response={200: VideoListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("VideoAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_videos(limit, offset, search, user_id=user_id)
@@ -163,7 +163,7 @@ class MusicAPI:
 
     @staticmethod
     @router.get("", response={200: MusicListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("MusicAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_musics(limit, offset, search, user_id=user_id)
@@ -224,7 +224,7 @@ class BlogAPI:
 
     @staticmethod
     @router.get("", response={200: BlogListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("BlogAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_blogs(limit, offset, search, user_id=user_id)
@@ -284,7 +284,7 @@ class ComicAPI:
 
     @staticmethod
     @router.get("", response={200: ComicListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("ComicAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_comics(limit, offset, search, user_id=user_id)
@@ -344,7 +344,7 @@ class PictureAPI:
 
     @staticmethod
     @router.get("", response={200: PictureListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("PictureAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_pictures(limit, offset, search, user_id=user_id)
@@ -403,7 +403,7 @@ class ChatAPI:
 
     @staticmethod
     @router.get("", response={200: ChatListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("ChatAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_chats(limit, offset, search, user_id=user_id)

--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -23,6 +23,7 @@ from api.src.types.schema.media.output import VideoDetailsOut, MusicDetailsOut, 
 from api.src.types.schema.message import MessageOut
 from api.src.types.schema.channel import ChannelOut
 from api.src.types.schema.user import AuthorOut, MediaUserOut
+from api.src.domain.interface.media.index import DEFAULT_PAGE_SIZE
 from api.src.usecase.auth import auth_check
 from api.src.usecase.media import create_video, create_music, create_blog, create_comic, create_picture, create_chat
 from api.src.usecase.media import get_home, get_recommend, get_videos, get_musics, get_blogs, get_comics, get_pictures, get_chats
@@ -101,7 +102,7 @@ class VideoAPI:
 
     @staticmethod
     @router.get("", response={200: VideoListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
         log.info("VideoAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_videos(limit, offset, search, user_id=user_id)
@@ -162,7 +163,7 @@ class MusicAPI:
 
     @staticmethod
     @router.get("", response={200: MusicListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
         log.info("MusicAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_musics(limit, offset, search, user_id=user_id)
@@ -223,7 +224,7 @@ class BlogAPI:
 
     @staticmethod
     @router.get("", response={200: BlogListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
         log.info("BlogAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_blogs(limit, offset, search, user_id=user_id)
@@ -283,7 +284,7 @@ class ComicAPI:
 
     @staticmethod
     @router.get("", response={200: ComicListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
         log.info("ComicAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_comics(limit, offset, search, user_id=user_id)
@@ -343,7 +344,7 @@ class PictureAPI:
 
     @staticmethod
     @router.get("", response={200: PictureListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
         log.info("PictureAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_pictures(limit, offset, search, user_id=user_id)
@@ -402,7 +403,7 @@ class ChatAPI:
 
     @staticmethod
     @router.get("", response={200: ChatListOut})
-    def list(request: HttpRequest, search: str = "", limit: int = 24, offset: int = 0):
+    def list(request: HttpRequest, search: str = "", limit: int = DEFAULT_PAGE_SIZE, offset: int = 0):
         log.info("ChatAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
         objs, total = get_chats(limit, offset, search, user_id=user_id)

--- a/myus/api/src/domain/entity/media/blog/repository.py
+++ b/myus/api/src/domain/entity/media/blog/repository.py
@@ -2,7 +2,7 @@ from django.db.models.query import QuerySet
 from api.db.models.media import Blog
 from api.src.domain.entity.media.blog._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_q_list, sort_queryset
+from api.src.domain.entity.media.index import distinct_queryset, filter_q_list, sort_queryset
 from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
@@ -16,7 +16,8 @@ class BlogRepository(BlogInterface):
         return Blog.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
-        qs = Blog.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs = Blog.objects.filter(*filter_q_list(filter, exclude))
+        qs = distinct_queryset(qs, filter)
         qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
         qs = qs[page.offset:page.offset + page.limit]
@@ -49,7 +50,8 @@ class BlogRepository(BlogInterface):
         Blog.objects.filter(id__in=ids).delete()
 
     def count(self, filter: FilterOption) -> int:
-        return Blog.objects.filter(*filter_q_list(filter)).distinct().count()
+        qs = Blog.objects.filter(*filter_q_list(filter))
+        return distinct_queryset(qs, filter).count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Blog.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/chat/repository.py
+++ b/myus/api/src/domain/entity/media/chat/repository.py
@@ -2,7 +2,7 @@ from django.db.models.query import QuerySet
 from api.db.models.media import Chat
 from api.src.domain.entity.media.chat._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_q_list, sort_queryset
+from api.src.domain.entity.media.index import distinct_queryset, filter_q_list, sort_queryset
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
@@ -16,7 +16,8 @@ class ChatRepository(ChatInterface):
         return Chat.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
-        qs = Chat.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs = Chat.objects.filter(*filter_q_list(filter, exclude))
+        qs = distinct_queryset(qs, filter)
         qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
         qs = qs[page.offset:page.offset + page.limit]
@@ -49,7 +50,8 @@ class ChatRepository(ChatInterface):
         Chat.objects.filter(id__in=ids).delete()
 
     def count(self, filter: FilterOption) -> int:
-        return Chat.objects.filter(*filter_q_list(filter)).distinct().count()
+        qs = Chat.objects.filter(*filter_q_list(filter))
+        return distinct_queryset(qs, filter).count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Chat.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/comic/repository.py
+++ b/myus/api/src/domain/entity/media/comic/repository.py
@@ -4,7 +4,7 @@ from django.db.models.query import QuerySet
 from api.db.models.media import Comic, ComicPage
 from api.src.domain.entity.media.comic._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_q_list, sort_queryset
+from api.src.domain.entity.media.index import distinct_queryset, filter_q_list, sort_queryset
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
@@ -19,7 +19,8 @@ class ComicRepository(ComicInterface):
         return Comic.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", pages_prefetch)
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
-        qs = Comic.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs = Comic.objects.filter(*filter_q_list(filter, exclude))
+        qs = distinct_queryset(qs, filter)
         qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
         qs = qs[page.offset:page.offset + page.limit]
@@ -60,7 +61,8 @@ class ComicRepository(ComicInterface):
         Comic.objects.filter(id__in=ids).delete()
 
     def count(self, filter: FilterOption) -> int:
-        return Comic.objects.filter(*filter_q_list(filter)).distinct().count()
+        qs = Comic.objects.filter(*filter_q_list(filter))
+        return distinct_queryset(qs, filter).count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Comic.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/index.py
+++ b/myus/api/src/domain/entity/media/index.py
@@ -5,7 +5,7 @@ from django.db.models.functions import Now
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from api.db.models.subscribe import Subscribe
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, RECOMMEND_DAYS, SortOption, SortType
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, RECOMMEND_DAYS, SortOption, SortType, SUBSCRIBE_BOOST
 
 T = TypeVar("T", bound=Model)
 
@@ -45,6 +45,12 @@ def filter_q_list(filter: FilterOption, exclude: ExcludeOption | None = None) ->
     return q_list
 
 
+def distinct_queryset(qs: QuerySet[T], filter: FilterOption) -> QuerySet[T]:
+    if filter.search or filter.is_recommend or filter.category_id:
+        return qs.distinct()
+    return qs
+
+
 def sort_queryset(qs: QuerySet[T], sort: SortOption, is_recommend: bool = False, user_id: int | None = None) -> tuple[QuerySet[T], str]:
     if sort.sort_type == SortType.SCORE:
         like_count = Count("like")
@@ -55,7 +61,7 @@ def sort_queryset(qs: QuerySet[T], sort: SortOption, is_recommend: bool = False,
             base = F("read") + like_count * 10 + F("read") * like_count / (F("read") + 1) * 20
             if user_id is not None:
                 is_subscribed = Exists(Subscribe.objects.filter(user_id=user_id, channel=OuterRef("channel"), is_subscribe=True))
-                multiplier = Case(When(is_subscribed, then=Value(2.0)), default=Value(1.0), output_field=FloatField())
+                multiplier = Case(When(is_subscribed, then=Value(SUBSCRIBE_BOOST)), default=Value(1.0), output_field=FloatField())
                 score_expr = ExpressionWrapper(base * multiplier, output_field=FloatField())
             else:
                 score_expr = ExpressionWrapper(base, output_field=FloatField())

--- a/myus/api/src/domain/entity/media/music/repository.py
+++ b/myus/api/src/domain/entity/media/music/repository.py
@@ -2,7 +2,7 @@ from django.db.models.query import QuerySet
 from api.db.models.media import Music
 from api.src.domain.entity.media.music._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_q_list, sort_queryset
+from api.src.domain.entity.media.index import distinct_queryset, filter_q_list, sort_queryset
 from api.src.domain.interface.media.music.data import MusicData
 from api.src.domain.interface.media.music.interface import MusicInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
@@ -16,7 +16,8 @@ class MusicRepository(MusicInterface):
         return Music.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
-        qs = Music.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs = Music.objects.filter(*filter_q_list(filter, exclude))
+        qs = distinct_queryset(qs, filter)
         qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
         qs = qs[page.offset:page.offset + page.limit]
@@ -49,7 +50,8 @@ class MusicRepository(MusicInterface):
         Music.objects.filter(id__in=ids).delete()
 
     def count(self, filter: FilterOption) -> int:
-        return Music.objects.filter(*filter_q_list(filter)).distinct().count()
+        qs = Music.objects.filter(*filter_q_list(filter))
+        return distinct_queryset(qs, filter).count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Music.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/picture/repository.py
+++ b/myus/api/src/domain/entity/media/picture/repository.py
@@ -2,7 +2,7 @@ from django.db.models.query import QuerySet
 from api.db.models.media import Picture
 from api.src.domain.entity.media.picture._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_q_list, sort_queryset
+from api.src.domain.entity.media.index import distinct_queryset, filter_q_list, sort_queryset
 from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
@@ -16,7 +16,8 @@ class PictureRepository(PictureInterface):
         return Picture.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
-        qs = Picture.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs = Picture.objects.filter(*filter_q_list(filter, exclude))
+        qs = distinct_queryset(qs, filter)
         qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
         qs = qs[page.offset:page.offset + page.limit]
@@ -49,7 +50,8 @@ class PictureRepository(PictureInterface):
         Picture.objects.filter(id__in=ids).delete()
 
     def count(self, filter: FilterOption) -> int:
-        return Picture.objects.filter(*filter_q_list(filter)).distinct().count()
+        qs = Picture.objects.filter(*filter_q_list(filter))
+        return distinct_queryset(qs, filter).count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Picture.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -2,7 +2,7 @@ from django.db.models.query import QuerySet
 from api.db.models.media import Video
 from api.src.domain.entity.media.video._convert import convert_data, marshal_data
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.media.index import filter_q_list, sort_queryset
+from api.src.domain.entity.media.index import distinct_queryset, filter_q_list, sort_queryset
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
@@ -16,7 +16,8 @@ class VideoRepository(VideoInterface):
         return Video.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
-        qs = Video.objects.filter(*filter_q_list(filter, exclude)).distinct()
+        qs = Video.objects.filter(*filter_q_list(filter, exclude))
+        qs = distinct_queryset(qs, filter)
         qs, order_by_key = sort_queryset(qs, sort, filter.is_recommend, user_id)
         qs = qs.order_by(order_by_key)
         qs = qs[page.offset:page.offset + page.limit]
@@ -49,7 +50,8 @@ class VideoRepository(VideoInterface):
         Video.objects.filter(id__in=ids).delete()
 
     def count(self, filter: FilterOption) -> int:
-        return Video.objects.filter(*filter_q_list(filter)).distinct().count()
+        qs = Video.objects.filter(*filter_q_list(filter))
+        return distinct_queryset(qs, filter).count()
 
     def is_liked(self, media_id: int, user_id: int) -> bool:
         return Video.objects.filter(id=media_id, like__id=user_id).exists()

--- a/myus/api/src/domain/interface/media/index.py
+++ b/myus/api/src/domain/interface/media/index.py
@@ -2,8 +2,10 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
+DEFAULT_PAGE_SIZE = 50
 RECOMMEND_DAYS = 200
 RECOMMEND_MIN_SCORE = 10.0
+SUBSCRIBE_BOOST = 2.0
 
 
 class SortType(Enum):
@@ -36,5 +38,5 @@ class ExcludeOption:
 
 @dataclass(frozen=True, slots=True)
 class PageOption:
-    limit: int = 50
+    limit: int = DEFAULT_PAGE_SIZE
     offset: int = 0

--- a/myus/api/src/domain/interface/media/index.py
+++ b/myus/api/src/domain/interface/media/index.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
-DEFAULT_PAGE_SIZE = 50
+PAGE_SIZE = 50
 RECOMMEND_DAYS = 200
 RECOMMEND_MIN_SCORE = 10.0
 SUBSCRIBE_BOOST = 2.0
@@ -38,5 +38,5 @@ class ExcludeOption:
 
 @dataclass(frozen=True, slots=True)
 class PageOption:
-    limit: int = DEFAULT_PAGE_SIZE
+    limit: int = PAGE_SIZE
     offset: int = 0


### PR DESCRIPTION
## Summary
- PR #737 のレビュー指摘 (#3 / #6 / #7) の対応
- DISTINCT を JOIN 条件があるときだけ適用するよう変更し、通常一覧の DB 負荷を削減
- ハードコードされていた値を定数化（PAGE_SIZE 50 / SUBSCRIBE_BOOST 2.0）

## 変更内容

### Domain interface
- **\`domain/interface/media/index.py\`**
  - \`DEFAULT_PAGE_SIZE = 50\` 定数を追加
  - \`SUBSCRIBE_BOOST = 2.0\` 定数を追加
  - \`PageOption.limit: int = 50\` → \`limit: int = DEFAULT_PAGE_SIZE\` に変更

### Domain entity
- **\`domain/entity/media/index.py\`**
  - \`distinct_queryset(qs, filter)\` ヘルパーを追加
    - \`filter.search\` / \`filter.is_recommend\` / \`filter.category_id\` のいずれか（=M2M JOIN を伴う条件）が指定された時のみ \`qs.distinct()\` を適用
  - \`sort_queryset\` 内のブースト倍率を \`Value(2.0)\` → \`Value(SUBSCRIBE_BOOST)\` に置換

### Repository (6 ファイル)
- **\`domain/entity/media/{video,music,blog,comic,picture,chat}/repository.py\`**
  - \`get_ids\` / \`count\` の \`.distinct()\` 呼び出しを \`distinct_queryset(qs, filter)\` 経由に統一
  - 通常の一覧（検索・レコメンド・カテゴリ条件なし）では DISTINCT が発行されなくなる

### Adapter
- **\`adapter/media.py\`**
  - 6 list エンドポイントの \`limit: int = 24\` → \`limit: int = DEFAULT_PAGE_SIZE\` に変更
  - ドメイン層の \`PageOption\` と adapter のデフォルト値が同じ定数を参照するように

## レビュー指摘マップ (PR #737)

| 指摘 | 対応 |
|---|---|
| #3 \`filter_search\` の DISTINCT コスト | \`distinct_queryset\` で JOIN を伴う filter の時のみ適用 |
| #6 ブースト倍率 \`2.0\` ハードコード | \`SUBSCRIBE_BOOST\` 定数化 |
| #7 PageOption (50) と adapter (24) のデフォルト不整合 | \`DEFAULT_PAGE_SIZE\` 共通定数で統一 |

## 効果

通常一覧の SQL 例:
\`\`\`sql
-- Before
SELECT COUNT(*) FROM (SELECT DISTINCT id FROM video WHERE publish=true) sub
SELECT id FROM video WHERE publish=true ORDER BY ... LIMIT 50

-- After (search/recommend/category なし時)
SELECT COUNT(*) FROM video WHERE publish=true
SELECT id FROM video WHERE publish=true ORDER BY ... LIMIT 50
\`\`\`

検索・レコメンド・カテゴリ絞り込み時は従来通り DISTINCT が付くので重複は防がれる。