### PR TITLE
【front】Error/Back・Login を widgets/Error/ に移動しグローバルクラスを排除

### DIFF
--- a/frontend/src/components/parts/Error/Error.module.scss
+++ b/frontend/src/components/parts/Error/Error.module.scss
@@ -1,4 +1,0 @@
-.error {
-  font-size: 16px;
-  color: rgb(255, 0, 0);
-}

--- a/frontend/src/components/widgets/Error/Back.tsx
+++ b/frontend/src/components/widgets/Error/Back.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router'
-import cx from 'utils/functions/cx'
 import Button from 'components/parts/Button'
 import style from './Error.module.scss'
 
@@ -23,8 +22,8 @@ export default function BackError(props: Props): React.JSX.Element {
 
   return (
     <>
-      <h2 className={cx(style.error, 'mt_24')}>{content}</h2>
-      <Button name="戻る" className="mt_24 w_80" onClick={handleBack} />
+      <h2 className={style.error}>{content}</h2>
+      <Button name="戻る" className={style.button} onClick={handleBack} />
     </>
   )
 }

--- a/frontend/src/components/widgets/Error/Custom404.tsx
+++ b/frontend/src/components/widgets/Error/Custom404.tsx
@@ -1,6 +1,6 @@
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
-import BackError from 'components/parts/Error/Back'
+import BackError from 'components/widgets/Error/Back'
 
 export default function Custom404(): React.JSX.Element {
   return (

--- a/frontend/src/components/widgets/Error/Custom500.tsx
+++ b/frontend/src/components/widgets/Error/Custom500.tsx
@@ -1,6 +1,6 @@
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
-import BackError from 'components/parts/Error/Back'
+import BackError from 'components/widgets/Error/Back'
 
 export default function Custom500(): React.JSX.Element {
   return (

--- a/frontend/src/components/widgets/Error/Error.module.scss
+++ b/frontend/src/components/widgets/Error/Error.module.scss
@@ -1,0 +1,10 @@
+.error {
+  margin-top: 24px;
+  font-size: 16px;
+  color: rgb(255, 0, 0);
+}
+
+.button {
+  width: 80px;
+  margin-top: 24px;
+}

--- a/frontend/src/components/widgets/Error/Login.tsx
+++ b/frontend/src/components/widgets/Error/Login.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router'
-import cx from 'utils/functions/cx'
 import Button from 'components/parts/Button'
 import style from './Error.module.scss'
 
@@ -18,8 +17,8 @@ export default function BackLogin(props: Props): React.JSX.Element {
 
   return (
     <>
-      <h2 className={cx(style.error, 'mt_24')}>{content}</h2>
-      <Button name="ログイン" className="mt_24 w_80" onClick={handleLogin} />
+      <h2 className={style.error}>{content}</h2>
+      <Button name="ログイン" className={style.button} onClick={handleLogin} />
     </>
   )
 }

--- a/frontend/src/components/widgets/Error/Unauthorized.tsx
+++ b/frontend/src/components/widgets/Error/Unauthorized.tsx
@@ -1,6 +1,6 @@
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
-import BackLogin from 'components/parts/Error/Login'
+import BackLogin from 'components/widgets/Error/Login'
 
 export default function Unauthorized(): React.JSX.Element {
   return (

--- a/frontend/src/components/widgets/Error/Unexpected.tsx
+++ b/frontend/src/components/widgets/Error/Unexpected.tsx
@@ -1,6 +1,6 @@
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
-import BackError from 'components/parts/Error/Back'
+import BackError from 'components/widgets/Error/Back'
 
 export default function Unexpected(): React.JSX.Element {
   return (


### PR DESCRIPTION
## Summary
- `parts/Error/Back` `parts/Error/Login` を `widgets/Error/` 配下に移動（`Button` 依存により parts 独立性ルールに違反していたため）
- グローバルユーティリティクラス `mt_24` / `w_80` を `Error.module.scss` の `.error` / `.button` に取り込んで排除
- 呼び出し側 4 ファイルの import パスを更新

## 変更内容

### 移動
- `parts/Error/Back.tsx` → `widgets/Error/Back.tsx`
- `parts/Error/Login.tsx` → `widgets/Error/Login.tsx`
- `parts/Error/Error.module.scss` → `widgets/Error/Error.module.scss`（再構成）

### `widgets/Error/Error.module.scss`
- `.error` に `margin-top: 24px` を追加（既存の `cx(style.error, 'mt_24')` を統合）
- `.button` を新設（`width: 80px; margin-top: 24px`）→ `mt_24 w_80` を置換
- `parts/Error/` ディレクトリは削除

### `widgets/Error/Back.tsx` / `Login.tsx`
- `import cx from 'utils/functions/cx'` を削除（`cx` 不要に）
- `<h2 className={cx(style.error, 'mt_24')}>` → `<h2 className={style.error}>`
- `<Button className="mt_24 w_80">` → `<Button className={style.button}>`

### 呼び出し側 import パス更新
- `widgets/Error/Custom404.tsx`
- `widgets/Error/Custom500.tsx`
- `widgets/Error/Unauthorized.tsx`
- `widgets/Error/Unexpected.tsx`

## 解消した違反（PR #768 ルール準拠）
- ✅ parts → 他 parts 依存（`Button`）2 件解消
- ✅ グローバルクラス使用（`mt_24` / `w_80`）4 件解消

## 確認
- `npm run lint` / `tsc --noEmit` 共に新規エラーなし
- 視覚差分なし（既存スタイル値と完全に等価）