### PR TITLE
【back】HashTag を hashtag.py へ分離し through テーブル方式に変更

### DIFF
--- a/myus/api/admin.py
+++ b/myus/api/admin.py
@@ -190,13 +190,13 @@ class MusicAdmin(ImportExportModelAdmin):
     list_select_related = ("channel",)
     search_fields = ("title", "channel__owner__nickname", "created")
     ordering = ("channel", "-created")
-    filter_horizontal = ("hashtag", "like")
+    filter_horizontal = ("like",)
     readonly_fields = ("total_like", "comment_count", "created", "updated")
     # inlines = [CommentInlineAdmin]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("channel", "title", "content", "lyric", "music", "hashtag", "like", "read", "publish", "download")}),
+        ("編集項目", {"fields": ("channel", "title", "content", "lyric", "music", "like", "read", "publish", "download")}),
         ("確認項目", {"fields": ("total_like", "comment_count", "created", "updated")})
     ]
 
@@ -207,13 +207,13 @@ class ComicAdmin(ImportExportModelAdmin):
     list_select_related = ("channel",)
     search_fields = ("title", "channel__owner__nickname", "created")
     ordering = ("channel", "-created")
-    filter_horizontal = ("hashtag", "like")
+    filter_horizontal = ("like",)
     readonly_fields = ("total_like", "comment_count", "created", "updated")
     # inlines = [CommentInlineAdmin, ComicPageInlineAdmin]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("channel", "title", "content", "image", "hashtag", "like", "read", "publish")}),
+        ("編集項目", {"fields": ("channel", "title", "content", "image", "like", "read", "publish")}),
         ("確認項目", {"fields": ("total_like", "comment_count", "created", "updated")})
     ]
 
@@ -224,13 +224,13 @@ class PictureAdmin(ImportExportModelAdmin):
     list_select_related = ("channel",)
     search_fields = ("title", "channel__owner__nickname", "created")
     ordering = ("channel", "-created")
-    filter_horizontal = ("hashtag", "like")
+    filter_horizontal = ("like",)
     readonly_fields = ("total_like", "comment_count", "created", "updated")
     # inlines = [CommentInlineAdmin]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("channel", "title", "content", "image", "hashtag", "like", "read", "publish")}),
+        ("編集項目", {"fields": ("channel", "title", "content", "image", "like", "read", "publish")}),
         ("確認項目", {"fields": ("total_like", "comment_count", "created", "updated")})
     ]
 
@@ -241,13 +241,13 @@ class BlogAdmin(ImportExportModelAdmin):
     list_select_related = ("channel",)
     search_fields = ("title", "channel__owner__nickname", "created")
     ordering = ("channel", "-created")
-    filter_horizontal = ("hashtag", "like")
+    filter_horizontal = ("like",)
     readonly_fields = ("total_like", "comment_count", "created", "updated")
     # inlines = [CommentInlineAdmin]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("channel", "title", "content", "delta", "image", "hashtag", "like", "read", "publish")}),
+        ("編集項目", {"fields": ("channel", "title", "content", "delta", "image", "like", "read", "publish")}),
         ("確認項目", {"fields": ("total_like", "comment_count", "created", "updated")})
     ]
 
@@ -262,13 +262,13 @@ class ChatAdmin(ImportExportModelAdmin):
     list_select_related = ("channel",)
     search_fields = ("title", "channel__owner__nickname", "created")
     ordering = ("channel", "-created")
-    filter_horizontal = ("hashtag", "like")
+    filter_horizontal = ("like",)
     readonly_fields = ("total_like", "thread_count", "joined_count", "created", "updated")
     inlines = [MessageInlineAdmin]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("channel", "title", "content", "hashtag", "like", "read", "period", "publish")}),
+        ("編集項目", {"fields": ("channel", "title", "content", "like", "read", "period", "publish")}),
         ("確認項目", {"fields": ("total_like", "thread_count", "joined_count", "created", "updated")})
     ]
 
@@ -509,13 +509,12 @@ class MusicAdminSite(admin.ModelAdmin, PublishMixin):
     search_fields = ("title", "created")
     ordering = ("-created",)
     actions = ("published", "unpublished")
-    filter_horizontal = ("hashtag",)
     readonly_fields = ("read", "total_like", "comment_count", "created", "updated")
     # inlines = [CommentInline]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("title", "content", "lyric", "music", "hashtag", "download", "publish")}),
+        ("編集項目", {"fields": ("title", "content", "lyric", "music", "download", "publish")}),
         ("確認項目", {"fields": ("read", "total_like", "comment_count", "created", "updated")})
     ]
 
