### PR TITLE
【front】SelectBox に required Props を追加し blog 作成のカテゴリーで適用

### DIFF
--- a/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
+++ b/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
@@ -9,11 +9,17 @@
     font-size: 14px;
     border: 1px solid rgb(200, 200, 200);
     border-radius: 5px;
+    background: rgb(255, 255, 255);
     cursor: pointer;
 
     &:focus-visible {
       outline: none;
       border-color: rgb(40, 130, 250);
+    }
+
+    &.error {
+      color: rgb(0, 0, 0);
+      background: rgb(255, 240, 240);
     }
   }
 
@@ -31,7 +37,13 @@
 
 .label {
   display: block;
-  margin-bottom: 4px;
   font-size: 14px;
   color: rgb(50, 50, 50);
+}
+
+.error_text {
+  padding-top: 2px;
+  text-indent: 4px;
+  font-size: 12px;
+  color: rgb(255, 0, 0);
 }

--- a/frontend/src/components/parts/Input/SelectBox/index.tsx
+++ b/frontend/src/components/parts/Input/SelectBox/index.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent } from 'react'
 import { Option } from 'types/internal/other'
+import cx from 'utils/functions/cx'
 import Select from 'components/parts/Select'
+import VStack from 'components/parts/Stack/Vertical'
 import style from './SelectBox.module.scss'
 
 interface Props {
@@ -9,24 +11,28 @@ interface Props {
   value: string
   options: Option[]
   placeholder?: string
+  required?: boolean
   disabled?: boolean
   className?: string
   onChange?: (e: ChangeEvent<HTMLSelectElement>) => void
 }
 
 export default function SelectBox(props: Props): React.JSX.Element {
-  const { label, className } = props
+  const { label, value, required = false, className, ...rest } = props
+
+  const isRequired = required && !value
 
   return (
-    <div className={className}>
+    <VStack gap="2" className={className}>
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
         </label>
       )}
       <div className={style.select_box}>
-        <Select {...props} id={label} className={style.select} />
+        <Select {...rest} value={value} id={label} className={cx(style.select, isRequired && style.error)} />
       </div>
-    </div>
+      {isRequired && <p className={style.error_text}>※必須入力です！</p>}
+    </VStack>
   )
 }

--- a/frontend/src/components/templates/manage/blog/create.tsx
+++ b/frontend/src/components/templates/manage/blog/create.tsx
@@ -68,7 +68,7 @@ export default function BlogCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />


### PR DESCRIPTION
## Summary
- `SelectBox` に `required` Props を追加し、空値のとき赤背景 + 「※必須入力です！」を表示（`Input` / `Textarea` と同形式）
- blog 作成画面のカテゴリー `SelectBox` に `required={isRequired}` を渡し、未選択でサブミットしたとき可視エラーを出す

## 変更内容

### `components/parts/Input/SelectBox/index.tsx`
- `required?: boolean` Props を追加
- `value` を分割代入で取り出し、`isRequired = required && !value` を判定
- 外側を `<VStack gap="2">` に変更（`Input` / `Textarea` と統一）
- `<Select>` の className に `isRequired && style.error` を `cx` で連結
- 空値検知時に `<p>※必須入力です！</p>` を表示
- `Select` 側に `required` prop を spread しないよう、destructure で `rest` を作成して渡す（`Select` のシグネチャに不要な prop を渡さない）

### `components/parts/Input/SelectBox/SelectBox.module.scss`
- `.select` に `background: rgb(255, 255, 255)` をデフォルト指定
- `.select.error` を追加（赤背景 `rgb(255, 240, 240)`、`Input` と一致）
- `.label` の `margin-bottom: 4px` を削除（外側の `VStack gap="2"` で間隔を担保）
- `.error_text` を追加（`Input.module.scss` と同じスタイル）

### `components/templates/manage/blog/create.tsx`
- カテゴリー `SelectBox` に `required={isRequired}` を渡す。`isRequiredCheck` で `categoryUlid` を検査済みのため、未選択のままサブミットすると赤背景 + メッセージが表示される