### PR TITLE
【docs】backend.md に Interface 層ルールを追加

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -83,6 +83,16 @@
 - 入出力はdataclass（Django ORMモデルを直接返さない）
 - usecase層ではinjector経由でinterfaceを取得（entityを直接インポートしない）
 
+### Interface層（抽象クラス）
+- **既存Interfaceの「シグネチャ・命名・構成」に必ず準拠**（独自設計禁止）
+- 雛形: `api/src/domain/interface/search_tag/interface.py` を参照
+- 必須メソッド: `get_ids(filter, sort, limit)` / `bulk_get(ids)` の読み取り2点
+- 任意メソッド（usecaseで必要になったときに追加）: `bulk_save` / `bulk_delete` / `count`
+- 必須型: `FilterOption` / `SortOption` dataclass + `SortType` enum
+- メソッド追加時は既存パターンと **完全に同じシグネチャ・引数名** を使う（独自シグネチャ禁止）
+- 「使わないから書く」「使うから簡略化する」のどちらも禁止：使う分だけ既存の形で書く
+- private メソッド（`_` プレフィックス）を Interface に宣言しない（抽象化は公開 API のみ。private ヘルパーは Repository 実装側に置く）
+
 ### Converterパターン
 - `_convert.py`に変換関数を定義
 - `convert_data`: Django ORM → dataclass


### PR DESCRIPTION
## Summary
- バックエンド開発ルールに **Interface 層（抽象クラス）** のセクションを新設
- 既存 Interface（`SearchTagInterface` 等）に揃える原則と、メソッド追加時の制約を明文化

## 変更内容

### `docs/backend.md`
「アーキテクチャ → Repository層」と「Converterパターン」の間に新セクション追加:

```markdown
### Interface層（抽象クラス）
- 既存Interfaceの「シグネチャ・命名・構成」に必ず準拠（独自設計禁止）
- 雛形: api/src/domain/interface/search_tag/interface.py を参照
- 必須メソッド: get_ids(filter, sort, limit) / bulk_get(ids) の読み取り2点
- 任意メソッド（usecaseで必要になったときに追加）: bulk_save / bulk_delete / count
- 必須型: FilterOption / SortOption dataclass + SortType enum
- メソッド追加時は既存パターンと完全に同じシグネチャ・引数名を使う（独自シグネチャ禁止）
- 「使わないから書く」「使うから簡略化する」のどちらも禁止：使う分だけ既存の形で書く
- private メソッド（_ プレフィックス）を Interface に宣言しない（抽象化は公開 API のみ。private ヘルパーは Repository 実装側に置く）
```

## 経緯
- Hashtag 系の interface 設計時に「全 4 点メソッドを書くべきか / 書かないか」「private ヘルパーを Interface に持たせるか」で迷う場面があった
- 既存 SearchTag を雛形として明示し、判断軸を文書化