### PR TITLE
【front】Count/Read からグローバルクラス mr_8 を削除し module.scss に移行

### DIFF
--- a/frontend/src/components/parts/Count/Read/Read.module.scss
+++ b/frontend/src/components/parts/Count/Read/Read.module.scss
@@ -4,5 +4,6 @@
 
   .icon {
     margin-top: -2px;
+    margin-right: 8px;
   }
 }

--- a/frontend/src/components/parts/Count/Read/index.tsx
+++ b/frontend/src/components/parts/Count/Read/index.tsx
@@ -11,7 +11,7 @@ export default function CountRead(props: Props): React.JSX.Element {
   return (
     <div className={style.count}>
       <div className={style.icon}>
-        <IconCaret size="16" className="mr_8" />
+        <IconCaret size="16" />
       </div>
       <span>{read}</span>
     </div>


### PR DESCRIPTION
## Summary
- `parts/Count/Read` で使用していたグローバルユーティリティクラス `mr_8` を削除
- 同等のスタイル（`margin-right: 8px`）を `Read.module.scss` の `.icon` に移管
- parts のグローバル CSS 依存違反を 1 件解消

## 変更内容

### `frontend/src/components/parts/Count/Read/index.tsx`
- `<IconCaret size="16" className="mr_8" />` → `<IconCaret size="16" />`

### `frontend/src/components/parts/Count/Read/Read.module.scss`
- `.icon` に `margin-right: 8px` を追加

### 視覚的差分
- 既存の `mr_8`（global utility = `margin-right: 8px`）と完全に等価。表示は変わらない。

## 背景
- PR #768 で導入した「parts はグローバル CSS / 共有 mixin / グローバルユーティリティクラスに依存しない」ルールに違反していた箇所の修正