### PR TITLE
【front】Input 系 parts の VStack 依存を削除し SCSS をネスト構造に整理

### DIFF
--- a/frontend/src/components/parts/Input/File/index.tsx
+++ b/frontend/src/components/parts/Input/File/index.tsx
@@ -1,6 +1,5 @@
 import { ChangeEvent, useRef, useState } from 'react'
 import cx from 'utils/functions/cx'
-import VStack from 'components/parts/Stack/Vertical'
 import style from '../Input.module.scss'
 
 interface Props {
@@ -36,7 +35,7 @@ export default function InputFile(props: Props): React.JSX.Element {
   }
 
   return (
-    <VStack gap="2" className={className}>
+    <div className={cx(style.box, className)}>
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
@@ -46,6 +45,6 @@ export default function InputFile(props: Props): React.JSX.Element {
       <input placeholder="ファイル選択..." value={fileNames.join(', ')} required={required} onClick={handleClick} className={cx(style.input, isRequired && style.error)} />
       {isRequired && <p className={style.error_text}>※必須入力です！</p>}
       {isErrorText && <p className={style.error_text}>{errorText}</p>}
-    </VStack>
+    </div>
   )
 }

--- a/frontend/src/components/parts/Input/Input.module.scss
+++ b/frontend/src/components/parts/Input/Input.module.scss
@@ -1,38 +1,44 @@
-.input {
-  width: 100%;
-  height: 36px;
-  padding: 6px 12px;
-  font-size: 14px;
-  border: 1px solid rgb(200, 200, 200);
-  border-radius: 5px;
-  background: rgb(255, 255, 255);
+.box {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 
-  &.disabled {
-    color: rgb(120, 120, 120);
-    border-color: rgb(220, 220, 220);
-    background: rgb(240, 240, 240);
+  .label {
+    display: block;
+    font-size: 14px;
+    color: rgb(50, 50, 50);
   }
 
-  &:focus-visible {
-    outline: none;
-    border-color: rgb(40, 130, 250);
+  .input {
+    width: 100%;
+    height: 36px;
+    padding: 6px 12px;
+    font-size: 14px;
+    border: 1px solid rgb(200, 200, 200);
+    border-radius: 5px;
+    background: rgb(255, 255, 255);
+
+    &.disabled {
+      color: rgb(120, 120, 120);
+      border-color: rgb(220, 220, 220);
+      background: rgb(240, 240, 240);
+    }
+
+    &:focus-visible {
+      outline: none;
+      border-color: rgb(40, 130, 250);
+    }
+
+    &.error {
+      color: rgb(0, 0, 0);
+      background: rgb(255, 240, 240);
+    }
   }
 
-  &.error {
-    color: rgb(0, 0, 0);
-    background: rgb(255, 240, 240);
+  .error_text {
+    padding-top: 2px;
+    text-indent: 4px;
+    font-size: 12px;
+    color: rgb(255, 0, 0);
   }
-}
-
-.label {
-  display: block;
-  font-size: 14px;
-  color: rgb(50, 50, 50);
-}
-
-.error_text {
-  padding-top: 2px;
-  text-indent: 4px;
-  font-size: 12px;
-  color: rgb(255, 0, 0);
 }

--- a/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
+++ b/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
@@ -1,49 +1,55 @@
-.select_box {
-  position: relative;
+.box {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 
-  .select {
-    width: 100%;
-    height: 36px;
-    padding: 6px 12px;
-    appearance: none;
+  .label {
+    display: block;
     font-size: 14px;
-    border: 1px solid rgb(200, 200, 200);
-    border-radius: 5px;
-    background: rgb(255, 255, 255);
-    cursor: pointer;
+    color: rgb(50, 50, 50);
+  }
 
-    &:focus-visible {
-      outline: none;
-      border-color: rgb(40, 130, 250);
+  .select_box {
+    position: relative;
+
+    .select {
+      width: 100%;
+      height: 36px;
+      padding: 6px 12px;
+      appearance: none;
+      font-size: 14px;
+      border: 1px solid rgb(200, 200, 200);
+      border-radius: 5px;
+      background: rgb(255, 255, 255);
+      cursor: pointer;
+
+      &:focus-visible {
+        outline: none;
+        border-color: rgb(40, 130, 250);
+      }
+
+      &.error {
+        color: rgb(0, 0, 0);
+        background: rgb(255, 240, 240);
+      }
     }
 
-    &.error {
-      color: rgb(0, 0, 0);
-      background: rgb(255, 240, 240);
+    &::after {
+      content: '';
+      position: absolute;
+      top: calc(50% - 1px);
+      right: 10px;
+      border: 4px solid rgb(120, 120, 120);
+      border-bottom: 0;
+      border-left-color: transparent;
+      border-right-color: transparent;
     }
   }
 
-  &::after {
-    content: '';
-    position: absolute;
-    top: calc(50% - 1px);
-    right: 10px;
-    border: 4px solid rgb(120, 120, 120);
-    border-bottom: 0;
-    border-left-color: transparent;
-    border-right-color: transparent;
+  .error_text {
+    padding-top: 2px;
+    text-indent: 4px;
+    font-size: 12px;
+    color: rgb(255, 0, 0);
   }
-}
-
-.label {
-  display: block;
-  font-size: 14px;
-  color: rgb(50, 50, 50);
-}
-
-.error_text {
-  padding-top: 2px;
-  text-indent: 4px;
-  font-size: 12px;
-  color: rgb(255, 0, 0);
 }

--- a/frontend/src/components/parts/Input/SelectBox/index.tsx
+++ b/frontend/src/components/parts/Input/SelectBox/index.tsx
@@ -2,7 +2,6 @@ import { ChangeEvent } from 'react'
 import { Option } from 'types/internal/other'
 import cx from 'utils/functions/cx'
 import Select from 'components/parts/Select'
-import VStack from 'components/parts/Stack/Vertical'
 import style from './SelectBox.module.scss'
 
 interface Props {
@@ -23,7 +22,7 @@ export default function SelectBox(props: Props): React.JSX.Element {
   const isRequired = required && !value
 
   return (
-    <VStack gap="2" className={className}>
+    <div className={cx(style.box, className)}>
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
@@ -33,6 +32,6 @@ export default function SelectBox(props: Props): React.JSX.Element {
         <Select {...rest} value={value} id={label} className={cx(style.select, isRequired && style.error)} />
       </div>
       {isRequired && <p className={style.error_text}>※必須入力です！</p>}
-    </VStack>
+    </div>
   )
 }

--- a/frontend/src/components/parts/Input/Textarea/Textarea.module.scss
+++ b/frontend/src/components/parts/Input/Textarea/Textarea.module.scss
@@ -1,38 +1,44 @@
-.textarea {
-  width: 100%;
-  min-height: 36px;
-  padding: 6px 12px;
-  font-size: 14px;
-  border: 1px solid rgb(200, 200, 200);
-  border-radius: 5px;
-  background: rgb(255, 255, 255);
-  resize: none;
-  overflow-y: hidden;
+.box {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 
-  &:disabled {
-    background: rgb(240, 240, 240);
+  .label {
+    display: block;
+    font-size: 14px;
+    color: rgb(50, 50, 50);
   }
 
-  &:focus-visible {
-    outline: none;
-    border-color: rgb(40, 130, 250);
+  .textarea {
+    width: 100%;
+    min-height: 36px;
+    padding: 6px 12px;
+    font-size: 14px;
+    border: 1px solid rgb(200, 200, 200);
+    border-radius: 5px;
+    background: rgb(255, 255, 255);
+    resize: none;
+    overflow-y: hidden;
+
+    &:disabled {
+      background: rgb(240, 240, 240);
+    }
+
+    &:focus-visible {
+      outline: none;
+      border-color: rgb(40, 130, 250);
+    }
+
+    &.error {
+      color: rgb(0, 0, 0);
+      background: rgb(255, 240, 240);
+    }
   }
 
-  &.error {
-    color: rgb(0, 0, 0);
-    background: rgb(255, 240, 240);
+  .error_text {
+    padding-top: 2px;
+    text-indent: 4px;
+    font-size: 12px;
+    color: rgb(255, 0, 0);
   }
-}
-
-.label {
-  display: block;
-  font-size: 14px;
-  color: rgb(50, 50, 50);
-}
-
-.error_text {
-  padding-top: 2px;
-  text-indent: 4px;
-  font-size: 12px;
-  color: rgb(255, 0, 0);
 }

--- a/frontend/src/components/parts/Input/Textarea/index.tsx
+++ b/frontend/src/components/parts/Input/Textarea/index.tsx
@@ -1,6 +1,5 @@
 import { ChangeEvent, useState, useRef, useEffect } from 'react'
 import cx from 'utils/functions/cx'
-import VStack from 'components/parts/Stack/Vertical'
 import style from './Textarea.module.scss'
 
 interface Props {
@@ -48,7 +47,7 @@ export default function Textarea(props: Props): React.JSX.Element {
   }
 
   return (
-    <VStack gap="2" className={className}>
+    <div className={cx(style.box, className)}>
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
@@ -57,6 +56,6 @@ export default function Textarea(props: Props): React.JSX.Element {
       <textarea {...props} id={label} ref={ref} value={value} onChange={handleChange} className={cx(style.textarea, isRequired && style.error)} />
       {isRequired && <p className={style.error_text}>※必須入力です！</p>}
       {isErrorText && <p className={style.error_text}>{errorText}</p>}
-    </VStack>
+    </div>
   )
 }

--- a/frontend/src/components/parts/Input/index.tsx
+++ b/frontend/src/components/parts/Input/index.tsx
@@ -1,7 +1,6 @@
 import React, { ChangeEvent, useState } from 'react'
 import cx from 'utils/functions/cx'
 import { useAutoFocus } from 'components/hooks/useAutoFocus'
-import VStack from 'components/parts/Stack/Vertical'
 import style from './Input.module.scss'
 
 interface Props {
@@ -39,7 +38,7 @@ export default function Input(props: Props): React.JSX.Element {
   }
 
   return (
-    <VStack gap="2" className={className}>
+    <div className={cx(style.box, className)}>
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
@@ -48,6 +47,6 @@ export default function Input(props: Props): React.JSX.Element {
       <input {...props} id={label} onChange={handleChange} ref={autoFocus ? inputFocus : undefined} className={cx(style.input, isRequired && style.error, disabled && style.disabled)} />
       {isRequired && <p className={style.error_text}>※必須入力です！</p>}
       {isErrorText && <p className={style.error_text}>{errorText}</p>}
-    </VStack>
+    </div>
   )
 }

--- a/frontend/src/components/widgets/TextEditor/TextEditor.module.scss
+++ b/frontend/src/components/widgets/TextEditor/TextEditor.module.scss
@@ -7,6 +7,7 @@
 }
 
 .editor {
+  overflow: hidden;
   border: 1px solid rgb(204, 204, 204);
   border-radius: 5px;
 


### PR DESCRIPTION
## Summary
- `parts/` 配下のコンポーネントから他 parts (`VStack`) への依存を排除し、自前の `<div>` + CSS で同じレイアウトを再現
- 各 SCSS を `.box` ルートにネストした構造に整理（CSS ルールに準拠）
- TextEditor のエラー時に下の角丸からはみ出る背景を修正

## 変更内容

### `parts/Input/index.tsx` / `Textarea/index.tsx` / `SelectBox/index.tsx` / `File/index.tsx`
- `VStack gap="2"` を `<div className={cx(style.box, className)}>` に置換
- `import VStack from 'components/parts/Stack/Vertical'` を削除
- 見た目は `display: flex; flex-direction: column; gap: 4px` で完全に等価

### `parts/Input/Input.module.scss` / `Textarea.module.scss` / `SelectBox.module.scss`
- ルート `.box` に `display: flex; flex-direction: column; gap: 4px` を定義
- `.label` / `.input` (`.textarea`/`.select_box`) / `.error_text` を `.box` の子としてネスト集約（最大3階層まで）
- セレクタ間に空行1行、同一セレクタ内のプロパティは詰める（`docs/css.md` 準拠）

### `widgets/TextEditor/TextEditor.module.scss`
- `.editor` に `overflow: hidden` を追加
- 必須エラー時に `:global(.tiptap)` に赤背景が付くと、内側の背景が外枠の角丸を貫通してしまう現象を修正
- ツールバーのバブルメニューは tiptap が body 直下に portal で出すため影響なし