### PR TITLE
【back】HashTag rename を関連箇所に反映

### DIFF
--- a/myus/api/admin.py
+++ b/myus/api/admin.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from django.db.models import Count
 from import_export.admin import ImportExportModelAdmin
 from api.db.models import Notification, AccessLog, Comment, Message, Follow, Advertise, ComicPage
-from api.db.models import User, Profile, MyPage, SearchTag, HashTag, UserNotification
+from api.db.models import User, Profile, MyPage, SearchTag, HashTag, NgWord, UserNotification
 from api.db.models import Video, Music, Blog, Comic, Picture, Chat
 from api.db.models.channel import Channel
 from api.utils.constant import model_media_comment_dict
@@ -139,19 +139,32 @@ class SearchTagAdmin(ImportExportModelAdmin):
 
 @admin.register(HashTag)
 class HashTagAdmin(ImportExportModelAdmin):
-    list_display = ("id", "jp_name", "en_name")
-    list_editable = ("jp_name", "en_name")
-    search_fields = ("jp_name", "en_name")
+    list_display = ("id", "ulid", "name")
+    list_editable = ("name",)
+    search_fields = ("ulid", "name")
     ordering = ("id",)
+    readonly_fields = ("ulid",)
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("jp_name", "en_name")}),
+        ("編集項目", {"fields": ("name",)}),
+        ("確認項目", {"fields": ("ulid",)}),
     ]
 
-    def save_model(self, request, obj, form, change):
-        obj.author = request.user
-        super(HashTagAdmin, self).save_model(request, obj, form, change)
+
+@admin.register(NgWord)
+class NgWordAdmin(ImportExportModelAdmin):
+    list_display = ("id", "word", "created")
+    list_editable = ("word",)
+    search_fields = ("word",)
+    ordering = ("id",)
+    readonly_fields = ("created",)
+
+    # 詳細画面
+    fieldsets = [
+        ("編集項目", {"fields": ("word",)}),
+        ("確認項目", {"fields": ("created",)}),
+    ]
 
 
 @admin.register(Video)
@@ -160,13 +173,13 @@ class VideoAdmin(ImportExportModelAdmin):
     list_select_related = ("channel",)
     search_fields = ("title", "channel__owner__nickname", "created")
     ordering = ("channel", "-created")
-    filter_horizontal = ("hashtag", "like")
+    filter_horizontal = ("like",)
     readonly_fields = ("total_like", "comment_count", "created", "updated")
     # inlines = [CommentInlineAdmin]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("channel", "title", "content", "image", "video", "convert", "hashtag", "like", "read", "publish")}),
+        ("編集項目", {"fields": ("channel", "title", "content", "image", "video", "convert", "like", "read", "publish")}),
         ("確認項目", {"fields": ("total_like", "comment_count", "created", "updated")})
     ]
 
@@ -432,13 +445,13 @@ manage_site.register(SearchTag, SearchTagAdminSite)
 
 
 class HashTagAdminSite(admin.ModelAdmin):
-    list_display = ("id", "jp_name", "en_name")
-    search_fields = ("jp_name", "en_name")
+    list_display = ("id", "ulid", "name")
+    search_fields = ("ulid", "name")
     ordering = ("id",)
 
     # 詳細画面
     fieldsets = [
-        ("確認項目", {"fields": ("jp_name", "en_name")}),
+        ("確認項目", {"fields": ("ulid", "name")}),
     ]
 
     def has_add_permission(self, request):
@@ -468,13 +481,12 @@ class VideoAdminSite(admin.ModelAdmin, PublishMixin):
     search_fields = ("title", "created")
     ordering = ("-created",)
     actions = ("published", "unpublished")
-    filter_horizontal = ("hashtag",)
     readonly_fields = ("read", "total_like", "comment_count", "created", "updated")
     # inlines = [CommentInline]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("title", "content", "image", "video", "convert", "hashtag", "publish")}),
+        ("編集項目", {"fields": ("title", "content", "image", "video", "convert", "publish")}),
         ("確認項目", {"fields": ("read", "total_like", "comment_count", "created", "updated")})
     ]
 

