### PR TITLE
【front】config ファイルの ESLint Node 環境を設定

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -14,6 +14,12 @@ export default [
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
   {
+    files: ['*.{js,mjs,cjs}'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,3 @@
-/** @type {import('next').NextConfig} */
-
 import { createRequire } from 'module'
 
 const require = createRequire(import.meta.url)
@@ -7,7 +5,7 @@ const { i18n } = require('./next-i18next.config.js')
 
 export default {
   reactStrictMode: true,
-  reactCompiler: true,
+  reactCompiler: process.env.NODE_ENV === 'production',
   basePath: '',
   i18n,
   images: {


### PR DESCRIPTION
## Summary
- `eslint.config.mjs` にルートの `.js/.mjs/.cjs` 用 `globals.node` ブロックを追加
- `next.config.mjs` の `reactCompiler` を本番ビルド時のみ有効化
- 使われていなかった JSDoc `@type` 注釈を削除

## 変更内容

### `frontend/eslint.config.mjs`
Node で動く config ファイル (`next.config.mjs` など) で `process.env.NODE_ENV` 参照時に `no-undef` が出ていたため、ルートの `.js/.mjs/.cjs` にだけ Node グローバルを渡すブロックを追加。
```js
{
  files: ['*.{js,mjs,cjs}'],
  languageOptions: {
    globals: globals.node,
  },
},
```
ESLint 9 の flat config では `/* eslint-env node */` コメントが非対応になったため、config 側で割り当てる方式に統一。

### `frontend/next.config.mjs`
- `reactCompiler: true` → `reactCompiler: process.env.NODE_ENV === 'production'` に変更し、開発ビルド時は無効化
- JSDoc `@type` 注釈は `tsconfig.json` の `types: ["@types/react", "@types/react-dom"]` 制限により実質機能していなかったため削除