### PR TITLE
【front】Hashtags 編集 UI にマスター選択・DnD 並び替え・Button 統一

### DIFF
--- a/frontend/src/api/internal/hashtag.ts
+++ b/frontend/src/api/internal/hashtag.ts
@@ -1,9 +1,15 @@
 import { apiClient } from 'lib/axios/internal'
+import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
-import { MediaHashtagsUpdateIn } from 'types/internal/hashtag'
+import { Req } from 'types/global'
+import { HashtagOut, MediaHashtagsUpdateIn } from 'types/internal/hashtag'
 import { ErrorOut } from 'types/internal/other'
 import { apiMediaHashtag } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
+
+export const getHashtags = async (req?: Req): Promise<ApiOut<HashtagOut[]>> => {
+  return await apiOut(apiClient('json').get(apiMediaHashtag, cookieHeader(req)))
+}
 
 export const putMediaHashtags = async (request: MediaHashtagsUpdateIn): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').put(apiMediaHashtag, camelSnake(request)))

--- a/frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss
+++ b/frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss
@@ -28,6 +28,40 @@
     flex: 1;
   }
 
+  .master_list {
+    max-height: 180px;
+    padding: 4px;
+    border: 1px solid rgb(220, 220, 220);
+    border-radius: 4px;
+    background-color: rgb(250, 250, 250);
+    overflow-y: auto;
+  }
+
+  .master_row {
+    padding: 2px 6px;
+    border-radius: 4px;
+
+    &:hover {
+      background-color: rgb(235, 240, 250);
+    }
+  }
+
+  .master_name {
+    font-size: 13px;
+    color: rgb(60, 60, 60);
+  }
+
+  .new_label {
+    font-size: 11px;
+    color: rgb(0, 130, 255);
+  }
+
+  .empty {
+    padding: 4px 6px;
+    font-size: 12px;
+    color: rgb(150, 150, 150);
+  }
+
   .edit_chip {
     display: inline-flex;
     align-items: center;
@@ -35,9 +69,34 @@
     padding: 2px 8px;
     font-size: 13px;
     color: rgb(60, 60, 60);
-    background-color: rgb(240, 245, 255);
     border: 1px solid rgb(180, 200, 230);
     border-radius: 12px;
+    background-color: rgb(240, 245, 255);
+    user-select: none;
+
+    &.dragging {
+      opacity: 0.4;
+    }
+
+    &.drag_over {
+      border-color: rgb(0, 130, 255);
+      background-color: rgb(220, 235, 255);
+    }
+  }
+
+  .drag_handle {
+    display: inline-flex;
+    align-items: center;
+    color: rgb(160, 160, 160);
+    cursor: grab;
+
+    &:hover {
+      color: rgb(0, 130, 255);
+    }
+
+    &:active {
+      cursor: grabbing;
+    }
   }
 
   .delete_button {

--- a/frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss
+++ b/frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss
@@ -62,6 +62,10 @@
     color: rgb(150, 150, 150);
   }
 