--- a/myus/api/src/domain/entity/media/blog/_convert.py
+++ b/myus/api/src/domain/entity/media/blog/_convert.py
@@ -30,7 +30,7 @@ def convert_data(obj: Blog) -> BlogData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        hashtags=[HashtagData(jp_name=h.jp_name) for h in obj.hashtag.all()],
+        hashtags=[HashtagData(id=h.id, ulid=h.ulid, name=h.name) for h in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/chat/_convert.py
+++ b/myus/api/src/domain/entity/media/chat/_convert.py
@@ -30,7 +30,7 @@ def convert_data(obj: Chat) -> ChatData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        hashtags=[HashtagData(jp_name=h.jp_name) for h in obj.hashtag.all()],
+        hashtags=[HashtagData(id=h.id, ulid=h.ulid, name=h.name) for h in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/comic/_convert.py
+++ b/myus/api/src/domain/entity/media/comic/_convert.py
@@ -29,7 +29,7 @@ def convert_data(obj: Comic) -> ComicData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        hashtags=[HashtagData(jp_name=h.jp_name) for h in obj.hashtag.all()],
+        hashtags=[HashtagData(id=h.id, ulid=h.ulid, name=h.name) for h in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/index.py
+++ b/myus/api/src/domain/entity/media/index.py
@@ -21,7 +21,7 @@ def filter_recommend() -> Q:
 
 
 def filter_search(search: str) -> Q:
-    return Q(title__icontains=search) | Q(hashtag__jp_name=search)
+    return Q(title__icontains=search) | Q(hashtag__name=search)
 
 
 def filter_q_list(filter: FilterOption, exclude: ExcludeOption | None = None) -> list[Q]:

--- a/myus/api/src/domain/entity/media/music/_convert.py
+++ b/myus/api/src/domain/entity/media/music/_convert.py
@@ -30,7 +30,7 @@ def convert_data(obj: Music) -> MusicData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        hashtags=[HashtagData(jp_name=h.jp_name) for h in obj.hashtag.all()],
+        hashtags=[HashtagData(id=h.id, ulid=h.ulid, name=h.name) for h in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/picture/_convert.py
+++ b/myus/api/src/domain/entity/media/picture/_convert.py
@@ -28,7 +28,7 @@ def convert_data(obj: Picture) -> PictureData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        hashtags=[HashtagData(jp_name=h.jp_name) for h in obj.hashtag.all()],
+        hashtags=[HashtagData(id=h.id, ulid=h.ulid, name=h.name) for h in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/video/_convert.py
+++ b/myus/api/src/domain/entity/media/video/_convert.py
@@ -30,7 +30,7 @@ def convert_data(obj: Video) -> VideoData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        hashtags=[HashtagData(jp_name=h.jp_name) for h in obj.hashtag.all()],
+        hashtags=[HashtagData(id=h.id, ulid=h.ulid, name=h.name) for h in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/interface/media/data.py
+++ b/myus/api/src/domain/interface/media/data.py
@@ -3,4 +3,6 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class HashtagData:
-    jp_name: str
+    id: int
+    ulid: str
+    name: str


### PR DESCRIPTION
## Summary
- PR #749（HashTag モデル再設計）の rename を関連レイヤに反映
- `jp_name` → `name` の伝播、検索クエリのフィールド名修正
- admin に NgWord を登録し、HashTag admin を新スキーマに合わせて更新

## 変更内容

### `myus/api/src/domain/interface/media/data.py`
- `HashtagData.jp_name` → `name` にリネーム

### 6 メディアの `_convert.py`
（`video`, `music`, `blog`, `comic`, `picture`, `chat`）
- `HashtagData(jp_name=h.jp_name)` → `HashtagData(name=h.name)`

### `myus/api/src/domain/entity/media/index.py`
- 検索クエリの既存バグ修正
  - `Q(title__icontains=search) | Q(hashtag__jp_name=search)` → `Q(hashtag__name=search)`

### `myus/api/admin.py`
- 新規 `NgWordAdmin` 登録（運営用 NG ワード管理画面）
- `HashTagAdmin` / `HashTagAdminSite` の `list_display` / `fieldsets` / `search_fields` を `name` / `ulid` 構成に更新
- 旧 `save_model` の `obj.author = request.user` を削除（HashTag モデルに `author` フィールドが無いため）

## 依存
- PR #749（HashTag モデル再設計）が先にマージされている前提