@@ -538,13 +537,12 @@ class ComicAdminSite(admin.ModelAdmin, PublishMixin):
     search_fields = ("title", "created")
     ordering = ("-created",)
     actions = ("published", "unpublished")
-    filter_horizontal = ("hashtag",)
     readonly_fields = ("read", "total_like", "comment_count", "created", "updated")
     # inlines = [CommentInline, ComicPageInline]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("title", "content", "image", "hashtag", "publish")}),
+        ("編集項目", {"fields": ("title", "content", "image", "publish")}),
         ("確認項目", {"fields": ("read", "total_like", "comment_count", "created", "updated")})
     ]
 
@@ -567,13 +565,12 @@ class PictureAdminSite(admin.ModelAdmin, PublishMixin):
     search_fields = ("title", "created")
     ordering = ("-created",)
     actions = ("published", "unpublished")
-    filter_horizontal = ("hashtag",)
     readonly_fields = ("read", "total_like", "comment_count", "created", "updated")
     # inlines = [CommentInline]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("title", "content", "image", "hashtag", "publish")}),
+        ("編集項目", {"fields": ("title", "content", "image", "publish")}),
         ("確認項目", {"fields": ("read", "total_like", "comment_count", "created", "updated")})
     ]
 
@@ -596,13 +593,12 @@ class BlogAdminSite(admin.ModelAdmin, PublishMixin):
     search_fields = ("title", "created")
     ordering = ("-created",)
     actions = ("published", "unpublished")
-    filter_horizontal = ("hashtag",)
     readonly_fields = ("read", "total_like", "comment_count", "created", "updated")
     # inlines = [CommentInline]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("title", "content", "delta", "image", "hashtag", "publish")}),
+        ("編集項目", {"fields": ("title", "content", "delta", "image", "publish")}),
         ("確認項目", {"fields": ("read", "total_like", "comment_count", "created", "updated")})
     ]
 
@@ -626,13 +622,12 @@ class ChatAdminSite(admin.ModelAdmin, PublishMixin):
     search_fields = ("title", "created")
     ordering = ("-created",)
     actions = ("published", "unpublished")
-    filter_horizontal = ("hashtag",)
     readonly_fields = ("read", "total_like", "thread_count", "joined_count", "created", "updated")
     inlines = [MessageInline]
 
     # 詳細画面
     fieldsets = [
-        ("編集項目", {"fields": ("title", "content", "hashtag", "period", "publish")}),
+        ("編集項目", {"fields": ("title", "content", "period", "publish")}),
         ("確認項目", {"fields": ("read", "total_like", "thread_count", "joined_count", "created", "updated")})
     ]
 

--- a/myus/api/db/models/__init__.py
+++ b/myus/api/db/models/__init__.py
@@ -2,6 +2,7 @@ from api.db.models.comment import *
 from api.db.models.common import *
 from api.db.models.master import *
 from api.db.models.media import *
+from api.db.models.hashtag import *
 from api.db.models.message import *
 from api.db.models.notification import *
 from api.db.models.stripe import *

--- a/myus/api/db/models/hashtag.py
+++ b/myus/api/db/models/hashtag.py
@@ -1,0 +1,94 @@
+from django.db import models
+from django_ulid.models import ulid
+
+
+class HashTag(models.Model):
+    """HashTag"""
+    id   = models.BigAutoField(primary_key=True)
+    ulid = models.CharField(max_length=26, unique=True, editable=False, default=ulid.new)
+    name = models.CharField(max_length=30, unique=True)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        db_table = "hashtag"
+        verbose_name_plural = "001 ハッシュタグ"
+
+
+class VideoHashtag(models.Model):
+    """VideoHashtag"""
+    id       = models.BigAutoField(primary_key=True)
+    video    = models.ForeignKey("db.Video", on_delete=models.CASCADE, related_name="video_hashtags")
+    hashtag  = models.ForeignKey(HashTag, on_delete=models.CASCADE, related_name="video_hashtags")
+    sequence = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "video_hashtag"
+        unique_together = [("video", "hashtag")]
+        ordering = ["sequence"]
+
+
+class MusicHashtag(models.Model):
+    """MusicHashtag"""
+    id       = models.BigAutoField(primary_key=True)
+    music    = models.ForeignKey("db.Music", on_delete=models.CASCADE, related_name="music_hashtags")
+    hashtag  = models.ForeignKey(HashTag, on_delete=models.CASCADE, related_name="music_hashtags")
+    sequence = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "music_hashtag"
+        unique_together = [("music", "hashtag")]
+        ordering = ["sequence"]
+
+
+class BlogHashtag(models.Model):
+    """BlogHashtag"""
+    id       = models.BigAutoField(primary_key=True)
+    blog     = models.ForeignKey("db.Blog", on_delete=models.CASCADE, related_name="blog_hashtags")
+    hashtag  = models.ForeignKey(HashTag, on_delete=models.CASCADE, related_name="blog_hashtags")
+    sequence = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "blog_hashtag"
+        unique_together = [("blog", "hashtag")]
+        ordering = ["sequence"]
+
+
+class ComicHashtag(models.Model):
+    """ComicHashtag"""
+    id       = models.BigAutoField(primary_key=True)
+    comic    = models.ForeignKey("db.Comic", on_delete=models.CASCADE, related_name="comic_hashtags")
+    hashtag  = models.ForeignKey(HashTag, on_delete=models.CASCADE, related_name="comic_hashtags")
+    sequence = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "comic_hashtag"
+        unique_together = [("comic", "hashtag")]
+        ordering = ["sequence"]
+
+
+class PictureHashtag(models.Model):
+    """PictureHashtag"""
+    id       = models.BigAutoField(primary_key=True)
+    picture  = models.ForeignKey("db.Picture", on_delete=models.CASCADE, related_name="picture_hashtags")
+    hashtag  = models.ForeignKey(HashTag, on_delete=models.CASCADE, related_name="picture_hashtags")
+    sequence = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "picture_hashtag"
+        unique_together = [("picture", "hashtag")]
+        ordering = ["sequence"]
+
+
+class ChatHashtag(models.Model):
+    """ChatHashtag"""
+    id       = models.BigAutoField(primary_key=True)
+    chat     = models.ForeignKey("db.Chat", on_delete=models.CASCADE, related_name="chat_hashtags")
+    hashtag  = models.ForeignKey(HashTag, on_delete=models.CASCADE, related_name="chat_hashtags")
+    sequence = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = "chat_hashtag"
+        unique_together = [("chat", "hashtag")]
+        ordering = ["sequence"]

