### PR TITLE
【back】media hashtag 共通エンドポイントと usecase を追加

### DIFF
--- a/myus/api/src/adapter/hashtag.py
+++ b/myus/api/src/adapter/hashtag.py
@@ -1,10 +1,11 @@
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
+from api.src.types.dto.hashtag import HashtagDTO
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.hashtag import MediaHashtagsUpdateIn
 from api.src.usecase.auth import auth_check
-from api.src.usecase.hashtag import HashtagInput, update_media_hashtags
+from api.src.usecase.hashtag import update_media_hashtags
 
 
 class MediaHashtagAPI:
@@ -21,7 +22,7 @@ class MediaHashtagAPI:
         if user_id is None:
             return 401, ErrorOut(message="Unauthorized")
 
-        hashtags = [HashtagInput(ulid=h.ulid, name=h.name) for h in input.hashtags]
+        hashtags = [HashtagDTO(ulid=h.ulid, name=h.name) for h in input.hashtags]
         if not update_media_hashtags(user_id, input.media_type, input.media_ulid, hashtags):
             return 400, ErrorOut(message="保存に失敗しました!")
 

--- a/myus/api/src/adapter/hashtag.py
+++ b/myus/api/src/adapter/hashtag.py
@@ -1,0 +1,28 @@
+from django.http import HttpRequest
+from ninja import Router
+from api.modules.logger import log
+from api.src.types.schema.common import ErrorOut
+from api.src.types.schema.hashtag import MediaHashtagsUpdateIn
+from api.src.usecase.auth import auth_check
+from api.src.usecase.hashtag import HashtagInput, update_media_hashtags
+
+
+class MediaHashtagAPI:
+    """MediaHashtagAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.put("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, input: MediaHashtagsUpdateIn):
+        log.info("MediaHashtagAPI put", media_type=input.media_type.value, media_ulid=input.media_ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        hashtags = [HashtagInput(ulid=h.ulid, name=h.name) for h in input.hashtags]
+        if not update_media_hashtags(user_id, input.media_type, input.media_ulid, hashtags):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")

--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -8,7 +8,7 @@ from api.src.domain.interface.media.blog.data import BlogData
 from api.src.domain.interface.media.comic.data import ComicData
 from api.src.domain.interface.media.picture.data import PictureData
 from api.src.domain.interface.media.chat.data import ChatData
-from api.src.domain.interface.media.data import HashtagData
+from api.src.domain.interface.hashtag.data import HashtagData
 from api.src.domain.interface.channel.data import ChannelData
 from api.utils.functions.index import create_url
 from api.src.types.dto.message import MessageDTO
@@ -631,4 +631,4 @@ def convert_media_user(obj: MediaUserDTO) -> MediaUserOut:
 
 
 def convert_hashtags(objs: list[HashtagData]) -> list[HashtagOut]:
-    return [HashtagOut(jp_name=x.jp_name) for x in objs]
+    return [HashtagOut(ulid=x.ulid, name=x.name) for x in objs]

--- a/myus/api/src/injectors/container.py
+++ b/myus/api/src/injectors/container.py
@@ -5,10 +5,12 @@ from api.src.injectors.index import (
     MediaModule,
     CommentModule,
     MessageModule,
+    HashtagModule,
     SearchTagModule,
     NotificationModule,
     FollowModule,
     SubscribeModule,
+    NgWordModule,
 )
 
 
@@ -18,10 +20,12 @@ modules: list[Module] = [
     MediaModule(),
     CommentModule(),
     MessageModule(),
+    HashtagModule(),
     SearchTagModule(),
     NotificationModule(),
     FollowModule(),
     SubscribeModule(),
+    NgWordModule(),
 ]
 
 injector = Injector(modules)

--- a/myus/api/src/injectors/index.py
+++ b/myus/api/src/injectors/index.py
@@ -11,6 +11,8 @@ from api.src.domain.entity.comment.repository import CommentRepository
 from api.src.domain.entity.message.repository import MessageRepository
 from api.src.domain.entity.follow.repository import FollowRepository
 from api.src.domain.entity.subscribe.repository import SubscribeRepository
+from api.src.domain.entity.hashtag.repository import HashtagRepository
+from api.src.domain.entity.ng_word.repository import NgWordRepository
 from api.src.domain.entity.search_tag.repository import SearchTagRepository
 from api.src.domain.entity.notification.repository import NotificationRepository
 from api.src.domain.interface.user.interface import UserInterface
@@ -25,6 +27,8 @@ from api.src.domain.interface.comment.interface import CommentInterface
 from api.src.domain.interface.message.interface import MessageInterface
 from api.src.domain.interface.follow.interface import FollowInterface
 from api.src.domain.interface.subscribe.interface import SubscribeInterface
+from api.src.domain.interface.hashtag.interface import HashtagInterface
+from api.src.domain.interface.ng_word.interface import NgWordInterface
 from api.src.domain.interface.search_tag.interface import SearchTagInterface
 from api.src.domain.interface.notification.interface import NotificationInterface
 
@@ -67,6 +71,12 @@ class MediaModule(Module):
         return ChatRepository()
 
 
+class HashtagModule(Module):
+    @provider
+    def provide_hashtag_repository(self) -> HashtagInterface:
+        return HashtagRepository()
+
+
 class CommentModule(Module):
     @provider
     def provide_comment_repository(self) -> CommentInterface:
@@ -77,6 +87,12 @@ class MessageModule(Module):
     @provider
     def provide_message_repository(self) -> MessageInterface:
         return MessageRepository()
+
+
+class NgWordModule(Module):
+    @provider
+    def provide_ng_word_repository(self) -> NgWordInterface:
+        return NgWordRepository()
 
 
 class SearchTagModule(Module):

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,6 +1,7 @@
 from ninja import NinjaAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.comment import CommentAPI
+from api.src.adapter.hashtag import MediaHashtagAPI
 from api.src.adapter.manage import ManageVideoAPI, ManageMusicAPI, ManageBlogAPI, ManageComicAPI, ManagePictureAPI, ManageChatAPI
 from api.src.adapter.media import HomeAPI, RecommendAPI, VideoAPI, MusicAPI, BlogAPI, ComicAPI, PictureAPI, ChatAPI
 from api.src.adapter.message import MessageAPI
@@ -34,5 +35,6 @@ api.add_router("/media/blog", BlogAPI().router, tags=["Media Blog"])
 api.add_router("/media/comic", ComicAPI().router, tags=["Media Comic"])
 api.add_router("/media/picture", PictureAPI().router, tags=["Media Picture"])
 api.add_router("/media/chat", ChatAPI().router, tags=["Media Chat"])
+api.add_router("/media/hashtag", MediaHashtagAPI().router, tags=["Media Hashtag"])
 api.add_router("/media/comment", CommentAPI().router, tags=["Media Comment"])
 api.add_router("/media/message", MessageAPI().router, tags=["Media Message"])

--- a/myus/api/src/types/dto/hashtag.py
+++ b/myus/api/src/types/dto/hashtag.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class HashtagDTO:
+    ulid: str
+    name: str

--- a/myus/api/src/types/dto/media.py
+++ b/myus/api/src/types/dto/media.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import date, datetime
-from api.src.domain.interface.media.data import HashtagData
+from api.src.domain.interface.hashtag.data import HashtagData
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.music.data import MusicData
 from api.src.domain.interface.media.blog.data import BlogData

--- a/myus/api/src/types/schema/hashtag.py
+++ b/myus/api/src/types/schema/hashtag.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from api.utils.enum.index import MediaType
+
+
+class HashtagItemIn(BaseModel):
+    ulid: str
+    name: str
+
+
+class MediaHashtagsUpdateIn(BaseModel):
+    media_type: MediaType
+    media_ulid: str
+    hashtags: list[HashtagItemIn]

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -23,7 +23,8 @@ class MediaOut(BaseModel):
 
 
 class HashtagOut(BaseModel):
-    jp_name: str
+    ulid: str
+    name: str
 
 
 class MediaDetailOut(BaseModel):

--- a/myus/api/src/usecase/hashtag.py
+++ b/myus/api/src/usecase/hashtag.py
@@ -31,7 +31,7 @@ def validate_name(name: str, ng_words: list[str]) -> bool:
     return True
 
 
-def _load_ng_words() -> list[str]:
+def get_ng_words() -> list[str]:
     repo = injector.get(NgWordInterface)
     ids = repo.get_ids(NgWordFilterOption(), NgWordSortOption())
     return [n.word for n in repo.bulk_get(ids)]
@@ -57,7 +57,7 @@ def update_media_hashtags(user_id: int, media_type: MediaType, media_ulid: str, 
         for tag in hashtag_repo.bulk_get(existing_ids):
             ulid_data_map[tag.ulid] = tag
 
-    ng_words = _load_ng_words()
+    ng_words = get_ng_words()
     seen_name: set[str] = set()
     update_hashtags: list[HashtagData] = []
 

--- a/myus/api/src/usecase/hashtag.py
+++ b/myus/api/src/usecase/hashtag.py
@@ -1,0 +1,92 @@
+import re
+from dataclasses import dataclass
+from api.modules.logger import log
+from api.src.domain.interface.hashtag.data import HashtagData
+from api.src.domain.interface.hashtag.interface import FilterOption as HashtagFilterOption, HashtagInterface, SortOption as HashtagSortOption
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
+from api.src.domain.interface.ng_word.interface import FilterOption as NgWordFilterOption, NgWordInterface, SortOption as NgWordSortOption
+from api.src.injectors.container import injector
+from api.utils.enum.index import MediaType
+from api.utils.functions.media import get_media_repository
+
+
+HASHTAG_MAX_LENGTH = 30
+ALLOWED_PATTERN = re.compile(r"^[ぁ-んァ-ヶー一-龯a-zA-Z]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class HashtagInput:
+    ulid: str
+    name: str
+
+
+def normalize_name(name: str) -> str:
+    return name.strip().lstrip("#").lower()
+
+
+def validate_name(name: str, ng_words: list[str]) -> bool:
+    if len(name) == 0:
+        return False
+    if len(name) > HASHTAG_MAX_LENGTH:
+        return False
+    if ALLOWED_PATTERN.match(name) is None:
+        return False
+    for ng in ng_words:
+        if ng in name:
+            return False
+    return True
+
+
+def _load_ng_words() -> list[str]:
+    repo = injector.get(NgWordInterface)
+    ids = repo.get_ids(NgWordFilterOption(), NgWordSortOption())
+    return [n.word for n in repo.bulk_get(ids)]
+
+
+def update_media_hashtags(user_id: int, media_type: MediaType, media_ulid: str, hashtags: list[HashtagInput]) -> bool:
+    media_repo = get_media_repository(media_type)
+    hashtag_repo = injector.get(HashtagInterface)
+    media_ids = media_repo.get_ids(FilterOption(ulid=media_ulid), ExcludeOption(), SortOption(), PageOption())
+    if len(media_ids) == 0:
+        log.error("Media not found", media_type=media_type.value, media_ulid=media_ulid)
+        return False
+
+    media = media_repo.bulk_get(media_ids)[0]
+    if media.channel.owner_id != user_id:
+        log.error("Media owner mismatch", media_type=media_type.value, media_ulid=media_ulid, user_id=user_id)
+        return False
+
+    ulids = [h.ulid for h in hashtags if h.ulid]
+    ulid_data_map: dict[str, HashtagData] = {}
+    if len(ulids) > 0:
+        existing_ids = hashtag_repo.get_ids(HashtagFilterOption(ulids=ulids), HashtagSortOption())
+        for tag in hashtag_repo.bulk_get(existing_ids):
+            ulid_data_map[tag.ulid] = tag
+
+    ng_words = _load_ng_words()
+    seen_name: set[str] = set()
+    update_hashtags: list[HashtagData] = []
+
+    for h in hashtags:
+        if h.ulid and h.ulid in ulid_data_map:
+            existing = ulid_data_map[h.ulid]
+            if existing.name in seen_name:
+                continue
+            seen_name.add(existing.name)
+            update_hashtags.append(existing)
+            continue
+
+        normalized = normalize_name(h.name)
+        if not validate_name(normalized, ng_words):
+            continue
+        if normalized in seen_name:
+            continue
+        seen_name.add(normalized)
+        update_hashtags.append(HashtagData(id=0, ulid="", name=normalized))
+
+    try:
+        hashtag_repo.bulk_save(media_type, media.id, update_hashtags)
+        return True
+    except Exception as e:
+        log.error("update_media_hashtags error", exc=e)
+        return False

--- a/myus/api/src/usecase/hashtag.py
+++ b/myus/api/src/usecase/hashtag.py
@@ -1,23 +1,17 @@
 import re
-from dataclasses import dataclass
 from api.modules.logger import log
 from api.src.domain.interface.hashtag.data import HashtagData
 from api.src.domain.interface.hashtag.interface import FilterOption as HashtagFilterOption, HashtagInterface, SortOption as HashtagSortOption
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.ng_word.interface import FilterOption as NgWordFilterOption, NgWordInterface, SortOption as NgWordSortOption
 from api.src.injectors.container import injector
+from api.src.types.dto.hashtag import HashtagDTO
 from api.utils.enum.index import MediaType
 from api.utils.functions.media import get_media_repository
 
 
 HASHTAG_MAX_LENGTH = 30
 ALLOWED_PATTERN = re.compile(r"^[ぁ-んァ-ヶー一-龯a-zA-Z]+$")
-
-
-@dataclass(frozen=True, slots=True)
-class HashtagInput:
-    ulid: str
-    name: str
 
 
 def normalize_name(name: str) -> str:
@@ -43,7 +37,7 @@ def _load_ng_words() -> list[str]:
     return [n.word for n in repo.bulk_get(ids)]
 
 
-def update_media_hashtags(user_id: int, media_type: MediaType, media_ulid: str, hashtags: list[HashtagInput]) -> bool:
+def update_media_hashtags(user_id: int, media_type: MediaType, media_ulid: str, hashtags: list[HashtagDTO]) -> bool:
     media_repo = get_media_repository(media_type)
     hashtag_repo = injector.get(HashtagInterface)
     media_ids = media_repo.get_ids(FilterOption(ulid=media_ulid), ExcludeOption(), SortOption(), PageOption())


### PR DESCRIPTION
## Summary
- 全 6 メディア共通の `PUT /api/media/hashtag` エンドポイントを追加
- `usecase.update_media_hashtags`: `ulid` 優先・`name` フォールバック + 正規化 + NG ワード検証 + `HashtagRepository.bulk_save` 呼び出しを 1 関数に集約
- `HashtagOut` の主キーを `id` から `ulid` に変更（外部 API には ulid のみ公開）

## 変更内容

### 新規 `adapter/hashtag.py`
```python
class MediaHashtagAPI:
    @router.put("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
    def put(request, input: MediaHashtagsUpdateIn):
        # 認証 → usecase 呼び出し → 結果返却
```

### 新規 `usecase/hashtag.py`
- `HashtagInput(ulid, name)` dataclass
- `normalize_name`: 前後空白除去・先頭 `#` 削除・小文字化
- `validate_name`: 長さ・許可文字 (`[ぁ-んァ-ヶー一-龯a-zA-Z]+`)・NG ワード部分一致チェック
- `update_media_hashtags(user_id, media_type, media_ulid, hashtags)`:
  1. メディア取得 + オーナー認可
  2. 既存タグを `ulid` でルックアップ → `ulid_data_map` に集約
  3. 入力ループで以下を判定し `update_hashtags` リスト構築
     - `ulid` 一致 → 既存 `HashtagData` を採用
     - `ulid` なし → `name` を normalize + validate → 新規候補
  4. `HashtagRepository.bulk_save(media_type, media.id, update_hashtags)` で atomic に保存

### 新規 `types/schema/hashtag.py`
```python
class HashtagItemIn(BaseModel):
    ulid: str  # 空文字許可（新規追加時）
    name: str

class MediaHashtagsUpdateIn(BaseModel):
    media_type: MediaType
    media_ulid: str
    hashtags: list[HashtagItemIn]
```

### 修正 `types/schema/media/output.py` / `adapter/media.py`
- `HashtagOut` の `id` を削除し `ulid` を追加（auto-increment id を外部に晒さない）
- `convert_hashtags` の戻り値を `HashtagOut(ulid, name)` へ調整

### 修正 `types/dto/media.py`
- `HashtagData` の import 元を `interface/media/data.py` (旧シム) → `interface/hashtag/data.py` に変更

### 修正 `injectors/index.py` / `container.py`
- `HashtagModule` を登録（`HashtagInterface` → `HashtagRepository` のバインド）

### 修正 `routers.py`
- `api.add_router("/media/hashtag", MediaHashtagAPI().router, tags=["Media Hashtag"])`

## 依存
- PR #752 (HashTag モデル + through), PR #753 (HashtagRepository), PR #751 (NgWord) すべてマージ済みであること

## 動作概要
```
PUT /api/media/hashtag
{
  "media_type": "Video",
  "media_ulid": "01ABC...",
  "hashtags": [
    {"ulid": "01XYZ...", "name": "プログラミング"},  // 既存
    {"ulid": "",         "name": "新規タグ"}          // 自由入力
  ]
}
```
- 既存タグ: `ulid` で識別して採用
- 新規タグ: `name` を正規化＋NG ワード検証して get_or_create
- through テーブルに `sequence` 付きで紐付け