### PR TITLE
【back】HashTag モデルを再設計し NgWord モデルを追加

### DIFF
--- a/myus/api/db/models/master.py
+++ b/myus/api/db/models/master.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django_ulid.models import ulid
 
 
 class Plan(models.Model):
@@ -35,13 +36,27 @@ class Category(models.Model):
 
 class HashTag(models.Model):
     """HashTag"""
-    id      = models.BigAutoField(primary_key=True)
-    jp_name = models.CharField(max_length=30)
-    en_name = models.CharField(max_length=60)
+    id   = models.BigAutoField(primary_key=True)
+    ulid = models.CharField(max_length=26, unique=True, editable=False, default=ulid.new)
+    name = models.CharField(max_length=30, unique=True)
 
     def __str__(self):
-        return self.jp_name
+        return self.name
 
     class Meta:
         db_table = "hashtag"
         verbose_name_plural = "001 ハッシュタグ"
+
+
+class NgWord(models.Model):
+    """NgWord"""
+    id      = models.BigAutoField(primary_key=True)
+    word    = models.CharField(max_length=30, unique=True)
+    created = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.word
+
+    class Meta:
+        db_table = "ng_word"
+        verbose_name_plural = "001 NGワード"


### PR DESCRIPTION
## Summary
- `HashTag` を一般的なハッシュタグ運用に合わせて再設計（`jp_name` → `name`、`en_name` 削除、UNIQUE 付与、`ulid` 追加）
- 自由入力ハッシュタグの不適切ワードフィルタ用に `NgWord` モデルを新規追加
- 後続 PR でマイグレーション・バリデーション・編集 UI を順次追加

## 変更内容

### `myus/api/db/models/master.py`

#### `HashTag`
- `jp_name`（max_length=30） → `name`（max_length=30, **UNIQUE**）にリネーム
- `en_name`（max_length=60）を削除
- `ulid`（max_length=26, UNIQUE, editable=False, default=ulid.new）を追加
  - 外部 URL（タグ別検索ページ等）への露出を想定して付与

#### `NgWord`（新規）
- `id`, `word`（max_length=30, UNIQUE）, `created`
- 運営が Django Admin から管理する内部モデル
- FE に露出しないため `ulid` は付与しない

## 後続 PR で予定

- マイグレーション 0002（重複 `jp_name` マージ→UNIQUE 付与、既存 M2M を sequence 付き through テーブルへ移管）
- `VideoHashtag` through モデル（投稿者の入力順を保持）
- バック usecase: 正規化＋バリデーション（記号/数字/スペース不可、長さ ≤30、NG ワード部分一致）
- フロント: メディア詳細画面でオーナー限定の自由入力ハッシュタグ編集 UI