### PR TITLE
【front】Pagination に margin prop を追加して一覧ページの余白を調整

### DIFF
--- a/frontend/src/components/parts/Pagination/Pagination.module.scss
+++ b/frontend/src/components/parts/Pagination/Pagination.module.scss
@@ -3,7 +3,6 @@
   justify-content: center;
   align-items: center;
   gap: 4px;
-  padding: 12px 0;
 
   .ellipsis {
     display: flex;

--- a/frontend/src/components/parts/Pagination/index.tsx
+++ b/frontend/src/components/parts/Pagination/index.tsx
@@ -1,3 +1,4 @@
+import cx from 'utils/functions/cx'
 import ArrowButton from './ArrowButton'
 import PageButton from './PageButton'
 import style from './Pagination.module.scss'
@@ -16,14 +17,17 @@ const calcPages = (current: number, total: number): (number | '...')[] => {
   return pages
 }
 
+type marinType = 'mv_16' | 'mv_24' | 'mv_32' | 'mv_40'
+
 interface Props {
   currentPage: number
   totalPages: number
+  margin?: marinType
   onChange: (page: number) => void
 }
 
 export default function Pagination(props: Props): React.JSX.Element | null {
-  const { currentPage, totalPages, onChange } = props
+  const { currentPage, totalPages, margin = 'mv_16', onChange } = props
 
   const pages = calcPages(currentPage, totalPages)
   const handlePrev = () => onChange(currentPage - 1)
@@ -31,7 +35,7 @@ export default function Pagination(props: Props): React.JSX.Element | null {
   const handlePage = (page: number) => () => onChange(page)
 
   return (
-    <nav className={style.pagination}>
+    <nav className={cx(style.pagination, margin)}>
       <ArrowButton type="left" disabled={currentPage === 1} onClick={handlePrev} />
       {pages.map((page, i) =>
         page === '...' ? (

--- a/frontend/src/components/parts/Pagination/index.tsx
+++ b/frontend/src/components/parts/Pagination/index.tsx
@@ -17,12 +17,12 @@ const calcPages = (current: number, total: number): (number | '...')[] => {
   return pages
 }
 
-type marinType = 'mv_16' | 'mv_24' | 'mv_32' | 'mv_40'
+type marginType = 'mv_16' | 'mv_24' | 'mv_32' | 'mv_40'
 
 interface Props {
   currentPage: number
   totalPages: number
-  margin?: marinType
+  margin?: marginType
   onChange: (page: number) => void
 }
 

--- a/frontend/src/components/templates/media/blog/list.tsx
+++ b/frontend/src/components/templates/media/blog/list.tsx
@@ -21,7 +21,7 @@ export default function Blogs(props: Props): React.JSX.Element {
   return (
     <Main title="Blog" search={search}>
       <CardList items={datas} Content={BlogCard} />
-      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} margin="mv_40" onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/chat/list.tsx
+++ b/frontend/src/components/templates/media/chat/list.tsx
@@ -21,7 +21,7 @@ export default function Chats(props: Props): React.JSX.Element {
   return (
     <Main title="Chat" search={search}>
       <CardList items={datas} Content={ChatCard} />
-      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} margin="mv_40" onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/comic/list.tsx
+++ b/frontend/src/components/templates/media/comic/list.tsx
@@ -21,7 +21,7 @@ export default function Comics(props: Props): React.JSX.Element {
   return (
     <Main title="Comic" search={search}>
       <CardList items={datas} Content={ComicCard} />
-      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} margin="mv_40" onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/music/list.tsx
+++ b/frontend/src/components/templates/media/music/list.tsx
@@ -21,7 +21,7 @@ export default function Musics(props: Props): React.JSX.Element {
   return (
     <Main title="Music" search={search}>
       <CardList items={datas} Content={MusicCard} />
-      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} margin="mv_40" onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/picture/list.tsx
+++ b/frontend/src/components/templates/media/picture/list.tsx
@@ -21,7 +21,7 @@ export default function Pictures(props: Props): React.JSX.Element {
   return (
     <Main title="Picture" search={search}>
       <CardList items={datas} Content={PictureCard} />
-      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} margin="mv_40" onChange={handlePage} />
     </Main>
   )
 }

--- a/frontend/src/components/templates/media/video/list.tsx
+++ b/frontend/src/components/templates/media/video/list.tsx
@@ -21,7 +21,7 @@ export default function Videos(props: Props): React.JSX.Element {
   return (
     <Main title="Video" search={search}>
       <CardList items={datas} Content={VideoCard} />
-      <Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} margin="mv_40" onChange={handlePage} />
     </Main>
   )
 }


### PR DESCRIPTION
## Summary
- `Pagination` コンポーネントに余白指定用の `margin` prop を追加
- SCSS 側の `padding: 12px 0` を廃止しユーティリティクラスで余白を制御
- 各メディア一覧ページで `margin="mv_40"` を指定

## 変更内容

### `frontend/src/components/parts/Pagination/`
- `index.tsx`
  - `margin?: 'mv_16' | 'mv_24' | 'mv_32' | 'mv_40'` を `Props` に追加（デフォルト `mv_16`）
  - `cx` を用いて `style.pagination` にユーティリティクラスを合成
- `Pagination.module.scss`
  - ハードコードされた `padding: 12px 0` を削除し、呼び出し側の `margin` prop に委譲

### `frontend/src/components/templates/media/{blog,chat,comic,music,picture,video}/list.tsx`
- `Pagination` に `margin="mv_40"` を指定して一覧ページ下部の余白を統一