### PR TITLE
【back】master hashtag 取得 API を追加

### DIFF
--- a/myus/api/src/adapter/hashtag.py
+++ b/myus/api/src/adapter/hashtag.py
@@ -3,15 +3,27 @@ from ninja import Router
 from api.modules.logger import log
 from api.src.types.dto.hashtag import HashtagDTO
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.hashtag import MediaHashtagsUpdateIn
+from api.src.types.schema.hashtag import HashtagOut, MediaHashtagsUpdateIn
 from api.src.usecase.auth import auth_check
-from api.src.usecase.hashtag import update_media_hashtags
+from api.src.usecase.hashtag import get_master_hashtags, update_media_hashtags
 
 
 class MediaHashtagAPI:
     """MediaHashtagAPI"""
 
     router = Router()
+
+    @staticmethod
+    @router.get("", response={200: list[HashtagOut], 401: ErrorOut})
+    def get(request: HttpRequest):
+        log.info("MediaHashtagAPI get")
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        hashtags = get_master_hashtags()
+        return 200, [HashtagOut(ulid=h.ulid, name=h.name) for h in hashtags]
 
     @staticmethod
     @router.put("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})

--- a/myus/api/src/types/schema/hashtag.py
+++ b/myus/api/src/types/schema/hashtag.py
@@ -11,3 +11,8 @@ class MediaHashtagsUpdateIn(BaseModel):
     media_type: MediaType
     media_ulid: str
     hashtags: list[HashtagItemIn]
+
+
+class HashtagOut(BaseModel):
+    ulid: str
+    name: str

--- a/myus/api/src/usecase/hashtag.py
+++ b/myus/api/src/usecase/hashtag.py
@@ -1,7 +1,7 @@
 import re
 from api.modules.logger import log
 from api.src.domain.interface.hashtag.data import HashtagData
-from api.src.domain.interface.hashtag.interface import FilterOption as HashtagFilterOption, HashtagInterface, SortOption as HashtagSortOption
+from api.src.domain.interface.hashtag.interface import FilterOption as HashtagFilterOption, HashtagInterface, SortOption as HashtagSortOption, SortType as HashtagSortType
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
 from api.src.domain.interface.ng_word.interface import FilterOption as NgWordFilterOption, NgWordInterface, SortOption as NgWordSortOption
 from api.src.injectors.container import injector
@@ -28,6 +28,12 @@ def validate_name(name: str, ng_words: list[str]) -> bool:
     if any(ng in name for ng in ng_words):
         return False
     return True
+
+
+def get_master_hashtags() -> list[HashtagDTO]:
+    repo = injector.get(HashtagInterface)
+    ids = repo.get_ids(HashtagFilterOption(), HashtagSortOption(is_asc=True, sort_type=HashtagSortType.NAME))
+    return [HashtagDTO(ulid=h.ulid, name=h.name) for h in repo.bulk_get(ids)]
 
 
 def get_ng_words() -> list[str]:


### PR DESCRIPTION
## Summary
- `GET /media/hashtag` を新設し、ハッシュタグマスター一覧を返却
- 認証必須（`auth_check`）、`SortType.NAME` 昇順で全件返却
- フロント側のマスター選択 UI（編集モードのプルダウン候補）の取得元として利用予定

## 変更内容
### `myus/api/src/types/schema/hashtag.py`
- 出力スキーマ `HashtagOut`（`ulid`, `name`）を追加

### `myus/api/src/usecase/hashtag.py`
- `get_master_hashtags() -> list[HashtagDTO]` を追加
  - `HashtagInterface.get_ids` + `bulk_get` を `SortType.NAME` 昇順で呼び出し
- `interface` のインポートに `SortType as HashtagSortType` を追加

### `myus/api/src/adapter/hashtag.py`
- `MediaHashtagAPI.get` を追加
- レスポンス: `200: list[HashtagOut]` / `401: ErrorOut`
- 既存 `PUT` と同様に `auth_check` で認証チェック