### PR TITLE
【front】React Compiler を常時有効化

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,7 +5,7 @@ const { i18n } = require('./next-i18next.config.js')
 
 export default {
   reactStrictMode: true,
-  reactCompiler: process.env.NODE_ENV === 'production',
+  reactCompiler: true,
   basePath: '',
   i18n,
   images: {


### PR DESCRIPTION
## Summary
- `next.config.mjs` の `reactCompiler` を `process.env.NODE_ENV === 'production'` から `true` に変更
- 開発環境でも React Compiler による最適化を適用し、dev / prod の挙動差を解消

## 変更内容

### `frontend/next.config.mjs`
```diff
- reactCompiler: process.env.NODE_ENV === 'production',
+ reactCompiler: true,
```

- これまでは本番ビルド時のみ React Compiler が有効化されていたため、開発中に気付けないパフォーマンス/再レンダリング起因の不具合があった
- 常時 ON にすることで、開発時点から Compiler の最適化挙動を前提にコーディング・動作確認できる