### PR TITLE
【front】media hashtag 更新 API と Hashtags 編集 UI を追加

### DIFF
--- a/frontend/src/api/internal/hashtag.ts
+++ b/frontend/src/api/internal/hashtag.ts
@@ -1,0 +1,10 @@
+import { apiClient } from 'lib/axios/internal'
+import { ApiOut, apiOut } from 'lib/error'
+import { MediaHashtagsUpdateIn } from 'types/internal/hashtag'
+import { ErrorOut } from 'types/internal/other'
+import { apiMediaHashtag } from 'api/uri'
+import { camelSnake } from 'utils/functions/convertCase'
+
+export const putMediaHashtags = async (request: MediaHashtagsUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').put(apiMediaHashtag, camelSnake(request)))
+}

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -56,6 +56,8 @@ export const apiPicture = (ulid: string) => base + `/media/picture/${ulid}`
 export const apiChats = base + '/media/chat'
 export const apiChat = (ulid: string) => base + `/media/chat/${ulid}`
 
+export const apiMediaHashtag = base + '/media/hashtag'
+
 export const apiComments = base + '/media/comment'
 export const apiComment = (ulid: string) => base + `/media/comment/${ulid}`
 

--- a/frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss
+++ b/frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss
@@ -7,3 +7,51 @@
     color: rgb(0, 130, 255);
   }
 }
+
+.edit_button {
+  display: inline-flex;
+  align-items: center;
+  color: rgb(130, 130, 130);
+  cursor: pointer;
+
+  &:hover {
+    color: rgb(0, 130, 255);
+  }
+}
+
+.edit_area {
+  padding: 8px;
+  border: 1px solid rgb(220, 220, 220);
+  border-radius: 6px;
+
+  .input {
+    flex: 1;
+  }
+
+  .edit_chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    font-size: 13px;
+    color: rgb(60, 60, 60);
+    background-color: rgb(240, 245, 255);
+    border: 1px solid rgb(180, 200, 230);
+    border-radius: 12px;
+  }
+
+  .delete_button {
+    display: inline-flex;
+    align-items: center;
+    color: rgb(160, 160, 160);
+    cursor: pointer;
+
+    &:hover {
+      color: rgb(220, 60, 60);
+    }
+  }
+
+  .edit_actions {
+    justify-content: flex-end;
+  }
+}

--- a/frontend/src/components/widgets/Media/Hashtags/index.tsx
+++ b/frontend/src/components/widgets/Media/Hashtags/index.tsx
@@ -1,29 +1,139 @@
+import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Hashtag } from 'types/internal/media/output'
-import { MediaPath } from 'utils/constants/enum'
+import { putMediaHashtags } from 'api/internal/hashtag'
+import { MediaPath, MediaType } from 'utils/constants/enum'
+import ButtonSquare from 'components/parts/Button/Square'
+import IconCross from 'components/parts/Icon/Cross'
+import IconEdit from 'components/parts/Icon/Edit'
+import Input from 'components/parts/Input'
 import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
 import style from './Hashtags.module.scss'