--- a/myus/api/db/models/master.py
+++ b/myus/api/db/models/master.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django_ulid.models import ulid
 
 
 class Plan(models.Model):
@@ -32,20 +31,6 @@ class Category(models.Model):
     class Meta:
         db_table = "category"
         verbose_name_plural = "001 カテゴリー"
-
-
-class HashTag(models.Model):
-    """HashTag"""
-    id   = models.BigAutoField(primary_key=True)
-    ulid = models.CharField(max_length=26, unique=True, editable=False, default=ulid.new)
-    name = models.CharField(max_length=30, unique=True)
-
-    def __str__(self):
-        return self.name
-
-    class Meta:
-        db_table = "hashtag"
-        verbose_name_plural = "001 ハッシュタグ"
 
 
 class NgWord(models.Model):

--- a/myus/api/db/models/media.py
+++ b/myus/api/db/models/media.py
@@ -3,7 +3,8 @@ from django_quill.fields import QuillField
 from django_ulid.models import ulid
 from api.db.models.base import MediaModel
 from api.db.models.channel import Channel
-from api.db.models.master import Category, HashTag
+from api.db.models.hashtag import HashTag, VideoHashtag, MusicHashtag, BlogHashtag, ComicHashtag, PictureHashtag, ChatHashtag
+from api.db.models.master import Category
 from api.db.models.user import User
 from api.utils.functions.file import comic_upload, image_upload, music_upload, video_upload
 
@@ -20,7 +21,7 @@ class Video(models.Model, MediaModel):
     video    = models.FileField(upload_to=video_upload, max_length=255, blank=True)
     convert  = models.FileField(upload_to=video_upload, max_length=255, blank=True)
     category = models.ManyToManyField(Category, blank=True)
-    hashtag  = models.ManyToManyField(HashTag, blank=True)
+    hashtag  = models.ManyToManyField(HashTag, through=VideoHashtag, blank=True)
     like     = models.ManyToManyField(User, related_name="video_like", blank=True)
     read     = models.IntegerField(default=0)
     publish  = models.BooleanField(default=True)
@@ -43,7 +44,7 @@ class Music(models.Model, MediaModel):
     lyric    = models.TextField()
     music    = models.FileField(upload_to=music_upload, max_length=255, blank=True)
     category = models.ManyToManyField(Category, blank=True)
-    hashtag  = models.ManyToManyField(HashTag, blank=True)
+    hashtag  = models.ManyToManyField(HashTag, through=MusicHashtag, blank=True)
     like     = models.ManyToManyField(User, related_name="music_like", blank=True)
     read     = models.IntegerField(default=0)
     download = models.BooleanField(default=True)
@@ -68,7 +69,7 @@ class Blog(models.Model, MediaModel):
     delta    = QuillField()
     image    = models.ImageField(upload_to=image_upload, max_length=255, blank=True)
     category = models.ManyToManyField(Category, blank=True)
