### PR TITLE
【front】blog 作成画面にカテゴリー選択を追加

### DIFF
--- a/frontend/src/api/internal/category.ts
+++ b/frontend/src/api/internal/category.ts
@@ -1,0 +1,10 @@
+import { apiClient } from 'lib/axios/internal'
+import { cookieHeader } from 'lib/config'
+import { ApiOut, apiOut } from 'lib/error'
+import { Req } from 'types/global'
+import { Category } from 'types/internal/category'
+import { apiMediaCategory } from 'api/uri'
+
+export const getCategories = async (req?: Req): Promise<ApiOut<Category[]>> => {
+  return await apiOut(apiClient('json').get(apiMediaCategory, cookieHeader(req)))
+}

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -56,6 +56,7 @@ export const apiPicture = (ulid: string) => base + `/media/picture/${ulid}`
 export const apiChats = base + '/media/chat'
 export const apiChat = (ulid: string) => base + `/media/chat/${ulid}`
 
+export const apiMediaCategory = base + '/media/category'
 export const apiMediaHashtag = base + '/media/hashtag'
 
 export const apiComments = base + '/media/comment'

--- a/frontend/src/components/templates/manage/blog/create.tsx
+++ b/frontend/src/components/templates/manage/blog/create.tsx
@@ -1,5 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import dynamic from 'next/dynamic'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { BlogIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
@@ -21,18 +22,20 @@ const TextEditor = dynamic(() => import('components/widgets/TextEditor'), { ssr:
 
 interface Props {
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function BlogCreate(props: Props): React.JSX.Element {
-  const { channels } = props
+  const { channels, categories } = props
 
   const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<BlogIn>({ channelUlid, publish: true, title: '', content: '', richtext: '', delta: '' })
+  const [values, setValues] = useState<BlogIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', richtext: '', delta: '' })
 
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -46,8 +49,8 @@ export default function BlogCreate(props: Props): React.JSX.Element {
   }
 
   const handleForm = async () => {
-    const { channelUlid, title, content, richtext, image } = values
-    if (!isRequiredCheck({ channelUlid, title, content, richtext, image })) return
+    const { channelUlid, categoryUlid, title, content, richtext, image } = values
+    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, richtext, image })) return
     handleLoading(true)
     const ret = await postBlogCreate(values)
     handleLoading(false)
@@ -55,7 +58,7 @@ export default function BlogCreate(props: Props): React.JSX.Element {
       handleToast(FetchError.Post, true)
       return
     }
-    setValues({ channelUlid, publish: true, title: '', content: '', richtext: '', delta: '' })
+    setValues({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', richtext: '', delta: '' })
     handleToast('作成しました', false)
   }
 
@@ -65,6 +68,7 @@ export default function BlogCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />

--- a/frontend/src/pages/manage/blog/create.tsx
+++ b/frontend/src/pages/manage/blog/create.tsx
@@ -1,21 +1,26 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import ErrorCheck from 'components/widgets/Error/Check'
 import BlogCreate from 'components/templates/manage/blog/create'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const ret = await getChannels(req)
-  if (ret.isErr()) return { props: { status: ret.error.status } }
-  const channels = ret.value
-  return { props: { ...translations, channels } }
+  const [channelRet, categoryRet] = await Promise.all([getChannels(req), getCategories(req)])
+  if (channelRet.isErr()) return { props: { status: channelRet.error.status } }
+  if (categoryRet.isErr()) return { props: { status: categoryRet.error.status } }
+  const channels = channelRet.value
+  const categories = categoryRet.value
+  return { props: { ...translations, channels, categories } }
 }
 
 interface Props {
   status: number
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function BlogCreatePage(props: Props): React.JSX.Element {

--- a/frontend/src/types/internal/category.d.ts
+++ b/frontend/src/types/internal/category.d.ts
@@ -1,0 +1,5 @@
+export interface Category {
+  ulid: string
+  jpName: string
+  enName: string
+}

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -19,6 +19,7 @@ export interface MusicIn {
 
 export interface BlogIn {
   channelUlid: string
+  categoryUlid: string
   publish: boolean
   title: string
   content: string


### PR DESCRIPTION
## Summary
- blog 作成画面のチャンネル選択の下にカテゴリー選択用 `SelectBox` を追加（選択肢は1つのみ）
- `getCategories` API クライアントと `Category` 型を新設
- `pages/manage/blog/create` で `getChannels` と並列にカテゴリ一覧を SSR 取得

## 変更内容

### `frontend/src/types/internal/category.d.ts`（新規）
- `Category` 型（`ulid` / `jpName` / `enName`）

### `frontend/src/api/internal/category.ts`（新規）
- `getCategories(req?)` で `apiMediaCategory` (`/api/media/category`) から取得

### `frontend/src/api/uri.ts`
- `apiMediaCategory` 定数を追加（`apiMediaHashtag` と同じ並びの `/media/` 系ブロック）

### `frontend/src/types/internal/media/input.d.ts`
- `BlogIn` に `categoryUlid: string` を追加（必須）

### `frontend/src/pages/manage/blog/create.tsx`
- `getChannels` と `getCategories` を `Promise.all` で並列取得し、いずれかエラーなら status を伝搬
- `Props` に `categories: Category[]` を追加

### `frontend/src/components/templates/manage/blog/create.tsx`
- `Props` / 初期 state / リセット処理に `categoryUlid` を追加
- 「チャンネル」直下に「カテゴリー」`SelectBox` を配置。先頭オプションは `{ label: '未選択', value: '' }` を入れて未選択を許容
- `isRequiredCheck` の対象に `categoryUlid` を含めて未選択時のサブミットを防止