### PR TITLE
【back】manage 一覧にサーバサイドページングを導入 + media シグネチャ整理

### DIFF
--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -5,6 +5,8 @@ from api.src.adapter.media import convert_videos, convert_musics, convert_blogs,
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.media.input import BulkDeleteIn, VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
 from api.src.types.schema.media.output import VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut
+from api.src.types.schema.media.output import VideoListOut, MusicListOut, BlogListOut, ComicListOut, PictureListOut, ChatListOut
+from api.src.domain.interface.media.index import PAGE_SIZE
 from api.src.usecase.auth import auth_check
 from api.src.usecase.manage.media import (
     get_manage_videos, get_manage_video, update_manage_video, delete_manage_video,
@@ -22,16 +24,16 @@ class ManageVideoAPI:
     router = Router()
 
     @staticmethod
-    @router.get("", response={200: list[VideoOut], 401: ErrorOut})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ManageVideoAPI list", search=search)
+    @router.get("", response={200: VideoListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", channel: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManageVideoAPI list", search=search, channel=channel, limit=limit, offset=offset)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        objs = get_manage_videos(user_id, search)
-        return 200, convert_videos(objs)
+        objs, total = get_manage_videos(user_id, search, channel, limit, offset)
+        return 200, VideoListOut(datas=convert_videos(objs), total=total)
 
     @staticmethod
     @router.get("/{ulid}", response={200: VideoOut, 401: ErrorOut, 404: ErrorOut})
@@ -83,16 +85,16 @@ class ManageMusicAPI:
     router = Router()
 
     @staticmethod
-    @router.get("", response={200: list[MusicOut], 401: ErrorOut})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ManageMusicAPI list", search=search)
+    @router.get("", response={200: MusicListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", channel: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManageMusicAPI list", search=search, channel=channel, limit=limit, offset=offset)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        objs = get_manage_musics(user_id, search)
-        return 200, convert_musics(objs)
+        objs, total = get_manage_musics(user_id, search, channel, limit, offset)
+        return 200, MusicListOut(datas=convert_musics(objs), total=total)
 
     @staticmethod
     @router.get("/{ulid}", response={200: MusicOut, 401: ErrorOut, 404: ErrorOut})
@@ -144,16 +146,16 @@ class ManageBlogAPI:
     router = Router()
 
     @staticmethod
-    @router.get("", response={200: list[BlogOut], 401: ErrorOut})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ManageBlogAPI list", search=search)
+    @router.get("", response={200: BlogListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", channel: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManageBlogAPI list", search=search, channel=channel, limit=limit, offset=offset)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        objs = get_manage_blogs(user_id, search)
-        return 200, convert_blogs(objs)
+        objs, total = get_manage_blogs(user_id, search, channel, limit, offset)
+        return 200, BlogListOut(datas=convert_blogs(objs), total=total)
 
     @staticmethod
     @router.get("/{ulid}", response={200: BlogOut, 401: ErrorOut, 404: ErrorOut})
@@ -205,16 +207,16 @@ class ManageComicAPI:
     router = Router()
 
     @staticmethod
-    @router.get("", response={200: list[ComicOut], 401: ErrorOut})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ManageComicAPI list", search=search)
+    @router.get("", response={200: ComicListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", channel: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManageComicAPI list", search=search, channel=channel, limit=limit, offset=offset)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        objs = get_manage_comics(user_id, search)
-        return 200, convert_comics(objs)
+        objs, total = get_manage_comics(user_id, search, channel, limit, offset)
+        return 200, ComicListOut(datas=convert_comics(objs), total=total)
 
     @staticmethod
     @router.get("/{ulid}", response={200: ComicOut, 401: ErrorOut, 404: ErrorOut})
@@ -266,16 +268,16 @@ class ManagePictureAPI:
     router = Router()
 
     @staticmethod
-    @router.get("", response={200: list[PictureOut], 401: ErrorOut})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ManagePictureAPI list", search=search)
+    @router.get("", response={200: PictureListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", channel: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManagePictureAPI list", search=search, channel=channel, limit=limit, offset=offset)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        objs = get_manage_pictures(user_id, search)
-        return 200, convert_pictures(objs)
+        objs, total = get_manage_pictures(user_id, search, channel, limit, offset)
+        return 200, PictureListOut(datas=convert_pictures(objs), total=total)
 
     @staticmethod
     @router.get("/{ulid}", response={200: PictureOut, 401: ErrorOut, 404: ErrorOut})
@@ -327,16 +329,16 @@ class ManageChatAPI:
     router = Router()
 
     @staticmethod
-    @router.get("", response={200: list[ChatOut], 401: ErrorOut})
-    def list(request: HttpRequest, search: str = ""):
-        log.info("ManageChatAPI list", search=search)
+    @router.get("", response={200: ChatListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", channel: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManageChatAPI list", search=search, channel=channel, limit=limit, offset=offset)
 
         user_id = auth_check(request)
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        objs = get_manage_chats(user_id, search)
-        return 200, convert_chats(objs)
+        objs, total = get_manage_chats(user_id, search, channel, limit, offset)
+        return 200, ChatListOut(datas=convert_chats(objs), total=total)
 
     @staticmethod
     @router.get("/{ulid}", response={200: ChatOut, 401: ErrorOut, 404: ErrorOut})

--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -105,7 +105,7 @@ class VideoAPI:
     def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("VideoAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
-        objs, total = get_videos(limit, offset, search, user_id=user_id)
+        objs, total = get_videos(search, user_id=user_id, limit=limit, offset=offset)
         data = VideoListOut(datas=convert_videos(objs), total=total)
         return 200, data
 
@@ -116,7 +116,7 @@ class VideoAPI:
 
         user_id = auth_check(request)
         obj = get_video_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs, _ = get_videos(50, 0, search, obj.id)
+        objs, _ = get_videos(search, obj.id)
 
         data = VideoDetailsOut(
             detail=VideoDetailOut(
@@ -166,7 +166,7 @@ class MusicAPI:
     def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("MusicAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
-        objs, total = get_musics(limit, offset, search, user_id=user_id)
+        objs, total = get_musics(search, user_id=user_id, limit=limit, offset=offset)
         data = MusicListOut(datas=convert_musics(objs), total=total)
         return 200, data
 
@@ -177,7 +177,7 @@ class MusicAPI:
 
         user_id = auth_check(request)
         obj = get_music_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs, _ = get_musics(50, 0, search, obj.id)
+        objs, _ = get_musics(search, obj.id)
 
         data = MusicDetailsOut(
             detail=MusicDetailOut(
@@ -227,7 +227,7 @@ class BlogAPI:
     def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("BlogAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
-        objs, total = get_blogs(limit, offset, search, user_id=user_id)
+        objs, total = get_blogs(search, user_id=user_id, limit=limit, offset=offset)
         data = BlogListOut(datas=convert_blogs(objs), total=total)
         return 200, data
 
@@ -238,7 +238,7 @@ class BlogAPI:
 
         user_id = auth_check(request)
         obj = get_blog_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs, _ = get_blogs(50, 0, search, obj.id)
+        objs, _ = get_blogs(search, obj.id)
 
         data = BlogDetailsOut(
             detail=BlogDetailOut(
@@ -287,7 +287,7 @@ class ComicAPI:
     def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("ComicAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
-        objs, total = get_comics(limit, offset, search, user_id=user_id)
+        objs, total = get_comics(search, user_id=user_id, limit=limit, offset=offset)
         data = ComicListOut(datas=convert_comics(objs), total=total)
         return 200, data
 
@@ -298,7 +298,7 @@ class ComicAPI:
 
         user_id = auth_check(request)
         obj = get_comic_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs, _ = get_comics(50, 0, search, obj.id)
+        objs, _ = get_comics(search, obj.id)
 
         data = ComicDetailsOut(
             detail=ComicDetailOut(
@@ -347,7 +347,7 @@ class PictureAPI:
     def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("PictureAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
-        objs, total = get_pictures(limit, offset, search, user_id=user_id)
+        objs, total = get_pictures(search, user_id=user_id, limit=limit, offset=offset)
         data = PictureListOut(datas=convert_pictures(objs), total=total)
         return 200, data
 
@@ -358,7 +358,7 @@ class PictureAPI:
 
         user_id = auth_check(request)
         obj = get_picture_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs, _ = get_pictures(50, 0, search, obj.id)
+        objs, _ = get_pictures(search, obj.id)
 
         data = PictureDetailsOut(
             detail=PictureDetailOut(
@@ -406,7 +406,7 @@ class ChatAPI:
     def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
         log.info("ChatAPI list", search=search, limit=limit, offset=offset)
         user_id = auth_check(request)
-        objs, total = get_chats(limit, offset, search, user_id=user_id)
+        objs, total = get_chats(search, user_id=user_id, limit=limit, offset=offset)
         data = ChatListOut(datas=convert_chats(objs), total=total)
         return 200, data
 
@@ -417,7 +417,7 @@ class ChatAPI:
 
         user_id = auth_check(request)
         obj = get_chat_detail(user_id=user_id, ulid=ulid, publish=True)
-        objs, _ = get_chats(50, 0, search, obj.id)
+        objs, _ = get_chats(search, obj.id)
 
         data = ChatDetailsOut(
             detail=ChatDetailOut(

--- a/myus/api/src/domain/entity/media/index.py
+++ b/myus/api/src/domain/entity/media/index.py
@@ -34,6 +34,8 @@ def filter_q_list(filter: FilterOption, exclude: ExcludeOption | None = None) ->
         q_list.append(Q(channel__owner_id=filter.owner_id))
     if filter.channel_id:
         q_list.append(Q(channel_id=filter.channel_id))
+    if filter.channel_ulid:
+        q_list.append(Q(channel__ulid=filter.channel_ulid))
     if filter.category_id:
         q_list.append(Q(category__id=filter.category_id))
     if filter.is_recommend:

--- a/myus/api/src/domain/interface/media/index.py
+++ b/myus/api/src/domain/interface/media/index.py
@@ -20,6 +20,7 @@ class FilterOption:
     publish: bool | None = None
     owner_id: int = 0
     channel_id: int = 0
+    channel_ulid: str = ""
     category_id: int = 0
     is_recommend: bool = False
     search: str = ""

--- a/myus/api/src/usecase/comment.py
+++ b/myus/api/src/usecase/comment.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from api.modules.logger import log
 from api.src.domain.interface.comment.data import CommentData
 from api.src.domain.interface.comment.interface import CommentInterface, FilterOption, SortOption
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption as MediaFilterOption, SortOption as MediaSortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption as MediaFilterOption, PageOption, SortOption as MediaSortOption
 from api.src.domain.interface.user.interface import UserInterface
 from api.src.injectors.container import injector
 from api.src.types.dto.comment import CommentDTO, ReplyDTO
@@ -102,7 +102,7 @@ def get_comments(type_no: CommentTypeNo, object_id: int, user_id: int | None) ->
 def create_comment(user_id: int, input: CommentCreateIn) -> CommentDTO | None:
     comment_repo = injector.get(CommentInterface)
     media_repo = get_media_repository(MediaType(input.type_name.value))
-    media_ids = media_repo.get_ids(MediaFilterOption(ulid=input.object_ulid, publish=True), ExcludeOption(), MediaSortOption())
+    media_ids = media_repo.get_ids(MediaFilterOption(ulid=input.object_ulid, publish=True), ExcludeOption(), MediaSortOption(), PageOption())
     if len(media_ids) == 0:
         log.warning("メディアが見つかりませんでした")
         return None

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -14,7 +14,7 @@ from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.chat.data import ChatData
 from api.src.domain.interface.media.chat.interface import ChatInterface
-from api.src.domain.interface.media.index import FilterOption, SortOption, ExcludeOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PAGE_SIZE, PageOption, SortOption
 from api.src.injectors.container import injector
 from api.src.types.schema.media.input import VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
 from api.utils.enum.index import ImageUpload
@@ -22,10 +22,11 @@ from api.utils.functions.index import create_url
 from api.utils.functions.media import save_upload
 
 
-def get_manage_videos(user_id: int, search: str) -> list[VideoData]:
+def get_manage_videos(user_id: int, search: str, channel_ulid: str = "", limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[VideoData], int]:
     repository = injector.get(VideoInterface)
-    filter = FilterOption(search=search, owner_id=user_id)
-    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    filter = FilterOption(search=search, owner_id=user_id, channel_ulid=channel_ulid)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o,
@@ -34,12 +35,12 @@ def get_manage_videos(user_id: int, search: str) -> list[VideoData]:
         convert=create_url(o.convert),
     ) for o in objs]
 
-    return data
+    return data, total
 
 
 def get_manage_video(user_id: int, ulid: str) -> VideoData | None:
     repository = injector.get(VideoInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.info("Video not found", ulid=ulid, user_id=user_id)
         return None
@@ -54,7 +55,7 @@ def get_manage_video(user_id: int, ulid: str) -> VideoData | None:
 
 def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(VideoInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.error("Video not found", ulid=ulid)
         return False
@@ -81,7 +82,7 @@ def delete_manage_video(user_id: int, ulids: list[str]) -> bool:
     delete_ids: list[int] = []
 
     for ulid in ulids:
-        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
         if len(ids) == 0:
             log.error("Video not found or owner mismatch", ulid=ulid, user_id=user_id)
             return False
@@ -95,19 +96,20 @@ def delete_manage_video(user_id: int, ulids: list[str]) -> bool:
         return False
 
 
-def get_manage_musics(user_id: int, search: str) -> list[MusicData]:
+def get_manage_musics(user_id: int, search: str, channel_ulid: str = "", limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[MusicData], int]:
     repository = injector.get(MusicInterface)
-    filter = FilterOption(search=search, owner_id=user_id)
-    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    filter = FilterOption(search=search, owner_id=user_id, channel_ulid=channel_ulid)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o, music=create_url(o.music)) for o in objs]
-    return data
+    return data, total
 
 
 def get_manage_music(user_id: int, ulid: str) -> MusicData | None:
     repository = injector.get(MusicInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.info("Music not found", ulid=ulid, user_id=user_id)
         return None
@@ -118,7 +120,7 @@ def get_manage_music(user_id: int, ulid: str) -> MusicData | None:
 
 def update_manage_music(user_id: int, ulid: str, input: MusicUpdateIn) -> bool:
     repository = injector.get(MusicInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.error("Music not found", ulid=ulid)
         return False
@@ -142,7 +144,7 @@ def delete_manage_music(user_id: int, ulids: list[str]) -> bool:
     delete_ids: list[int] = []
 
     for ulid in ulids:
-        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
         if len(ids) == 0:
             log.error("Music not found or owner mismatch", ulid=ulid, user_id=user_id)
             return False
@@ -156,19 +158,20 @@ def delete_manage_music(user_id: int, ulids: list[str]) -> bool:
         return False
 
 
-def get_manage_blogs(user_id: int, search: str) -> list[BlogData]:
+def get_manage_blogs(user_id: int, search: str, channel_ulid: str = "", limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[BlogData], int]:
     repository = injector.get(BlogInterface)
-    filter = FilterOption(search=search, owner_id=user_id)
-    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    filter = FilterOption(search=search, owner_id=user_id, channel_ulid=channel_ulid)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o, image=create_url(o.image)) for o in objs]
-    return data
+    return data, total
 
 
 def get_manage_blog(user_id: int, ulid: str) -> BlogData | None:
     repository = injector.get(BlogInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.info("Blog not found", ulid=ulid, user_id=user_id)
         return None
@@ -179,7 +182,7 @@ def get_manage_blog(user_id: int, ulid: str) -> BlogData | None:
 
 def update_manage_blog(user_id: int, ulid: str, input: BlogUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(BlogInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.error("Blog not found", ulid=ulid)
         return False
@@ -206,7 +209,7 @@ def delete_manage_blog(user_id: int, ulids: list[str]) -> bool:
     delete_ids: list[int] = []
 
     for ulid in ulids:
-        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
         if len(ids) == 0:
             log.error("Blog not found or owner mismatch", ulid=ulid, user_id=user_id)
             return False
@@ -220,22 +223,23 @@ def delete_manage_blog(user_id: int, ulids: list[str]) -> bool:
         return False
 
 
-def get_manage_comics(user_id: int, search: str) -> list[ComicData]:
+def get_manage_comics(user_id: int, search: str, channel_ulid: str = "", limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[ComicData], int]:
     repository = injector.get(ComicInterface)
-    filter = FilterOption(search=search, owner_id=user_id)
-    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    filter = FilterOption(search=search, owner_id=user_id, channel_ulid=channel_ulid)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o,
         image=create_url(o.image),
         pages=[create_url(p) for p in o.pages],
     ) for o in objs]
-    return data
+    return data, total
 
 
 def get_manage_comic(user_id: int, ulid: str) -> ComicData | None:
     repository = injector.get(ComicInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.info("Comic not found", ulid=ulid, user_id=user_id)
         return None
@@ -249,7 +253,7 @@ def get_manage_comic(user_id: int, ulid: str) -> ComicData | None:
 
 def update_manage_comic(user_id: int, ulid: str, input: ComicUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(ComicInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.error("Comic not found", ulid=ulid)
         return False
@@ -276,7 +280,7 @@ def delete_manage_comic(user_id: int, ulids: list[str]) -> bool:
     delete_ids: list[int] = []
 
     for ulid in ulids:
-        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
         if len(ids) == 0:
             log.error("Comic not found or owner mismatch", ulid=ulid, user_id=user_id)
             return False
@@ -290,19 +294,20 @@ def delete_manage_comic(user_id: int, ulids: list[str]) -> bool:
         return False
 
 
-def get_manage_pictures(user_id: int, search: str) -> list[PictureData]:
+def get_manage_pictures(user_id: int, search: str, channel_ulid: str = "", limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[PictureData], int]:
     repository = injector.get(PictureInterface)
-    filter = FilterOption(search=search, owner_id=user_id)
-    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
+    filter = FilterOption(search=search, owner_id=user_id, channel_ulid=channel_ulid)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
     objs = repository.bulk_get(ids=ids)
 
     data = [replace(o, image=create_url(o.image)) for o in objs]
-    return data
+    return data, total
 
 
 def get_manage_picture(user_id: int, ulid: str) -> PictureData | None:
     repository = injector.get(PictureInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.info("Picture not found", ulid=ulid, user_id=user_id)
         return None
@@ -313,7 +318,7 @@ def get_manage_picture(user_id: int, ulid: str) -> PictureData | None:
 
 def update_manage_picture(user_id: int, ulid: str, input: PictureUpdateIn, image: UploadedFile | None = None) -> bool:
     repository = injector.get(PictureInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.error("Picture not found", ulid=ulid)
         return False
@@ -340,7 +345,7 @@ def delete_manage_picture(user_id: int, ulids: list[str]) -> bool:
     delete_ids: list[int] = []
 
     for ulid in ulids:
-        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
         if len(ids) == 0:
             log.error("Picture not found or owner mismatch", ulid=ulid, user_id=user_id)
             return False
@@ -354,16 +359,18 @@ def delete_manage_picture(user_id: int, ulids: list[str]) -> bool:
         return False
 
 
-def get_manage_chats(user_id: int, search: str) -> list[ChatData]:
+def get_manage_chats(user_id: int, search: str, channel_ulid: str = "", limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[ChatData], int]:
     repository = injector.get(ChatInterface)
-    filter = FilterOption(search=search, owner_id=user_id)
-    ids = repository.get_ids(filter, ExcludeOption(), SortOption())
-    return repository.bulk_get(ids=ids)
+    filter = FilterOption(search=search, owner_id=user_id, channel_ulid=channel_ulid)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
+    objs = repository.bulk_get(ids=ids)
+    return objs, total
 
 
 def get_manage_chat(user_id: int, ulid: str) -> ChatData | None:
     repository = injector.get(ChatInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.info("Chat not found", ulid=ulid, user_id=user_id)
         return None
@@ -373,7 +380,7 @@ def get_manage_chat(user_id: int, ulid: str) -> ChatData | None:
 
 def update_manage_chat(user_id: int, ulid: str, input: ChatUpdateIn) -> bool:
     repository = injector.get(ChatInterface)
-    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption())
+    ids = repository.get_ids(FilterOption(ulid=ulid), ExcludeOption(), SortOption(), PageOption())
     if len(ids) == 0:
         log.error("Chat not found", ulid=ulid)
         return False
@@ -397,7 +404,7 @@ def delete_manage_chat(user_id: int, ulids: list[str]) -> bool:
     delete_ids: list[int] = []
 
     for ulid in ulids:
-        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption())
+        ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
         if len(ids) == 0:
             log.error("Chat not found or owner mismatch", ulid=ulid, user_id=user_id)
             return False

--- a/myus/api/src/usecase/media.py
+++ b/myus/api/src/usecase/media.py
@@ -14,7 +14,7 @@ from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.chat.interface import ChatInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption, SortType
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PAGE_SIZE, PageOption, SortOption, SortType
 from api.src.injectors.container import injector
 from api.src.types.dto.media import MediaCreateDTO, HomeDTO, VideoDetailDTO, MusicDetailDTO, BlogDetailDTO, ComicDetailDTO, PictureDetailDTO, ChatDetailDTO
 from api.src.types.schema.media.input import VideoIn, MusicIn, BlogIn, ComicIn, PictureIn, ChatIn
@@ -226,26 +226,26 @@ def create_chat(input: ChatIn) -> MediaCreateDTO | None:
 
 
 def get_home(limit: int, search: str) -> HomeDTO:
-    videos, _ = get_videos(limit, 0, search)
-    musics, _ = get_musics(limit, 0, search)
-    blogs, _ = get_blogs(limit, 0, search)
-    comics, _ = get_comics(limit, 0, search)
-    pictures, _ = get_pictures(limit, 0, search)
-    chats, _ = get_chats(limit, 0, search)
+    videos, _ = get_videos(search, limit=limit)
+    musics, _ = get_musics(search, limit=limit)
+    blogs, _ = get_blogs(search, limit=limit)
+    comics, _ = get_comics(search, limit=limit)
+    pictures, _ = get_pictures(search, limit=limit)
+    chats, _ = get_chats(search, limit=limit)
     return HomeDTO(videos=videos, musics=musics, blogs=blogs, comics=comics, pictures=pictures, chats=chats)
 
 
 def get_recommend(limit: int, search: str) -> HomeDTO:
-    videos, _ = get_videos(limit, 0, search, is_recommend=True)
-    musics, _ = get_musics(limit, 0, search, is_recommend=True)
-    blogs, _ = get_blogs(limit, 0, search, is_recommend=True)
-    comics, _ = get_comics(limit, 0, search, is_recommend=True)
-    pictures, _ = get_pictures(limit, 0, search, is_recommend=True)
-    chats, _ = get_chats(limit, 0, search, is_recommend=True)
+    videos, _ = get_videos(search, is_recommend=True, limit=limit)
+    musics, _ = get_musics(search, is_recommend=True, limit=limit)
+    blogs, _ = get_blogs(search, is_recommend=True, limit=limit)
+    comics, _ = get_comics(search, is_recommend=True, limit=limit)
+    pictures, _ = get_pictures(search, is_recommend=True, limit=limit)
+    chats, _ = get_chats(search, is_recommend=True, limit=limit)
     return HomeDTO(videos=videos, musics=musics, blogs=blogs, comics=comics, pictures=pictures, chats=chats)
 
 
-def get_videos(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[VideoData], int]:
+def get_videos(search: str, id: int = 0, channel_id: int = 0, user_id: int | None = None, is_recommend: bool = False, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[VideoData], int]:
     repository = injector.get(VideoInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
@@ -262,7 +262,7 @@ def get_videos(limit: int, offset: int, search: str, id: int = 0, channel_id: in
     return data, total
 
 
-def get_musics(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[MusicData], int]:
+def get_musics(search: str, id: int = 0, channel_id: int = 0, user_id: int | None = None, is_recommend: bool = False, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[MusicData], int]:
     repository = injector.get(MusicInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
@@ -273,7 +273,7 @@ def get_musics(limit: int, offset: int, search: str, id: int = 0, channel_id: in
     return data, total
 
 
-def get_blogs(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[BlogData], int]:
+def get_blogs(search: str, id: int = 0, channel_id: int = 0, user_id: int | None = None, is_recommend: bool = False, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[BlogData], int]:
     repository = injector.get(BlogInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
@@ -284,7 +284,7 @@ def get_blogs(limit: int, offset: int, search: str, id: int = 0, channel_id: int
     return data, total
 
 
-def get_comics(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[ComicData], int]:
+def get_comics(search: str, id: int = 0, channel_id: int = 0, user_id: int | None = None, is_recommend: bool = False, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[ComicData], int]:
     repository = injector.get(ComicInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
@@ -300,7 +300,7 @@ def get_comics(limit: int, offset: int, search: str, id: int = 0, channel_id: in
     return data, total
 
 
-def get_pictures(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[PictureData], int]:
+def get_pictures(search: str, id: int = 0, channel_id: int = 0, user_id: int | None = None, is_recommend: bool = False, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[PictureData], int]:
     repository = injector.get(PictureInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)
@@ -311,7 +311,7 @@ def get_pictures(limit: int, offset: int, search: str, id: int = 0, channel_id: 
     return data, total
 
 
-def get_chats(limit: int, offset: int, search: str, id: int = 0, channel_id: int = 0, is_recommend: bool = False, user_id: int | None = None) -> tuple[list[ChatData], int]:
+def get_chats(search: str, id: int = 0, channel_id: int = 0, user_id: int | None = None, is_recommend: bool = False, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[ChatData], int]:
     repository = injector.get(ChatInterface)
     filter = FilterOption(search=search, publish=True, channel_id=channel_id, is_recommend=is_recommend)
     sort = SortOption(sort_type=SortType.SCORE)

--- a/myus/api/src/usecase/message.py
+++ b/myus/api/src/usecase/message.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 from datetime import datetime
 from api.modules.logger import log
 from api.src.domain.interface.media.chat.interface import ChatInterface
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption as MediaFilterOption, SortOption as MediaSortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption as MediaFilterOption, PageOption, SortOption as MediaSortOption
 from api.src.domain.interface.message.data import MessageData as MessageDomainData
 from api.src.domain.interface.message.interface import FilterOption, MessageInterface, SortOption
 from api.src.domain.interface.notification.data import NotificationContentData, NotificationData
@@ -72,7 +72,7 @@ def get_replies(message_ulid: str) -> list[MessageReplyDTO]:
 
 def create_message(user_id: int, chat_ulid: str, text: str, parent_ulid: str) -> MessageDTO | None:
     chat_repo = injector.get(ChatInterface)
-    chat_ids = chat_repo.get_ids(MediaFilterOption(ulid=chat_ulid, publish=True), ExcludeOption(), MediaSortOption())
+    chat_ids = chat_repo.get_ids(MediaFilterOption(ulid=chat_ulid, publish=True), ExcludeOption(), MediaSortOption(), PageOption())
     if len(chat_ids) == 0:
         log.warning("チャットが見つかりませんでした", chat_ulid=chat_ulid)
         return None

--- a/myus/api/src/usecase/user.py
+++ b/myus/api/src/usecase/user.py
@@ -5,7 +5,7 @@ from api.db.models.user import User
 from api.modules.logger import log
 from api.src.injectors.container import injector
 from api.src.domain.interface.comment.interface import CommentInterface, FilterOption as CommentFilterOption, SortOption as CommentSortOption
-from api.src.domain.interface.media.index import ExcludeOption, FilterOption as MediaFilterOption, SortOption as MediaSortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption as MediaFilterOption, PageOption, SortOption as MediaSortOption
 from api.src.domain.interface.user.data import ProfileData, UserAllData, UserNotificationData
 from api.src.domain.interface.user.interface import FilterOption, UserInterface
 from api.src.types.dto.user import AuthorDTO, LikeDTO
@@ -134,7 +134,7 @@ def update_notification(user_id: int, input: SettingNotificationIn) -> bool:
 def like_media(user_id: int, media_type: MediaType, ulid: str) -> LikeDTO | None:
     repository = injector.get(UserInterface)
     media_repo = get_media_repository(media_type)
-    ids = media_repo.get_ids(MediaFilterOption(ulid=ulid, publish=True), ExcludeOption(), MediaSortOption())
+    ids = media_repo.get_ids(MediaFilterOption(ulid=ulid, publish=True), ExcludeOption(), MediaSortOption(), PageOption())
     if len(ids) == 0:
         return None
 

--- a/myus/api/src/usecase/userpage.py
+++ b/myus/api/src/usecase/userpage.py
@@ -5,15 +5,13 @@ from api.src.usecase.media import get_videos, get_musics, get_blogs, get_comics,
 
 
 def get_userpage_media(limit: int, search: str, channel_id: int = 0) -> HomeDTO:
-    data = HomeDTO(
-        videos=get_videos(limit, search, channel_id=channel_id),
-        musics=get_musics(limit, search, channel_id=channel_id),
-        blogs=get_blogs(limit, search, channel_id=channel_id),
-        comics=get_comics(limit, search, channel_id=channel_id),
-        pictures=get_pictures(limit, search, channel_id=channel_id),
-        chats=get_chats(limit, search, channel_id=channel_id),
-    )
-    return data
+    videos, _ = get_videos(search, channel_id=channel_id, limit=limit)
+    musics, _ = get_musics(search, channel_id=channel_id, limit=limit)
+    blogs, _ = get_blogs(search, channel_id=channel_id, limit=limit)
+    comics, _ = get_comics(search, channel_id=channel_id, limit=limit)
+    pictures, _ = get_pictures(search, channel_id=channel_id, limit=limit)
+    chats, _ = get_chats(search, channel_id=channel_id, limit=limit)
+    return HomeDTO(videos=videos, musics=musics, blogs=blogs, comics=comics, pictures=pictures, chats=chats)
 
 
 def is_following(follower_id: int, following_id: int) -> bool:


### PR DESCRIPTION
## Summary
- manage 管理画面 API (\`/api/manage/{type}/\`) に \`limit\` / \`offset\` / \`channel\` フィルタを追加し、\`{ datas, total }\` 返却に統一
- media 公開 API 側 \`get_xxx\` のシグネチャを manage と揃った **(search, id, channel_id, user_id, is_recommend, limit, offset)** 順にリファクタ
- \`RELATED_LIMIT\` などのマジックナンバーを \`PAGE_SIZE\` デフォルトへ統合して削除

## API 契約
\`\`\`
GET /api/manage/{type}/?search=...&channel=ulid&limit=50&offset=0
→ { datas: [...], total: N }
\`\`\`

## 変更内容

### Domain
- **\`domain/interface/media/index.py\`**
  - \`FilterOption.channel_ulid: str = ""\` 追加
- **\`domain/entity/media/index.py\`**
  - \`filter_q_list\` で \`Q(channel__ulid=...)\` 対応

### Usecase
- **\`usecase/manage/media.py\`**
  - \`get_manage_xxx\` 6関数を \`(user_id, search, channel_ulid, limit, offset) -> tuple[list, int]\` に統一
  - 他の \`repository.get_ids\` 呼び出しに \`PageOption()\` 追加
- **\`usecase/media.py\`**
  - \`get_videos\` 等 6 関数を **(search, id, channel_id, user_id, is_recommend, limit, offset)** 順に整理
  - \`limit\` / \`offset\` にデフォルト追加 → \`get_home\` / \`get_recommend\` / detail / userpage の呼び出しが簡潔に
- **\`usecase/comment.py\`** / **\`usecase/message.py\`** / **\`usecase/user.py\`**
  - \`media_repo.get_ids\` に \`PageOption()\` 引数追加（interface 変更に追従）
- **\`usecase/userpage.py\`**
  - \`get_xxx\` 呼び出しを kwarg 形式に整理

### Adapter
- **\`adapter/manage.py\`**
  - 6 list エンドポイントを \`VideoListOut\` 等返却に、\`search\` / \`channel\` / \`limit\` / \`offset\` クエリ受け取りに
- **\`adapter/media.py\`**
  - \`RELATED_LIMIT\` 定数を廃止、detail 系の \`limit=50\` を省略して \`PAGE_SIZE\` デフォルトに寄せた
  - 呼び出し側の kwarg 順をシグネチャに合わせて並べ替え

## 統一されたシグネチャパターン

\`\`\`python
# media（公開）
def get_videos(search: str,
               id: int = 0, channel_id: int = 0, user_id: int | None = None,
               is_recommend: bool = False,
               limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[VideoData], int]:

# manage（管理、auth 必須）
def get_manage_videos(user_id: int, search: str,
                      channel_ulid: str = "",
                      limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[VideoData], int]:
\`\`\`

両者とも **\`search\` → \`ID 系 filter\` → \`フラグ\` → \`limit/offset\`** の順で統一。

## 備考
- FE 側（\`pages/manage/*\` / \`templates/manage/*\` / \`api/internal/manage/get.ts\` 等）は別 PR 予定
- 単独マージだと FE 既存コードとレスポンス形式が不整合になるので BE/FE セットでマージする想定
- \`period\` 関連の mypy エラー 2 件は本 PR 対象外（pre-existing）