-    hashtag  = models.ManyToManyField(HashTag, blank=True)
+    hashtag  = models.ManyToManyField(HashTag, through=BlogHashtag, blank=True)
     like     = models.ManyToManyField(User, related_name="blog_like", blank=True)
     read     = models.IntegerField(default=0)
     publish  = models.BooleanField(default=True)
@@ -90,7 +91,7 @@ class Comic(models.Model, MediaModel):
     content  = models.TextField()
     image    = models.ImageField(upload_to=image_upload, max_length=255, blank=True)
     category = models.ManyToManyField(Category, blank=True)
-    hashtag  = models.ManyToManyField(HashTag, blank=True)
+    hashtag  = models.ManyToManyField(HashTag, through=ComicHashtag, blank=True)
     like     = models.ManyToManyField(User, related_name="comic_like", blank=True)
     read     = models.IntegerField(default=0)
     publish  = models.BooleanField(default=True)
@@ -127,7 +128,7 @@ class Picture(models.Model, MediaModel):
     content  = models.TextField()
     image    = models.ImageField(upload_to=image_upload, max_length=255, blank=True)
     category = models.ManyToManyField(Category, blank=True)
-    hashtag  = models.ManyToManyField(HashTag, blank=True)
+    hashtag  = models.ManyToManyField(HashTag, through=PictureHashtag, blank=True)
     like     = models.ManyToManyField(User, related_name="picture_like", blank=True)
     read     = models.IntegerField(default=0)
     publish  = models.BooleanField(default=True)
@@ -148,7 +149,7 @@ class Chat(models.Model):
     title    = models.CharField(max_length=100)
     content  = models.TextField()
     category = models.ManyToManyField(Category, blank=True)
-    hashtag  = models.ManyToManyField(HashTag, blank=True)
+    hashtag  = models.ManyToManyField(HashTag, through=ChatHashtag, blank=True)
     like     = models.ManyToManyField(User, related_name="chat_like", blank=True)
     read     = models.IntegerField(default=0)
     period   = models.DateField()


### PR DESCRIPTION
## Summary
- `HashTag` を独立ファイル `db/models/hashtag.py` に分離
- 6 メディア用の through モデルを新規追加し、ハッシュタグの **入力順 (sequence)** を保持できる構造へ刷新
- 各メディアの hashtag M2M を `through=XxxHashtag` に変更

## 変更内容

### 新規 `myus/api/db/models/hashtag.py`
- `HashTag(id, ulid, name)` を `master.py` から移動
- 6 つの through モデルを追加
  - `VideoHashtag`, `MusicHashtag`, `BlogHashtag`, `ComicHashtag`, `PictureHashtag`, `ChatHashtag`
  - 各モデル: `id`, `media`(FK), `hashtag`(FK), `sequence`(PositiveInteger)
  - `Meta`: `db_table`, `unique_together = [(media, hashtag)]`, `ordering = ["sequence"]`
- through モデル側の媒体 FK は文字列参照 (`"db.Video"` 等) にして循環 import を回避
- 媒体の宣言順 (`Video → Music → Blog → Comic → Picture → Chat`) でクラス定義

### `myus/api/db/models/master.py`
- `HashTag` クラスを削除（hashtag.py へ移動）
- `Plan`, `Category`, `NgWord` のみ残存

### `myus/api/db/models/media.py`
- `from api.db.models.hashtag import HashTag, VideoHashtag, MusicHashtag, BlogHashtag, ComicHashtag, PictureHashtag, ChatHashtag` を追加
- 各メディアの hashtag M2M を以下に変更
  ```python
  hashtag = models.ManyToManyField(HashTag, through=VideoHashtag, blank=True)
  ```

### `myus/api/db/models/__init__.py`
- `from api.db.models.hashtag import *` を追加（既存の wildcard import パターンに準拠）

### `myus/api/admin.py`
- through 化により Django Admin の制約に従い、6 メディア × Admin/AdminSite から `filter_horizontal` と `fieldsets` の `hashtag` を削除
- (Django の admin.E013: through を持つ M2M は `filter_horizontal` / 直接 `fieldsets` で扱えないため)

## 後続 PR で予定
- マイグレーション 0003 (auto M2M → through テーブル + sequence 移管)
- `HashtagInterface` / `HashtagRepository` の新設
- `usecase/hashtag.py` で集約保存
- 6 メディア `_convert.py` を `obj.video_hashtags.all()` 経由（sequence 順）に変更
- フロントの編集 UI

## マージ前提
- PR #749 (HashTag jp_name → name + ulid 追加) が先行マージ済みであること
- 本 PR 単独だと `obj.hashtag.set([ids])` 等の旧式 API を使う既存コードが破綻するため、後続 PR とセットでマージ必須