### PR TITLE
【front】FontAwesome 依存を削除し IconSearch を追加

### DIFF
--- a/frontend/src/components/parts/Icon/Search.tsx
+++ b/frontend/src/components/parts/Icon/Search.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  size: string
+  className?: string
+}
+
+export default function IconSearch(props: Props): React.JSX.Element {
+  const { size, className } = props
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" width={size} height={size} className={className}>
+      <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
+    </svg>
+  )
+}

--- a/frontend/src/components/parts/Input/Search/index.tsx
+++ b/frontend/src/components/parts/Input/Search/index.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
 import cx from 'utils/functions/cx'
+import IconSearch from 'components/parts/Icon/Search'
 import style from './Search.module.scss'
 
 interface Props {
@@ -24,7 +25,7 @@ export default function Search(props: Props): React.JSX.Element {
     <div className={cx(style.searchbar, className)}>
       <input type="search" name="search" placeholder="検索..." value={value} onChange={onChange} onKeyDown={handleKeyDown} className={style.input} />
       <button onClick={handleSearch} className={style.icon}>
-        <i className="fas fa-search"></i>
+        <IconSearch size="16" />
       </button>
     </div>
   )

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -37,7 +37,6 @@ class MyDocument extends Document {
           <link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#000000" />
           <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" />
           <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Caslon+Display&family=Roboto&display=swap" />
-          <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.1/css/all.css" />
           <base href="/"></base>
         </Head>
         <body>


### PR DESCRIPTION
## Summary
- `parts/Icon/Search.tsx` を新規作成（Bootstrap Icons の検索アイコン SVG。既存 Icon と同じ `size` / `className` Props 構造）
- `parts/Input/Search` の `<i className="fas fa-search">` を `<IconSearch size="16" />` に置換し、parts のグローバル CSS 依存違反を解消
- `_document.tsx` から FontAwesome の CDN `<link>` を削除（残る使用箇所なし → ロード不要）

## 変更内容

### `frontend/src/components/parts/Icon/Search.tsx`（新規）
- `IconGlobe` 等の既存 Icon と同形式（`size: string` / `className?: string`、`fill="currentColor"`、`viewBox="0 0 16 16"`）
- Bootstrap Icons の `search` SVG パスを使用

### `frontend/src/components/parts/Input/Search/index.tsx`
- `import IconSearch from 'components/parts/Icon/Search'` を追加
- `<i className="fas fa-search">` → `<IconSearch size="16" />`
- アイコン色は親 `<button>` の `color: rgb(255, 255, 255)` を `currentColor` 経由で継承（見た目変化なし）

### `frontend/src/pages/_document.tsx`
- `<link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.1/css/all.css" />` を削除
- 全コードベース内で `fa-` / `fas` / `far` 等の FontAwesome クラス使用箇所が他にないことを `grep` で確認済み

## 効果
- ✅ parts のグローバル CSS 依存違反 1 件解消（PR #768 ルール準拠）
- ✅ HTTP リクエスト 1 件削減（外部 CDN 依存解消）
- ✅ アイコン管理が SVG コンポーネントに統一

## 確認
- `npm run lint` / `tsc --noEmit` 共に新規エラーなし