### PR TITLE
【docs】parts 独立性ルールの例外ケースを 4 種に整理

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -111,7 +111,6 @@ const [user, setUser] = useState<User | null>(null)
 
 - `parts/` 配下のコンポーネントは他の `parts/` を import しない（最下層UIとしてそれ単体で動作する）
 - レイアウト（縦並び・間隔等）は `VStack` / `HStack` などの parts に頼らず、自前の `<div>` + CSS（`display: flex` / `gap` 等）で実現する
-- 例外: `Icon` などの純粋表示用 parts は他 parts から import してよい（循環依存を作らない範囲）
 - `widgets/` / `templates/` から parts を呼ぶ・複数 parts を組み合わせるのは正常な使い方
 
 ```typescript
@@ -123,6 +122,17 @@ return <VStack gap="2">...</VStack>
 return <div className={style.box}>...</div>
 // .box { display: flex; flex-direction: column; gap: 4px; }
 ```
+
+#### 例外として許容されるケース
+
+以下のパターンは「parts → parts」依存でも例外として許容する。レビュー時の判断基準にする。
+
+1. **純粋表示用 parts への依存**: `Icon` / `Spinner` / `ExImage` 等、state を持たず描画だけする parts は他 parts から import してよい
+2. **同ファミリ内の派生**: `Avatar/Link` が `Avatar` を呼ぶ、`Button/Square` が `Button` の補助 parts を共有する等、同コンポーネントファミリのサブバリアント
+3. **同サブツリーのプリミティブ取り込み**: `Input/SelectBox` が `Input/Select` を内部で使う等、同フォルダ階層の下位 parts への限定依存
+4. **合成 UI として例外的に parts に置く部品**: `Modal` のような汎用合成 UI で、内部にクローズ用 `Button` 等の小さな部品を含むケース（移動候補ではあるが許容）
+
+判定は「循環依存を作らないか」「最下層 UI の独立性を本質的に壊さないか」を基準にする。
 
 ### parts の CSS も独立性を持つ
 
@@ -166,3 +176,4 @@ return <div className={style.box}>...</div>
 - 2026-04-16: useState型引数必須、docs/に一元化、構成整理
 - 2026-04-22: `interface Props`はコンポーネント関数の直前配置ルール追加
 - 2026-04-27: 依存方向ルール追加（`parts/` は他 parts / グローバル CSS に依存せず単体で動作する）
+- 2026-04-27: parts 独立性の例外ケース 4 種を明文化（純粋表示用・同ファミリ派生・同サブツリー・汎用合成 UI）


### PR DESCRIPTION
## Summary
- PR #768 で追加した「parts は独立性を持つ」ルールに対して、運用上許容される例外パターンを 4 種類として明文化
- 既存コードベースの `Avatar/Link → Avatar`、`Button → Spinner`、`SelectBox → Select`、`Modal → Button` 等を「ルール違反」ではなく「例外として許容」と扱える基準を提供

## 変更内容

### `docs/frontend.md` の "依存方向 → parts は独立性を持つ" セクション
- 既存の「例外: `Icon` などの純粋表示用 parts は…」の 1 行例外を削除し、新しい "例外として許容されるケース" サブセクションに昇格
- 4 種の例外パターンを箇条書きで明文化

| # | パターン | 例 |
|---|---|---|
| 1 | 純粋表示用 parts への依存 | `Button` → `Spinner`、`Avatar` → `ExImage` |
| 2 | 同ファミリ内の派生 | `Avatar/Link` → `Avatar` |
| 3 | 同サブツリーのプリミティブ取り込み | `Input/SelectBox` → `Input/Select` |
| 4 | 合成 UI として例外的に parts に置く部品 | `Modal` のクローズ Button |

- 判定基準（「循環依存を作らないか」「最下層 UI の独立性を本質的に壊さないか」）も併記
- 更新履歴に 2026-04-27 行を追加

## 背景
- ルール追加後の棚卸しで、6 ファイルの parts → parts 依存が残っていたが、いずれも上記 4 種のいずれかに該当し「例外として許容」と判断
- ルール文を実態に合わせて整備することで、レビュー時の揺れと過剰修正を防ぐ