+  .loading {
+    padding: 4px 6px;
+  }
+
   .edit_chip {
     display: inline-flex;
     align-items: center;

--- a/frontend/src/components/widgets/Media/Hashtags/index.tsx
+++ b/frontend/src/components/widgets/Media/Hashtags/index.tsx
@@ -10,6 +10,7 @@ import IconCross from 'components/parts/Icon/Cross'
 import IconEdit from 'components/parts/Icon/Edit'
 import IconGrip from 'components/parts/Icon/Grip'
 import Input from 'components/parts/Input'
+import Spinner from 'components/parts/Spinner'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
 import style from './Hashtags.module.scss'
@@ -43,6 +44,7 @@ export default function Hashtags(props: Props): React.JSX.Element {
   const router = useRouter()
   const [isEdit, setIsEdit] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isMasterLoading, setIsMasterLoading] = useState<boolean>(false)
   const [editTags, setEditTags] = useState<Hashtag[]>([])
   const [inputTag, setInputTag] = useState<string>('')
   const [dragIndex, setDragIndex] = useState<number | null>(null)
@@ -63,8 +65,13 @@ export default function Hashtags(props: Props): React.JSX.Element {
     setEditTags([...hashtags])
     setInputTag('')
     setIsEdit(true)
+    setIsMasterLoading(true)
     const ret = await getHashtags()
-    if (ret.isErr()) return
+    setIsMasterLoading(false)
+    if (ret.isErr()) {
+      onToast?.('候補の取得に失敗しました', true)
+      return
+    }
     setMaster(ret.value)
   }
 
@@ -83,10 +90,6 @@ export default function Hashtags(props: Props): React.JSX.Element {
   }
 
   const handleAddNew = () => {
-    if (!showNewRow) {
-      onToast?.('使用できない文字が含まれています', true)
-      return
-    }
     setEditTags([...editTags, { ulid: '', name: normalizedInput }])
     setInputTag('')
   }
@@ -135,21 +138,29 @@ export default function Hashtags(props: Props): React.JSX.Element {
       <VStack gap="2" className={style.edit_area}>
         <Input placeholder="タグ名" maxLength={HASHTAG_MAX_LENGTH} value={inputTag} onChange={handleInput} className={style.input} />
         <VStack gap="1" className={style.master_list}>
-          {showNewRow && (
-            <HStack gap="2" justify="between" className={style.master_row}>
-              <span className={style.master_name}>
-                #{normalizedInput} <span className={style.new_label}>(新規)</span>
-              </span>
-              <Button size="s" color="blue" name="追加" onClick={handleAddNew} />
+          {isMasterLoading ? (
+            <HStack justify="center" className={style.loading}>
+              <Spinner color="gray" size="s" />
             </HStack>
+          ) : (
+            <>
+              {showNewRow && (
+                <HStack gap="2" justify="between" className={style.master_row}>
+                  <span className={style.master_name}>
+                    #{normalizedInput} <span className={style.new_label}>(新規)</span>
+                  </span>
+                  <Button size="s" color="blue" name="追加" onClick={handleAddNew} />
+                </HStack>
+              )}
+              {filteredMaster.map((m) => (
+                <HStack key={m.ulid} gap="2" justify="between" className={style.master_row}>
+                  <span className={style.master_name}>#{m.name}</span>
+                  <Button size="s" color="blue" name="追加" onClick={() => handleAddMaster(m)} />
+                </HStack>
+              ))}
+              {!showNewRow && filteredMaster.length === 0 && <span className={style.empty}>候補なし</span>}
+            </>
           )}
-          {filteredMaster.map((m) => (
-            <HStack key={m.ulid} gap="2" justify="between" className={style.master_row}>
-              <span className={style.master_name}>#{m.name}</span>
-              <Button size="s" color="blue" name="追加" onClick={() => handleAddMaster(m)} />
-            </HStack>
-          ))}
-          {!showNewRow && filteredMaster.length === 0 && <span className={style.empty}>候補なし</span>}
         </VStack>
         <HStack gap="4" wrap>
           {editTags.map((tag, index) => (
@@ -174,7 +185,7 @@ export default function Hashtags(props: Props): React.JSX.Element {
           ))}
         </HStack>
         <HStack gap="2" className={style.edit_actions}>
-          <Button size="s" name="キャンセル" onClick={handleCancel} />
+          <Button size="s" name="キャンセル" disabled={isLoading} onClick={handleCancel} />
           <Button size="s" color="green" name="保存" loading={isLoading} onClick={handleSave} />
         </HStack>
       </VStack>

--- a/frontend/src/components/widgets/Media/Hashtags/index.tsx
+++ b/frontend/src/components/widgets/Media/Hashtags/index.tsx
@@ -1,11 +1,14 @@
 import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
+import { HashtagOut } from 'types/internal/hashtag'
 import { Hashtag } from 'types/internal/media/output'
-import { putMediaHashtags } from 'api/internal/hashtag'
+import { getHashtags, putMediaHashtags } from 'api/internal/hashtag'
 import { MediaPath, MediaType } from 'utils/constants/enum'
-import ButtonSquare from 'components/parts/Button/Square'
+import cx from 'utils/functions/cx'
+import Button from 'components/parts/Button'
 import IconCross from 'components/parts/Icon/Cross'
 import IconEdit from 'components/parts/Icon/Edit'
+import IconGrip from 'components/parts/Icon/Grip'
 import Input from 'components/parts/Input'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
@@ -42,17 +45,27 @@ export default function Hashtags(props: Props): React.JSX.Element {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [editTags, setEditTags] = useState<Hashtag[]>([])
   const [inputTag, setInputTag] = useState<string>('')
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+  const [master, setMaster] = useState<HashtagOut[]>([])
 
   const canEdit = isOwner && mediaUlid !== undefined
+  const normalizedInput = normalizeName(inputTag)
+  const editNames = new Set(editTags.map((t) => t.name))
+  const filteredMaster = master.filter((m) => !editNames.has(m.name) && (normalizedInput === '' || m.name.includes(normalizedInput)))
+  const showNewRow = isValidName(normalizedInput) && !editNames.has(normalizedInput) && !master.some((m) => m.name === normalizedInput)
 
   const handleRouter = (name: string) => {
     router.push(`/media/${mediaPath}?search=${name}`)
   }
 
-  const handleStart = () => {
+  const handleStart = async () => {
     setEditTags([...hashtags])
     setInputTag('')
     setIsEdit(true)
+    const ret = await getHashtags()
+    if (ret.isErr()) return
+    setMaster(ret.value)
   }
 
   const handleCancel = () => {
@@ -62,22 +75,42 @@ export default function Hashtags(props: Props): React.JSX.Element {
   }
 
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setInputTag(e.target.value)
+  const handleDelete = (index: number) => setEditTags(editTags.filter((_, i) => i !== index))
 
-  const handleAdd = () => {
-    const normalized = normalizeName(inputTag)
-    if (!isValidName(normalized)) {
-      onToast?.('使用できない文字が含まれています', true)
-      return
-    }
-    if (editTags.some((t) => t.name === normalized)) {
-      setInputTag('')
-      return
-    }
-    setEditTags([...editTags, { ulid: '', name: normalized }])
+  const handleAddMaster = (item: HashtagOut) => {
+    setEditTags([...editTags, { ulid: item.ulid, name: item.name }])
     setInputTag('')
   }
 
-  const handleDelete = (index: number) => setEditTags(editTags.filter((_, i) => i !== index))
+  const handleAddNew = () => {
+    if (!showNewRow) {
+      onToast?.('使用できない文字が含まれています', true)
+      return
+    }
+    setEditTags([...editTags, { ulid: '', name: normalizedInput }])
+    setInputTag('')
+  }
+
+  const handleDragStart = (index: number) => setDragIndex(index)
+
+  const handleDrag = (e: React.DragEvent, index: number | null = null) => {
+    e.preventDefault()
+    setDragOverIndex(index)
+  }
+
+  const handleDrop = (index: number) => {
+    if (dragIndex === null || dragIndex === index) return
+    const newTags = [...editTags]
+    const removed = newTags.splice(dragIndex, 1)
+    if (removed[0] === undefined) return
+    newTags.splice(index, 0, removed[0])
+    setEditTags(newTags)
+  }
+
+  const handleDragEnd = () => {
+    setDragIndex(null)
+    setDragOverIndex(null)
+  }
 
   const handleSave = async () => {
     if (mediaUlid === undefined) return
@@ -100,13 +133,39 @@ export default function Hashtags(props: Props): React.JSX.Element {
   if (isEdit) {
     return (
       <VStack gap="2" className={style.edit_area}>
-        <HStack gap="2">
-          <Input placeholder="タグ名" maxLength={HASHTAG_MAX_LENGTH} value={inputTag} onChange={handleInput} className={style.input} />
-          <ButtonSquare name="追加" color="sakura" onClick={handleAdd} />
-        </HStack>
+        <Input placeholder="タグ名" maxLength={HASHTAG_MAX_LENGTH} value={inputTag} onChange={handleInput} className={style.input} />
+        <VStack gap="1" className={style.master_list}>
+          {showNewRow && (
+            <HStack gap="2" justify="between" className={style.master_row}>
+              <span className={style.master_name}>
+                #{normalizedInput} <span className={style.new_label}>(新規)</span>
+              </span>
+              <Button size="s" color="blue" name="追加" onClick={handleAddNew} />
+            </HStack>
+          )}
+          {filteredMaster.map((m) => (
+            <HStack key={m.ulid} gap="2" justify="between" className={style.master_row}>
+              <span className={style.master_name}>#{m.name}</span>
+              <Button size="s" color="blue" name="追加" onClick={() => handleAddMaster(m)} />
+            </HStack>
+          ))}
+          {!showNewRow && filteredMaster.length === 0 && <span className={style.empty}>候補なし</span>}
+        </VStack>
         <HStack gap="4" wrap>
           {editTags.map((tag, index) => (
-            <span key={tag.name} className={style.edit_chip}>
+            <span
+              key={tag.name}
+              className={cx(style.edit_chip, dragIndex === index && style.dragging, dragOverIndex === index && style.drag_over)}
+              draggable
+              onDragStart={() => handleDragStart(index)}
+              onDragOver={(e) => handleDrag(e, index)}
+              onDragLeave={(e) => handleDrag(e)}
+              onDrop={() => handleDrop(index)}
+              onDragEnd={handleDragEnd}
+            >
+              <span className={style.drag_handle}>
+                <IconGrip size="12" />
+              </span>
               <span>#{tag.name}</span>
               <span className={style.delete_button} onClick={() => handleDelete(index)}>
                 <IconCross size="14" />
@@ -115,8 +174,8 @@ export default function Hashtags(props: Props): React.JSX.Element {
           ))}
         </HStack>
         <HStack gap="2" className={style.edit_actions}>
-          <ButtonSquare name="キャンセル" color="sakura" onClick={handleCancel} />
-          <ButtonSquare name="保存" color="emerald" loading={isLoading} onClick={handleSave} />
+          <Button size="s" name="キャンセル" onClick={handleCancel} />
+          <Button size="s" color="green" name="保存" loading={isLoading} onClick={handleSave} />
         </HStack>
       </VStack>
     )

--- a/frontend/src/types/internal/hashtag.d.ts
+++ b/frontend/src/types/internal/hashtag.d.ts
@@ -5,6 +5,11 @@ export interface HashtagItem {
   name: string
 }
 
+export interface HashtagOut {
+  ulid: string
+  name: string
+}
+
 export interface MediaHashtagsUpdateIn {
   mediaType: MediaType
   mediaUlid: string


### PR DESCRIPTION
## Summary
- ハッシュタグ編集モードに「マスターからの選択 / 入力での新規追加」 UI を実装（部分一致 FE フィルタ）
- 編集チップに HTML5 DnD を組み込み、並び替えに対応
- `ButtonSquare` を共通 `Button` に統一し、既存 `Comment/ReplyInput` 等と色慣例を揃える

## 変更内容
### `frontend/src/types/internal/hashtag.d.ts`
- `HashtagOut`（`ulid` / `name`）を追加。バックエンドの `GET /media/hashtag` レスポンス型として使用

### `frontend/src/api/internal/hashtag.ts`
- `getHashtags(req?)` を追加。`apiClient('json').get(apiMediaHashtag, cookieHeader(req))` で全マスターを取得

### `frontend/src/components/widgets/Media/Hashtags/index.tsx`
- マスター取得を `handleStart` 内で実行（編集モード突入時に 1 回 fetch、`useEffect` 不使用）
- 入力値で部分一致フィルタ（`m.name.includes(normalizedInput)`）
- `editTags` に既にあるタグはマスター候補から除外
- マスター行ごとに `<Button color="blue" size="s" name="追加">` を配置（`handleAddMaster` で既存 ulid 付き追加）
- 入力値がマスター不一致 + バリデーション通過 + 重複なし のときに「`#xxx (新規)`」行を先頭に表示し、`handleAddNew` で `ulid: ''` の新規として追加
- マスター候補も新規追加候補も無いケースに「候補なし」表示
- 編集チップを `draggable` 化し、`dragIndex` / `dragOverIndex` 状態と `handleDragStart` / `handleDrag` / `handleDrop` / `handleDragEnd` を追加（`SearchTagBar` と同等パターン）
- チップ先頭に `IconGrip` のドラッグハンドルを追加
- ボタンを `ButtonSquare` から共通 `Button` へ置換: 追加=blue, キャンセル=デフォルト, 保存=green（`loading` 付き）

### `frontend/src/components/widgets/Media/Hashtags/Hashtags.module.scss`
- `.master_list`（max-height 180px / scroll） / `.master_row`（ホバー強調） / `.master_name` / `.new_label` / `.empty` を追加
- `.edit_chip` に `&.dragging`（透過） / `&.drag_over`（強調ボーダー・背景）と `user-select: none` を追加
- `.drag_handle`（`cursor: grab` / `:active grabbing`）を新設