### PR TITLE
【front】media detail に hashtag 編集 UI を配線

### DIFF
--- a/frontend/src/components/widgets/Media/Detail/Common.tsx
+++ b/frontend/src/components/widgets/Media/Detail/Common.tsx
@@ -9,6 +9,7 @@ import MediaDetailRight from './Right'
 
 interface Props {
   media: {
+    ulid: string
     title: string
     content: string
     read: number

--- a/frontend/src/components/widgets/Media/Detail/Left.tsx
+++ b/frontend/src/components/widgets/Media/Detail/Left.tsx
@@ -37,10 +37,12 @@ export interface MediaDetailState {
   subscribeCount: number
   text: string
   comments: Comment[]
+  hashtags: Hashtag[]
 }
 
 interface Props {
   media: {
+    ulid: string
     title: string
     content: string
     read: number
@@ -67,8 +69,9 @@ export default function MediaDetailLeft(props: Props): React.JSX.Element {
       subscribeCount: 0,
       text: '',
       comments: media.comments,
+      hashtags: media.hashtags,
     }),
-    [mediaUser, media.like, media.comments],
+    [mediaUser, media.like, media.comments, media.hashtags],
   )
 
   const router = useRouter()
@@ -80,11 +83,13 @@ export default function MediaDetailLeft(props: Props): React.JSX.Element {
   const [formState, setFormState] = useState<MediaDetailState>(initFormState)
   useEffect(() => setFormState(initFormState), [router.query.ulid, initFormState])
 
-  const { isLike, isSubscribe, likeCount, subscribeCount, text, comments } = formState
+  const { isLike, isSubscribe, likeCount, subscribeCount, text, comments, hashtags } = formState
+  const isOwner = user.isActive && user.ulid === channel.ownerUlid
   const isFallowDisable = !user.isActive || user.ulid === channel.ownerUlid
   const handleModal = () => setIsModal(!isModal)
   const handleContentView = () => setIsContentView(!isContentView)
   const handleCommentView = () => setIsCommentView(!isCommentView)
+  const handleHashtags = (hashtags: Hashtag[]) => setFormState((prev) => ({ ...prev, hashtags }))
   const handleComment = (e: ChangeEvent<HTMLTextAreaElement>) => setFormState((prev) => ({ ...prev, text: e.target.value }))
 
   const handleLike = async () => {
@@ -138,7 +143,7 @@ export default function MediaDetailLeft(props: Props): React.JSX.Element {
           <CountLike isLike={isLike} disable={!user.isActive} count={likeCount} onClick={handleLike} />
         </div>
 
-        <Hashtags hashtags={media.hashtags} mediaPath={media.mediaPath} />
+        <Hashtags hashtags={hashtags} mediaPath={media.mediaPath} mediaUlid={media.ulid} isOwner={isOwner} onUpdate={handleHashtags} onToast={handleToast} />
       </VStack>
 
       <Divide />


### PR DESCRIPTION
## Summary
- `MediaDetailLeft` の `Hashtags` 呼び出しに編集機能（`mediaUlid` / `isOwner` / `onUpdate` / `onToast`）を配線
- `MediaDetailState` に `hashtags` を追加し、保存後の楽観的更新に対応
- `media.ulid` を `Common.tsx` / `Left.tsx` の Props 型に追加

## 変更内容
### `frontend/src/components/widgets/Media/Detail/Common.tsx`
- Props の `media` 型に `ulid: string` を追加（下流の `Left` コンポーネントで使用）

### `frontend/src/components/widgets/Media/Detail/Left.tsx`
- `MediaDetailState` に `hashtags: Hashtag[]` を追加
- `initFormState` の deps に `media.hashtags` を追加して再初期化に追従
- `isOwner = user.isActive && user.ulid === channel.ownerUlid` を導出
- `handleHashtags` を追加し `setFormState` の `hashtags` を更新
- `<Hashtags>` 呼び出しに `mediaUlid` / `isOwner` / `onUpdate` / `onToast` を渡し、表示用の `hashtags` を Props 直渡しから state 経由に変更