### PR TITLE
【back】CategoryInterface に bulk_save を追加

### DIFF
--- a/myus/api/src/domain/entity/category/_convert.py
+++ b/myus/api/src/domain/entity/category/_convert.py
@@ -1,5 +1,8 @@
+from typing import assert_never
 from api.db.models.master import Category
+from api.db.models.media import Blog, Chat, Comic, Music, Picture, Video
 from api.src.domain.interface.category.data import CategoryData
+from api.utils.enum.index import MediaType
 
 
 def convert_data(obj: Category) -> CategoryData:
@@ -9,3 +12,21 @@ def convert_data(obj: Category) -> CategoryData:
         jp_name=obj.jp_name,
         en_name=obj.en_name,
     )
+
+
+def get_media_model(media_type: MediaType) -> type[Video] | type[Music] | type[Blog] | type[Comic] | type[Picture] | type[Chat]:
+    match media_type:
+        case MediaType.VIDEO:
+            return Video
+        case MediaType.MUSIC:
+            return Music
+        case MediaType.BLOG:
+            return Blog
+        case MediaType.COMIC:
+            return Comic
+        case MediaType.PICTURE:
+            return Picture
+        case MediaType.CHAT:
+            return Chat
+        case _:
+            assert_never(media_type)

--- a/myus/api/src/domain/entity/category/repository.py
+++ b/myus/api/src/domain/entity/category/repository.py
@@ -1,10 +1,11 @@
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from api.db.models.master import Category
-from api.src.domain.entity.category._convert import convert_data
+from api.src.domain.entity.category._convert import convert_data, get_media_model
 from api.src.domain.entity.index import sort_ids
 from api.src.domain.interface.category.data import CategoryData
 from api.src.domain.interface.category.interface import CategoryInterface, FilterOption, SortOption
+from api.utils.enum.index import MediaType
 
 
 class CategoryRepository(CategoryInterface):
@@ -32,3 +33,17 @@ class CategoryRepository(CategoryInterface):
         objs = list(self.queryset().filter(id__in=ids))
         sorted_objs = sort_ids(objs, ids)
         return [convert_data(obj) for obj in sorted_objs]
+
+    def bulk_save(self, media_type: MediaType, media_id: int, objs: list[CategoryData]) -> list[int]:
+        if len(objs) == 0:
+            category_ids: list[int] = []
+        else:
+            ulids = [o.ulid for o in objs if o.ulid]
+            existing_map = {c.ulid: c.id for c in Category.objects.filter(ulid__in=ulids)}
+            category_ids = [existing_map[o.ulid] for o in objs if o.ulid in existing_map]
+
+        model_class = get_media_model(media_type)
+        obj = model_class.objects.get(id=media_id)
+        obj.category.set(category_ids)
+
+        return category_ids

--- a/myus/api/src/domain/interface/category/interface.py
+++ b/myus/api/src/domain/interface/category/interface.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from api.src.domain.interface.category.data import CategoryData
+from api.utils.enum.index import MediaType
 
 
 class SortType(Enum):
@@ -27,4 +28,8 @@ class CategoryInterface(ABC):
 
     @abstractmethod
     def bulk_get(self, ids: list[int]) -> list[CategoryData]:
+        ...
+
+    @abstractmethod
+    def bulk_save(self, media_type: MediaType, media_id: int, objs: list[CategoryData]) -> list[int]:
         ...


### PR DESCRIPTION
## Summary
- `CategoryInterface` に `bulk_save(media_type, media_id, objs)` を追加（`HashtagInterface.bulk_save` と完全同シグネチャ）
- 対象 media モデルの `category` M2M を `.set()` で上書きする実装
- `get_media_model` ヘルパを `_convert.py` に追加

## 変更内容

### `domain/interface/category/interface.py`
- `bulk_save(self, media_type: MediaType, media_id: int, objs: list[CategoryData]) -> list[int]` を抽象メソッドとして追加。`HashtagInterface.bulk_save` のシグネチャと完全一致

### `domain/entity/category/_convert.py`
- `get_media_model(media_type) -> type[Video] | type[Music] | type[Blog] | type[Comic] | type[Picture] | type[Chat]` を追加。具体ユニオン返り値で mypy の `type[Model]` 警告を回避
- ※ 現状 `user/_convert.py:107` に同名・同実装が存在。中期的には共通化（`api/utils/functions/media.py` への集約）が望ましい

### `domain/entity/category/repository.py`
- `bulk_save` を実装: `objs` の `ulid` を解決 → `category_ids` を確定 → `model_class.objects.get(id=media_id)` で対象 media を取得 → `obj.category.set(category_ids)`
- 単一の M2M `set()` 呼び出しのみなので明示的な `transaction.atomic()` は使用せず（呼び出し側 usecase でトランザクション制御する想定）
- 命名は既存規約に準拠: `obj` / `model_class` (`user/repository.py:91-92` と同形式)

## 残タスク（別 PR）
- usecase / adapter / schema / DI 登録と blog 作成画面のカテゴリー連携
- `get_media_model` を `api/utils/functions/media.py` に集約して重複解消