### PR TITLE
【back】hashtag validate_name の NG ワードチェックを any() に置換

### DIFF
--- a/myus/api/src/usecase/hashtag.py
+++ b/myus/api/src/usecase/hashtag.py
@@ -25,9 +25,8 @@ def validate_name(name: str, ng_words: list[str]) -> bool:
         return False
     if ALLOWED_PATTERN.match(name) is None:
         return False
-    for ng in ng_words:
-        if ng in name:
-            return False
+    if any(ng in name for ng in ng_words):
+        return False
     return True
 
 


### PR DESCRIPTION
## Summary
- `validate_name` 内の NG ワード判定を for ループから `any()` に置換し簡潔化

## 変更内容
### `myus/api/src/usecase/hashtag.py`
- NG ワードを順次走査して `return False` していた for ループを `any(ng in name for ng in ng_words)` に置換
- ロジックは等価のまま、可読性と Python idiom 的な書き方に統一