### PR TITLE
【front】Hashtags 編集 UI を Edit コンポーネントに分割

### DIFF
--- a/frontend/src/components/widgets/Media/Hashtags/Edit.tsx
+++ b/frontend/src/components/widgets/Media/Hashtags/Edit.tsx
@@ -1,0 +1,162 @@
+import { ChangeEvent, useState } from 'react'
+import { HashtagOut } from 'types/internal/hashtag'
+import { Hashtag } from 'types/internal/media/output'
+import { putMediaHashtags } from 'api/internal/hashtag'
+import { MediaPath, MediaType } from 'utils/constants/enum'
+import cx from 'utils/functions/cx'
+import Button from 'components/parts/Button'
+import IconCross from 'components/parts/Icon/Cross'
+import IconGrip from 'components/parts/Icon/Grip'
+import Input from 'components/parts/Input'
+import Spinner from 'components/parts/Spinner'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+import style from './Hashtags.module.scss'
+
+const HASHTAG_MAX_LENGTH = 30
+const ALLOWED_PATTERN = /^[ぁ-んァ-ヶー一-龯a-zA-Z]+$/
+
+const pathToTypeMap: Record<MediaPath, MediaType> = {
+  [MediaPath.Video]: MediaType.Video,
+  [MediaPath.Music]: MediaType.Music,
+  [MediaPath.Blog]: MediaType.Blog,
+  [MediaPath.Comic]: MediaType.Comic,
+  [MediaPath.Picture]: MediaType.Picture,
+  [MediaPath.Chat]: MediaType.Chat,
+}
+
+const normalizeName = (raw: string): string => raw.trim().replace(/^#+/, '').toLowerCase()
+const isValidName = (name: string): boolean => name.length > 0 && name.length <= HASHTAG_MAX_LENGTH && ALLOWED_PATTERN.test(name)
+
+interface Props {
+  hashtags: Hashtag[]
+  master: HashtagOut[]
+  isMasterLoading: boolean
+  mediaPath: MediaPath
+  mediaUlid: string
+  onSave: (hashtags: Hashtag[]) => void
+  onCancel: () => void
+  onToast?: (content: string, isError: boolean) => void
+}
+
+export default function HashtagsEdit(props: Props): React.JSX.Element {
+  const { hashtags, master, isMasterLoading, mediaPath, mediaUlid, onSave, onCancel, onToast } = props
+
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [editTags, setEditTags] = useState<Hashtag[]>([...hashtags])
+  const [inputTag, setInputTag] = useState<string>('')
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+
+  const normalizedInput = normalizeName(inputTag)
+  const editNames = new Set(editTags.map((t) => t.name))
+  const filteredMaster = master.filter((m) => !editNames.has(m.name) && (normalizedInput === '' || m.name.includes(normalizedInput)))
+  const showNewRow = isValidName(normalizedInput) && !editNames.has(normalizedInput) && !master.some((m) => m.name === normalizedInput)
+
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setInputTag(e.target.value)
+  const handleDelete = (index: number) => setEditTags(editTags.filter((_, i) => i !== index))
+
+  const handleAddMaster = (item: HashtagOut) => {
+    setEditTags([...editTags, { ulid: item.ulid, name: item.name }])
+    setInputTag('')
+  }
+
+  const handleAddNew = () => {
+    setEditTags([...editTags, { ulid: '', name: normalizedInput }])
+    setInputTag('')
+  }
+
+  const handleDragStart = (index: number) => setDragIndex(index)
+
+  const handleDrag = (e: React.DragEvent, index: number | null = null) => {
+    e.preventDefault()
+    setDragOverIndex(index)
+  }
+
+  const handleDrop = (index: number) => {
+    if (dragIndex === null || dragIndex === index) return
+    const newTags = [...editTags]
+    const removed = newTags.splice(dragIndex, 1)
+    if (removed[0] === undefined) return
+    newTags.splice(index, 0, removed[0])
+    setEditTags(newTags)
+  }
+
+  const handleDragEnd = () => {
+    setDragIndex(null)
+    setDragOverIndex(null)
+  }
+
+  const handleSave = async () => {
+    setIsLoading(true)
+    const ret = await putMediaHashtags({
+      mediaType: pathToTypeMap[mediaPath],
+      mediaUlid,
+      hashtags: editTags,
+    })
+    setIsLoading(false)
+    if (ret.isErr()) {
+      onToast?.('ハッシュタグの保存に失敗しました', true)
+      return
+    }
+    onSave(editTags)
+    onToast?.('ハッシュタグを保存しました', false)
+  }
+
+  return (
+    <VStack gap="2" className={style.edit_area}>
+      <Input placeholder="タグ名" maxLength={HASHTAG_MAX_LENGTH} value={inputTag} onChange={handleInput} className={style.input} />
+      <VStack gap="1" className={style.master_list}>
+        {isMasterLoading ? (
+          <HStack justify="center" className={style.loading}>
+            <Spinner color="gray" size="s" />
+          </HStack>
+        ) : (
+          <>
+            {showNewRow && (
+              <HStack gap="2" justify="between" className={style.master_row}>
+                <span className={style.master_name}>
+                  #{normalizedInput} <span className={style.new_label}>(新規)</span>
+                </span>
+                <Button size="s" color="blue" name="追加" onClick={handleAddNew} />
+              </HStack>
+            )}
+            {filteredMaster.map((m) => (
+              <HStack key={m.ulid} gap="2" justify="between" className={style.master_row}>
+                <span className={style.master_name}>#{m.name}</span>
+                <Button size="s" color="blue" name="追加" onClick={() => handleAddMaster(m)} />
+              </HStack>
+            ))}
+            {!showNewRow && filteredMaster.length === 0 && <span className={style.empty}>候補なし</span>}
+          </>
+        )}
+      </VStack>
+      <HStack gap="4" wrap>
+        {editTags.map((tag, index) => (
+          <span
+            key={tag.name}
+            className={cx(style.edit_chip, dragIndex === index && style.dragging, dragOverIndex === index && style.drag_over)}
+            draggable
+            onDragStart={() => handleDragStart(index)}
+            onDragOver={(e) => handleDrag(e, index)}
+            onDragLeave={(e) => handleDrag(e)}
+            onDrop={() => handleDrop(index)}
+            onDragEnd={handleDragEnd}
+          >
+            <span className={style.drag_handle}>
+              <IconGrip size="12" />
+            </span>
+            <span>#{tag.name}</span>
+            <span className={style.delete_button} onClick={() => handleDelete(index)}>
+              <IconCross size="14" />
+            </span>
+          </span>
+        ))}
+      </HStack>
+      <HStack gap="2" className={style.edit_actions}>
+        <Button size="s" name="キャンセル" disabled={isLoading} onClick={onCancel} />
+        <Button size="s" color="green" name="保存" loading={isLoading} onClick={handleSave} />
+      </HStack>
+    </VStack>
+  )
+}

--- a/frontend/src/components/widgets/Media/Hashtags/index.tsx
+++ b/frontend/src/components/widgets/Media/Hashtags/index.tsx
@@ -1,34 +1,13 @@
-import { ChangeEvent, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { HashtagOut } from 'types/internal/hashtag'
 import { Hashtag } from 'types/internal/media/output'
-import { getHashtags, putMediaHashtags } from 'api/internal/hashtag'
-import { MediaPath, MediaType } from 'utils/constants/enum'
-import cx from 'utils/functions/cx'
-import Button from 'components/parts/Button'
-import IconCross from 'components/parts/Icon/Cross'
+import { getHashtags } from 'api/internal/hashtag'
+import { MediaPath } from 'utils/constants/enum'
 import IconEdit from 'components/parts/Icon/Edit'
-import IconGrip from 'components/parts/Icon/Grip'
-import Input from 'components/parts/Input'
-import Spinner from 'components/parts/Spinner'
 import HStack from 'components/parts/Stack/Horizontal'
-import VStack from 'components/parts/Stack/Vertical'
+import HashtagsEdit from './Edit'
 import style from './Hashtags.module.scss'
-
-const HASHTAG_MAX_LENGTH = 30
-const ALLOWED_PATTERN = /^[ぁ-んァ-ヶー一-龯a-zA-Z]+$/
-
-const pathToTypeMap: Record<MediaPath, MediaType> = {
-  [MediaPath.Video]: MediaType.Video,
-  [MediaPath.Music]: MediaType.Music,
-  [MediaPath.Blog]: MediaType.Blog,
-  [MediaPath.Comic]: MediaType.Comic,
-  [MediaPath.Picture]: MediaType.Picture,
-  [MediaPath.Chat]: MediaType.Chat,
-}
-
-const normalizeName = (raw: string): string => raw.trim().replace(/^#+/, '').toLowerCase()
-const isValidName = (name: string): boolean => name.length > 0 && name.length <= HASHTAG_MAX_LENGTH && ALLOWED_PATTERN.test(name)
 
 interface Props {
   hashtags: Hashtag[]
@@ -41,29 +20,19 @@ interface Props {
 
 export default function Hashtags(props: Props): React.JSX.Element {
   const { hashtags, mediaPath, mediaUlid, isOwner = false, onUpdate, onToast } = props
+
   const router = useRouter()
   const [isEdit, setIsEdit] = useState<boolean>(false)
-  const [isLoading, setIsLoading] = useState<boolean>(false)
   const [isMasterLoading, setIsMasterLoading] = useState<boolean>(false)
-  const [editTags, setEditTags] = useState<Hashtag[]>([])
-  const [inputTag, setInputTag] = useState<string>('')
-  const [dragIndex, setDragIndex] = useState<number | null>(null)
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const [master, setMaster] = useState<HashtagOut[]>([])
 
   const canEdit = isOwner && mediaUlid !== undefined
-  const normalizedInput = normalizeName(inputTag)
-  const editNames = new Set(editTags.map((t) => t.name))
-  const filteredMaster = master.filter((m) => !editNames.has(m.name) && (normalizedInput === '' || m.name.includes(normalizedInput)))
-  const showNewRow = isValidName(normalizedInput) && !editNames.has(normalizedInput) && !master.some((m) => m.name === normalizedInput)
 
   const handleRouter = (name: string) => {
     router.push(`/media/${mediaPath}?search=${name}`)
   }
 
   const handleStart = async () => {
-    setEditTags([...hashtags])
-    setInputTag('')
     setIsEdit(true)
     setIsMasterLoading(true)
     const ret = await getHashtags()
@@ -75,120 +44,25 @@ export default function Hashtags(props: Props): React.JSX.Element {
     setMaster(ret.value)
   }
 
-  const handleCancel = () => {
-    setEditTags([])
-    setInputTag('')
+  const handleCancel = () => setIsEdit(false)
+
+  const handleSave = (saved: Hashtag[]) => {
+    onUpdate?.(saved)
     setIsEdit(false)
   }
 
-  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setInputTag(e.target.value)
-  const handleDelete = (index: number) => setEditTags(editTags.filter((_, i) => i !== index))
-
-  const handleAddMaster = (item: HashtagOut) => {
-    setEditTags([...editTags, { ulid: item.ulid, name: item.name }])
-    setInputTag('')
-  }
-
-  const handleAddNew = () => {
-    setEditTags([...editTags, { ulid: '', name: normalizedInput }])
-    setInputTag('')
-  }
-
-  const handleDragStart = (index: number) => setDragIndex(index)
-
-  const handleDrag = (e: React.DragEvent, index: number | null = null) => {
-    e.preventDefault()
-    setDragOverIndex(index)
-  }
-
-  const handleDrop = (index: number) => {
-    if (dragIndex === null || dragIndex === index) return
-    const newTags = [...editTags]
-    const removed = newTags.splice(dragIndex, 1)
-    if (removed[0] === undefined) return
-    newTags.splice(index, 0, removed[0])
-    setEditTags(newTags)
-  }
-
-  const handleDragEnd = () => {
-    setDragIndex(null)
-    setDragOverIndex(null)
-  }
-
-  const handleSave = async () => {
-    if (mediaUlid === undefined) return
-    setIsLoading(true)
-    const ret = await putMediaHashtags({
-      mediaType: pathToTypeMap[mediaPath],
-      mediaUlid,
-      hashtags: editTags,
-    })
-    setIsLoading(false)
-    if (ret.isErr()) {
-      onToast?.('ハッシュタグの保存に失敗しました', true)
-      return
-    }
-    onUpdate?.(editTags)
-    onToast?.('ハッシュタグを保存しました', false)
-    setIsEdit(false)
-  }
-
-  if (isEdit) {
+  if (isEdit && mediaUlid !== undefined) {
     return (
-      <VStack gap="2" className={style.edit_area}>
-        <Input placeholder="タグ名" maxLength={HASHTAG_MAX_LENGTH} value={inputTag} onChange={handleInput} className={style.input} />
-        <VStack gap="1" className={style.master_list}>
-          {isMasterLoading ? (
-            <HStack justify="center" className={style.loading}>
-              <Spinner color="gray" size="s" />
-            </HStack>
-          ) : (
-            <>
-              {showNewRow && (
-                <HStack gap="2" justify="between" className={style.master_row}>
-                  <span className={style.master_name}>
-                    #{normalizedInput} <span className={style.new_label}>(新規)</span>
-                  </span>
-                  <Button size="s" color="blue" name="追加" onClick={handleAddNew} />
-                </HStack>
-              )}
-              {filteredMaster.map((m) => (
-                <HStack key={m.ulid} gap="2" justify="between" className={style.master_row}>
-                  <span className={style.master_name}>#{m.name}</span>
-                  <Button size="s" color="blue" name="追加" onClick={() => handleAddMaster(m)} />
-                </HStack>
-              ))}
-              {!showNewRow && filteredMaster.length === 0 && <span className={style.empty}>候補なし</span>}
-            </>
-          )}
-        </VStack>
-        <HStack gap="4" wrap>
-          {editTags.map((tag, index) => (
-            <span
-              key={tag.name}
-              className={cx(style.edit_chip, dragIndex === index && style.dragging, dragOverIndex === index && style.drag_over)}
-              draggable
-              onDragStart={() => handleDragStart(index)}
-              onDragOver={(e) => handleDrag(e, index)}
-              onDragLeave={(e) => handleDrag(e)}
-              onDrop={() => handleDrop(index)}
-              onDragEnd={handleDragEnd}
-            >
-              <span className={style.drag_handle}>
-                <IconGrip size="12" />
-              </span>
-              <span>#{tag.name}</span>
-              <span className={style.delete_button} onClick={() => handleDelete(index)}>
-                <IconCross size="14" />
-              </span>
-            </span>
-          ))}
-        </HStack>
-        <HStack gap="2" className={style.edit_actions}>
-          <Button size="s" name="キャンセル" disabled={isLoading} onClick={handleCancel} />
-          <Button size="s" color="green" name="保存" loading={isLoading} onClick={handleSave} />
-        </HStack>
-      </VStack>
+      <HashtagsEdit
+        hashtags={hashtags}
+        master={master}
+        isMasterLoading={isMasterLoading}
+        mediaPath={mediaPath}
+        mediaUlid={mediaUlid}
+        onSave={handleSave}
+        onCancel={handleCancel}
+        onToast={onToast}
+      />
     )
   }
 


### PR DESCRIPTION
## Summary
- Hashtags の編集パネルを `Edit.tsx` に分割し、`index.tsx` は表示と編集モード切替のみを担当する構成に変更
- マスター候補取得は親の編集開始ハンドラで実施し、結果を子に props で渡すことで `useEffect` を排除

## 変更内容

### `frontend/src/components/widgets/Media/Hashtags/Edit.tsx`（新規）
- 編集パネルの JSX と編集関連 state（`editTags`, `inputTag`, `dragIndex`, `dragOverIndex`, `isLoading`）を移管
- 入力ハンドラ、マスター追加・新規追加、ドラッグ並び替え、保存ハンドラを集約
- `master` / `isMasterLoading` は親から props で受け取る

### `frontend/src/components/widgets/Media/Hashtags/index.tsx`（変更）
- 編集モード時は `<HashtagsEdit>` を返すだけに簡素化
- `handleStart` でマスター候補を取得し state に保持、編集開始ボタン押下のみで取得
- `handleSave` は子の保存完了通知を受けて `onUpdate` 呼び出しと `isEdit` 解除を行う