### PR TITLE
【front】manage トップに認証チェックを追加

### DIFF
--- a/frontend/src/api/internal/user.ts
+++ b/frontend/src/api/internal/user.ts
@@ -26,6 +26,14 @@ export const getUser = async (req?: Req): Promise<ApiOut<UserMe>> => {
   return await apiOut(apiClient('json').get(apiUser, cookieHeader(req)))
 }
 
+export const getUserPage = async (ulid: string, req?: Req): Promise<ApiOut<UserPage>> => {
+  return await apiOut(apiClient('json').get(apiUserPage(ulid), cookieHeader(req)))
+}
+
+export const getUserPageMedia = async (ulid: string, channelUlid: string, req?: Req): Promise<ApiOut<UserPageMedia>> => {
+  return await apiOut(apiClient('json').get(apiUserPageMedia(ulid, channelUlid), cookieHeader(req)))
+}
+
 export const getSearchTag = async (req?: Req): Promise<ApiOut<SearchTagOut[]>> => {
   return await apiOut(apiClient('json').get(apiSearchTag, cookieHeader(req)))
 }
@@ -64,12 +72,4 @@ export const postNotificationConfirmed = async (ulid: string): Promise<ApiOut<Er
 
 export const postNotificationDeleted = async (ulid: string): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').post(apiNotificationDeleted, camelSnake({ ulid })))
-}
-
-export const getUserPage = async (ulid: string, req?: Req): Promise<ApiOut<UserPage>> => {
-  return await apiOut(apiClient('json').get(apiUserPage(ulid), cookieHeader(req)))
-}
-
-export const getUserPageMedia = async (ulid: string, channelUlid: string, req?: Req): Promise<ApiOut<UserPageMedia>> => {
-  return await apiOut(apiClient('json').get(apiUserPageMedia(ulid, channelUlid), cookieHeader(req)))
 }

--- a/frontend/src/components/layout/Header/DropMenu/Cloud.tsx
+++ b/frontend/src/components/layout/Header/DropMenu/Cloud.tsx
@@ -23,7 +23,7 @@ export default function DropMenuCloud(props: Props): React.JSX.Element {
 
   const handleManage = () => {
     if (user.isStaff) router.push('http://127.0.0.1:8000/myus-admin')
-    if (user.isActive) router.push('/manage')
+    router.push('/manage')
     onClose()
   }
 

--- a/frontend/src/components/templates/setting/notification.tsx
+++ b/frontend/src/components/templates/setting/notification.tsx
@@ -43,14 +43,14 @@ export default function SettingNotification(props: Props): React.JSX.Element {
     setValues(ret.value)
   }
 
+  const notificationKeys: (keyof UserNotification)[] = ['isVideo', 'isMusic', 'isBlog', 'isComic', 'isPicture', 'isChat', 'isFollow', 'isReply', 'isLike', 'isViews']
+
   const button = (
     <HStack gap="4">
       <Button color="green" size="s" name="保存" loading={isLoading} onClick={handleSubmit} />
       <Button color="blue" size="s" name="リセット" onClick={handleReset} />
     </HStack>
   )
-
-  const notificationKeys: (keyof UserNotification)[] = ['isVideo', 'isMusic', 'isBlog', 'isComic', 'isPicture', 'isChat', 'isFollow', 'isReply', 'isLike', 'isViews']
 
   return (
     <Main title="通知設定" type="table" toast={toast} button={button}>

--- a/frontend/src/pages/manage/index.tsx
+++ b/frontend/src/pages/manage/index.tsx
@@ -1,12 +1,24 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { getUser } from 'api/internal/user'
+import ErrorCheck from 'components/widgets/Error/Check'
 import Manage from 'components/templates/manage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
+  const ret = await getUser(req)
+  if (ret.isErr()) return { props: { status: ret.error.status } }
   return { props: { ...translations } }
 }
 
-export default function ManagePage(): React.JSX.Element {
-  return <Manage />
+interface Props {
+  status: number
+}
+
+export default function ManagePage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <Manage />
+    </ErrorCheck>
+  )
 }


### PR DESCRIPTION
## Summary
- `/manage` トップに `getUser` 呼び出しを追加し、未ログイン時は Unauthorized 画面に遷移
- DropMenuCloud の `isActive` 判定を除去 (ページ側で認証ガードするため不要)
- 細かい並び順調整 (user.ts / notification.tsx)

## 変更内容

### `frontend/src/pages/manage/index.tsx`
- `getServerSideProps` で `getUser(req)` を呼び、401 を `props.status` に載せる
- 返却値を `ErrorCheck` でラップし、未ログインなら「ログインしてください」画面へ遷移
- 既存の `/manage/blog` などサブページと同じ認証ガードパターンに揃える

### `frontend/src/components/layout/Header/DropMenu/Cloud.tsx`
- `handleManage` から `if (user.isActive)` 判定を削除
- ページ側で認証ガードするようになったため、クリック側で出し分ける必要がなくなった

### `frontend/src/api/internal/user.ts`
- `getUserPage` / `getUserPageMedia` を `getUser` 直後に並び替え (ユーザー系まとめ)

### `frontend/src/components/templates/setting/notification.tsx`
- `notificationKeys` の定義位置を `button` より上に移動 (利用箇所に近い順)