+
+const HASHTAG_MAX_LENGTH = 30
+const ALLOWED_PATTERN = /^[ぁ-んァ-ヶー一-龯a-zA-Z]+$/
+
+const pathToTypeMap: Record<MediaPath, MediaType> = {
+  [MediaPath.Video]: MediaType.Video,
+  [MediaPath.Music]: MediaType.Music,
+  [MediaPath.Blog]: MediaType.Blog,
+  [MediaPath.Comic]: MediaType.Comic,
+  [MediaPath.Picture]: MediaType.Picture,
+  [MediaPath.Chat]: MediaType.Chat,
+}
+
+const normalizeName = (raw: string): string => raw.trim().replace(/^#+/, '').toLowerCase()
+const isValidName = (name: string): boolean => name.length > 0 && name.length <= HASHTAG_MAX_LENGTH && ALLOWED_PATTERN.test(name)
 
 interface Props {
   hashtags: Hashtag[]
   mediaPath: MediaPath
+  mediaUlid?: string
+  isOwner?: boolean
+  onUpdate?: (hashtags: Hashtag[]) => void
+  onToast?: (content: string, isError: boolean) => void
 }
 
 export default function Hashtags(props: Props): React.JSX.Element {
-  const { hashtags, mediaPath } = props
+  const { hashtags, mediaPath, mediaUlid, isOwner = false, onUpdate, onToast } = props
   const router = useRouter()
+  const [isEdit, setIsEdit] = useState<boolean>(false)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [editTags, setEditTags] = useState<Hashtag[]>([])
+  const [inputTag, setInputTag] = useState<string>('')
 
-  const handleRouter = (jpName: string) => {
-    router.push(`/media/${mediaPath}?search=${jpName}`)
+  const canEdit = isOwner && mediaUlid !== undefined
+
+  const handleRouter = (name: string) => {
+    router.push(`/media/${mediaPath}?search=${name}`)
+  }
+
+  const handleStart = () => {
+    setEditTags([...hashtags])
+    setInputTag('')
+    setIsEdit(true)
+  }
+
+  const handleCancel = () => {
+    setEditTags([])
+    setInputTag('')
+    setIsEdit(false)
+  }
+
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setInputTag(e.target.value)
+
+  const handleAdd = () => {
+    const normalized = normalizeName(inputTag)
+    if (!isValidName(normalized)) {
+      onToast?.('使用できない文字が含まれています', true)
+      return
+    }
+    if (editTags.some((t) => t.name === normalized)) {
+      setInputTag('')
+      return
+    }
+    setEditTags([...editTags, { ulid: '', name: normalized }])
+    setInputTag('')
+  }
+
+  const handleDelete = (index: number) => setEditTags(editTags.filter((_, i) => i !== index))
+
+  const handleSave = async () => {
+    if (mediaUlid === undefined) return
+    setIsLoading(true)
+    const ret = await putMediaHashtags({
+      mediaType: pathToTypeMap[mediaPath],
+      mediaUlid,
+      hashtags: editTags,
+    })
+    setIsLoading(false)
+    if (ret.isErr()) {
+      onToast?.('ハッシュタグの保存に失敗しました', true)
+      return
+    }
+    onUpdate?.(editTags)
+    onToast?.('ハッシュタグを保存しました', false)
+    setIsEdit(false)
+  }
+
+  if (isEdit) {
+    return (
+      <VStack gap="2" className={style.edit_area}>
+        <HStack gap="2">
+          <Input placeholder="タグ名" maxLength={HASHTAG_MAX_LENGTH} value={inputTag} onChange={handleInput} className={style.input} />
+          <ButtonSquare name="追加" color="sakura" onClick={handleAdd} />
+        </HStack>
+        <HStack gap="4" wrap>
+          {editTags.map((tag, index) => (
+            <span key={tag.name} className={style.edit_chip}>
+              <span>#{tag.name}</span>
+              <span className={style.delete_button} onClick={() => handleDelete(index)}>
+                <IconCross size="14" />
+              </span>
+            </span>
+          ))}
+        </HStack>
+        <HStack gap="2" className={style.edit_actions}>
+          <ButtonSquare name="キャンセル" color="sakura" onClick={handleCancel} />
+          <ButtonSquare name="保存" color="emerald" loading={isLoading} onClick={handleSave} />
+        </HStack>
+      </VStack>
+    )
   }
 
   return (
     <HStack gap="4" wrap>
       {hashtags.map((hashtag) => (
-        <span key={hashtag.jpName} className={style.hashtag} onClick={() => handleRouter(hashtag.jpName)}>
-          #{hashtag.jpName}
+        <span key={hashtag.name} className={style.hashtag} onClick={() => handleRouter(hashtag.name)}>
+          #{hashtag.name}
         </span>
       ))}
+      {canEdit && (
+        <span className={style.edit_button} onClick={handleStart}>
+          <IconEdit size="14" />
+        </span>
+      )}
     </HStack>
   )
 }

--- a/frontend/src/types/internal/hashtag.d.ts
+++ b/frontend/src/types/internal/hashtag.d.ts
@@ -1,0 +1,12 @@
+import { MediaType } from 'utils/constants/enum'
+
+export interface HashtagItem {
+  ulid: string
+  name: string
+}
+
+export interface MediaHashtagsUpdateIn {
+  mediaType: MediaType
+  mediaUlid: string
+  hashtags: HashtagItem[]
+}

--- a/frontend/src/types/internal/media/output.d.ts
+++ b/frontend/src/types/internal/media/output.d.ts
@@ -33,7 +33,8 @@ export interface Media {
 }
 
 export interface Hashtag {
-  jpName: string
+  ulid: string
+  name: string
 }
 
 export interface MediaDetail {


### PR DESCRIPTION
## Summary
- media hashtag 更新用の internal API クライアント `putMediaHashtags` と関連型を追加
- 既存 `Hashtag` 型を `{ ulid, name }` 形式へ刷新（`jpName` を廃止）
- `Hashtags` コンポーネントに所有者向けのインライン編集 UI と保存処理を追加

## 変更内容
### API / 型
#### `frontend/src/api/internal/hashtag.ts`（新規）
- `putMediaHashtags(request: MediaHashtagsUpdateIn)` を追加
- `apiClient('json').put` で `apiMediaHashtag` に対し `camelSnake` 変換した payload を送信

#### `frontend/src/api/uri.ts`
- `apiMediaHashtag = base + '/media/hashtag'` を追加

#### `frontend/src/types/internal/hashtag.d.ts`（新規）
- `HashtagItem`: `ulid`, `name`
- `MediaHashtagsUpdateIn`: `mediaType`, `mediaUlid`, `hashtags`

#### `frontend/src/types/internal/media/output.d.ts`
- `Hashtag` を `jpName: string` から `{ ulid, name }` に変更（through テーブル化対応）

### コンポーネント
#### `frontend/src/components/widgets/Media/Hashtags/index.tsx`
- `mediaUlid` / `isOwner` / `onUpdate` / `onToast` props を追加し編集モードを実装
- 編集 UI: 入力 + 追加ボタン + チップ表示 + 削除 + 保存/キャンセル
- 保存時は `pathToTypeMap` で `MediaPath → MediaType` 変換し `putMediaHashtags` を呼び出す
- 入力バリデーション: `normalizeName`（trim / 先頭 # 除去 / 小文字化）と `ALLOWED_PATTERN`（日本語 + 英字）+ 最大 30 文字
- 表示側のキー・遷移パラメータを `jpName` から `name` に置換

#### `frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss`
- `.edit_button` / `.edit_area` / `.edit_chip` / `.delete_button` / `.edit_actions` のスタイルを追加