### PR TITLE
【back】Video / Music / Comic / Picture / Chat 作成にカテゴリー連携を追加

### DIFF
--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 class VideoIn(BaseModel):
     channel_ulid: str
+    category_ulid: str
     publish: bool
     title: str
     content: str
@@ -10,6 +11,7 @@ class VideoIn(BaseModel):
 
 class MusicIn(BaseModel):
     channel_ulid: str
+    category_ulid: str
     publish: bool
     title: str
     content: str
@@ -28,6 +30,7 @@ class BlogIn(BaseModel):
 
 class ComicIn(BaseModel):
     channel_ulid: str
+    category_ulid: str
     publish: bool
     title: str
     content: str
@@ -35,6 +38,7 @@ class ComicIn(BaseModel):
 
 class PictureIn(BaseModel):
     channel_ulid: str
+    category_ulid: str
     publish: bool
     title: str
     content: str
@@ -42,6 +46,7 @@ class PictureIn(BaseModel):
 
 class ChatIn(BaseModel):
     channel_ulid: str
+    category_ulid: str
     publish: bool
     title: str
     content: str

--- a/myus/api/src/usecase/media.py
+++ b/myus/api/src/usecase/media.py
@@ -58,8 +58,14 @@ def create_video(input: VideoIn, image: UploadedFile, video: UploadedFile) -> Me
         hashtags=[],
     )
 
-    new_ids = repository.bulk_save([new_video])
-    assert len(new_ids) == 1, "作成に失敗しました"
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
+    with transaction.atomic():
+        new_ids = repository.bulk_save([new_video])
+        assert len(new_ids) == 1, "作成に失敗しました"
+        category_repo.bulk_save(MediaType.VIDEO, new_ids[0], categories)
+
     obj = repository.bulk_get(new_ids)[0]
 
     def encode_task() -> None:
@@ -100,10 +106,15 @@ def create_music(input: MusicIn, music: UploadedFile) -> MediaCreateDTO | None:
         hashtags=[],
     )
 
-    new_ids = repository.bulk_save([new_music])
-    assert len(new_ids) == 1, "作成に失敗しました"
-    obj = repository.bulk_get(new_ids)[0]
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
+    with transaction.atomic():
+        new_ids = repository.bulk_save([new_music])
+        assert len(new_ids) == 1, "作成に失敗しました"
+        category_repo.bulk_save(MediaType.MUSIC, new_ids[0], categories)
+
+    obj = repository.bulk_get(new_ids)[0]
     return MediaCreateDTO(ulid=obj.ulid)
 
 
@@ -166,10 +177,15 @@ def create_comic(input: ComicIn, image: UploadedFile, pages: list[UploadedFile])
         hashtags=[],
     )
 
-    new_ids = repository.bulk_save([new_comic])
-    assert len(new_ids) == 1, "作成に失敗しました"
-    obj = repository.bulk_get(new_ids)[0]
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
+    with transaction.atomic():
+        new_ids = repository.bulk_save([new_comic])
+        assert len(new_ids) == 1, "作成に失敗しました"
+        category_repo.bulk_save(MediaType.COMIC, new_ids[0], categories)
+
+    obj = repository.bulk_get(new_ids)[0]
     return MediaCreateDTO(ulid=obj.ulid)
 
 
@@ -195,10 +211,15 @@ def create_picture(input: PictureIn, image: UploadedFile) -> MediaCreateDTO | No
         hashtags=[],
     )
 
-    new_ids = repository.bulk_save([new_picture])
-    assert len(new_ids) == 1, "作成に失敗しました"
-    obj = repository.bulk_get(new_ids)[0]
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
+    with transaction.atomic():
+        new_ids = repository.bulk_save([new_picture])
+        assert len(new_ids) == 1, "作成に失敗しました"
+        category_repo.bulk_save(MediaType.PICTURE, new_ids[0], categories)
+
+    obj = repository.bulk_get(new_ids)[0]
     return MediaCreateDTO(ulid=obj.ulid)
 
 
@@ -226,10 +247,15 @@ def create_chat(input: ChatIn) -> MediaCreateDTO | None:
         hashtags=[],
     )
 
-    new_ids = repository.bulk_save([new_chat])
-    assert len(new_ids) == 1, "作成に失敗しました"
-    obj = repository.bulk_get(new_ids)[0]
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
+    with transaction.atomic():
+        new_ids = repository.bulk_save([new_chat])
+        assert len(new_ids) == 1, "作成に失敗しました"
+        category_repo.bulk_save(MediaType.CHAT, new_ids[0], categories)
+
+    obj = repository.bulk_get(new_ids)[0]
     return MediaCreateDTO(ulid=obj.ulid)
 
 


### PR DESCRIPTION
## Summary
- Blog で先行導入したカテゴリー連携を Video / Music / Comic / Picture / Chat の 5 メディアに展開
- 各 `In` スキーマに `category_ulid: str`（必須）を追加し、create usecase で `CategoryRepository.bulk_save` を呼んで M2M 設定
- DB 書き込み（メディア本体 + カテゴリ）を `transaction.atomic` で囲んでロールバックを担保

## 変更内容

### `api/src/types/schema/media/input.py`
- `VideoIn` / `MusicIn` / `ComicIn` / `PictureIn` / `ChatIn` に `category_ulid: str` を追加（Blog と同形式・初期値なし必須）

### `api/src/usecase/media.py`
- `create_video` / `create_music` / `create_comic` / `create_picture` / `create_chat` を以下のパターンに更新（Blog と同じ）:
  ```python
  category_repo = injector.get(CategoryInterface)
  categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
  with transaction.atomic():
      new_ids = repository.bulk_save([new_xxx])
      assert len(new_ids) == 1, "作成に失敗しました"
      category_repo.bulk_save(MediaType.XXX, new_ids[0], categories)
  obj = repository.bulk_get(new_ids)[0]
  ```
- `create_video` の `encode_task`（非同期動画変換）はトランザクション外（DB 書き込みのみアトミック化）

## 残タスク（別 PR）
- フロント: 5 メディアの create 画面（pages / templates）にカテゴリー SelectBox を追加して `BlogCreate` と同 UX に揃える