### PR TITLE
【front】Video / Music / Comic / Picture / Chat 作成画面にカテゴリー選択を追加

### DIFF
--- a/frontend/src/components/templates/manage/chat/create.tsx
+++ b/frontend/src/components/templates/manage/chat/create.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { ChatIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
@@ -18,18 +19,20 @@ import VStack from 'components/parts/Stack/Vertical'
 
 interface Props {
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ChatCreate(props: Props): React.JSX.Element {
-  const { channels } = props
+  const { channels, categories } = props
 
   const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<ChatIn>({ channelUlid, publish: true, title: '', content: '', period: '' })
+  const [values, setValues] = useState<ChatIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', period: '' })
 
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -37,8 +40,8 @@ export default function ChatCreate(props: Props): React.JSX.Element {
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
 
   const handleForm = async () => {
-    const { channelUlid, title, content, period } = values
-    if (!isRequiredCheck({ channelUlid, title, content, period })) return
+    const { channelUlid, categoryUlid, title, content, period } = values
+    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, period })) return
     handleLoading(true)
     const ret = await postChatCreate(values)
     handleLoading(false)
@@ -46,7 +49,7 @@ export default function ChatCreate(props: Props): React.JSX.Element {
       handleToast(FetchError.Post, true)
       return
     }
-    setValues({ channelUlid, publish: true, title: '', content: '', period: '' })
+    setValues({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', period: '' })
     handleToast('作成しました', false)
   }
 
@@ -56,6 +59,7 @@ export default function ChatCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <Input label="期間" name="period" placeholder={`${nowDate.year}-12-31`} required={isRequired} onChange={handleInput} />

--- a/frontend/src/components/templates/manage/comic/create.tsx
+++ b/frontend/src/components/templates/manage/comic/create.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { ComicIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
@@ -18,18 +19,20 @@ import VStack from 'components/parts/Stack/Vertical'
 
 interface Props {
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ComicCreate(props: Props): React.JSX.Element {
-  const { channels } = props
+  const { channels, categories } = props
 
   const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<ComicIn>({ channelUlid, publish: true, title: '', content: '' })
+  const [values, setValues] = useState<ComicIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
 
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -39,8 +42,8 @@ export default function ComicCreate(props: Props): React.JSX.Element {
   const handleMultiFile = (files: File | File[]) => Array.isArray(files) && setValues({ ...values, pages: files })
 
   const handleForm = async () => {
-    const { channelUlid, title, content, image, pages } = values
-    if (!isRequiredCheck({ channelUlid, title, content, image, pages })) return
+    const { channelUlid, categoryUlid, title, content, image, pages } = values
+    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, image, pages })) return
     handleLoading(true)
     const ret = await postComicCreate(values)
     handleLoading(false)
@@ -48,7 +51,7 @@ export default function ComicCreate(props: Props): React.JSX.Element {
       handleToast(FetchError.Post, true)
       return
     }
-    setValues({ channelUlid, publish: true, title: '', content: '' })
+    setValues({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
     handleToast('作成しました', false)
   }
 
@@ -58,6 +61,7 @@ export default function ComicCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />

--- a/frontend/src/components/templates/manage/music/create.tsx
+++ b/frontend/src/components/templates/manage/music/create.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { MusicIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
@@ -19,18 +20,20 @@ import VStack from 'components/parts/Stack/Vertical'
 
 interface Props {
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function MusicCreate(props: Props): React.JSX.Element {
-  const { channels } = props
+  const { channels, categories } = props
 
   const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<MusicIn>({ channelUlid, publish: true, title: '', content: '', lyric: '', download: true })
+  const [values, setValues] = useState<MusicIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', lyric: '', download: true })
 
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -40,8 +43,8 @@ export default function MusicCreate(props: Props): React.JSX.Element {
   const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, music: files })
 
   const handleForm = async () => {
-    const { channelUlid, title, content, music } = values
-    if (!isRequiredCheck({ channelUlid, title, content, music })) return
+    const { channelUlid, categoryUlid, title, content, music } = values
+    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, music })) return
     handleLoading(true)
     const ret = await postMusicCreate(values)
     handleLoading(false)
@@ -49,7 +52,7 @@ export default function MusicCreate(props: Props): React.JSX.Element {
       handleToast(FetchError.Post, true)
       return
     }
-    setValues({ channelUlid, publish: true, title: '', content: '', lyric: '', download: true })
+    setValues({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', lyric: '', download: true })
     handleToast('作成しました', false)
   }
 
@@ -59,6 +62,7 @@ export default function MusicCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <Textarea label="歌詞" name="lyric" required={isRequired} onChange={handleText} />

--- a/frontend/src/components/templates/manage/picture/create.tsx
+++ b/frontend/src/components/templates/manage/picture/create.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { PictureIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
@@ -18,18 +19,20 @@ import VStack from 'components/parts/Stack/Vertical'
 
 interface Props {
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function PictureCreate(props: Props): React.JSX.Element {
-  const { channels } = props
+  const { channels, categories } = props
 
   const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<PictureIn>({ channelUlid, publish: true, title: '', content: '' })
+  const [values, setValues] = useState<PictureIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
 
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -38,8 +41,8 @@ export default function PictureCreate(props: Props): React.JSX.Element {
   const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
-    const { channelUlid, title, content, image } = values
-    if (!isRequiredCheck({ channelUlid, title, content, image })) return
+    const { channelUlid, categoryUlid, title, content, image } = values
+    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, image })) return
     handleLoading(true)
     const ret = await postPictureCreate(values)
     handleLoading(false)
@@ -47,7 +50,7 @@ export default function PictureCreate(props: Props): React.JSX.Element {
       handleToast(FetchError.Post, true)
       return
     }
-    setValues({ channelUlid, publish: true, title: '', content: '' })
+    setValues({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
     handleToast('作成しました', false)
   }
 
@@ -57,6 +60,7 @@ export default function PictureCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <InputFile label="画像" accept="image/*" required={isRequired} onChange={handleFile} />

--- a/frontend/src/components/templates/manage/video/create.tsx
+++ b/frontend/src/components/templates/manage/video/create.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { VideoIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
@@ -18,19 +19,21 @@ import VStack from 'components/parts/Stack/Vertical'
 
 interface Props {
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function VideoCreate(props: Props): React.JSX.Element {
-  const { channels } = props
+  const { channels, categories } = props
 
   const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const [formKey, setFormKey] = useState(0)
-  const [values, setValues] = useState<VideoIn>({ channelUlid, publish: true, title: '', content: '' })
+  const [values, setValues] = useState<VideoIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
 
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -40,8 +43,8 @@ export default function VideoCreate(props: Props): React.JSX.Element {
   const handleMovie = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, video: files })
 
   const handleForm = async () => {
-    const { channelUlid, title, content, image, video } = values
-    if (!isRequiredCheck({ channelUlid, title, content, image, video })) return
+    const { channelUlid, categoryUlid, title, content, image, video } = values
+    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, image, video })) return
     handleLoading(true)
     const ret = await postVideoCreate(values)
     handleLoading(false)
@@ -49,7 +52,7 @@ export default function VideoCreate(props: Props): React.JSX.Element {
       handleToast(FetchError.Post, true)
       return
     }
-    setValues({ channelUlid, publish: true, title: '', content: '' })
+    setValues({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
     setFormKey((prev) => prev + 1)
     handleToast('作成中です。完了まで時間がかかる場合があります', false)
   }
@@ -60,6 +63,7 @@ export default function VideoCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />

--- a/frontend/src/pages/manage/chat/create.tsx
+++ b/frontend/src/pages/manage/chat/create.tsx
@@ -1,21 +1,26 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import ErrorCheck from 'components/widgets/Error/Check'
 import ChatCreate from 'components/templates/manage/chat/create'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const ret = await getChannels(req)
-  if (ret.isErr()) return { props: { status: ret.error.status } }
-  const channels = ret.value
-  return { props: { ...translations, channels } }
+  const [channelRet, categoryRet] = await Promise.all([getChannels(req), getCategories(req)])
+  if (channelRet.isErr()) return { props: { status: channelRet.error.status } }
+  if (categoryRet.isErr()) return { props: { status: categoryRet.error.status } }
+  const channels = channelRet.value
+  const categories = categoryRet.value
+  return { props: { ...translations, channels, categories } }
 }
 
 interface Props {
   status: number
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ChatCreatePage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/comic/create.tsx
+++ b/frontend/src/pages/manage/comic/create.tsx
@@ -1,21 +1,26 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import ErrorCheck from 'components/widgets/Error/Check'
 import ComicCreate from 'components/templates/manage/comic/create'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const ret = await getChannels(req)
-  if (ret.isErr()) return { props: { status: ret.error.status } }
-  const channels = ret.value
-  return { props: { ...translations, channels } }
+  const [channelRet, categoryRet] = await Promise.all([getChannels(req), getCategories(req)])
+  if (channelRet.isErr()) return { props: { status: channelRet.error.status } }
+  if (categoryRet.isErr()) return { props: { status: categoryRet.error.status } }
+  const channels = channelRet.value
+  const categories = categoryRet.value
+  return { props: { ...translations, channels, categories } }
 }
 
 interface Props {
   status: number
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ComicCreatePage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/music/create.tsx
+++ b/frontend/src/pages/manage/music/create.tsx
@@ -1,21 +1,26 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import ErrorCheck from 'components/widgets/Error/Check'
 import MusicCreate from 'components/templates/manage/music/create'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const ret = await getChannels(req)
-  if (ret.isErr()) return { props: { status: ret.error.status } }
-  const channels = ret.value
-  return { props: { ...translations, channels } }
+  const [channelRet, categoryRet] = await Promise.all([getChannels(req), getCategories(req)])
+  if (channelRet.isErr()) return { props: { status: channelRet.error.status } }
+  if (categoryRet.isErr()) return { props: { status: categoryRet.error.status } }
+  const channels = channelRet.value
+  const categories = categoryRet.value
+  return { props: { ...translations, channels, categories } }
 }
 
 interface Props {
   status: number
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function MusicCreatePage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/picture/create.tsx
+++ b/frontend/src/pages/manage/picture/create.tsx
@@ -1,21 +1,26 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import ErrorCheck from 'components/widgets/Error/Check'
 import PictureCreate from 'components/templates/manage/picture/create'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const ret = await getChannels(req)
-  if (ret.isErr()) return { props: { status: ret.error.status } }
-  const channels = ret.value
-  return { props: { ...translations, channels } }
+  const [channelRet, categoryRet] = await Promise.all([getChannels(req), getCategories(req)])
+  if (channelRet.isErr()) return { props: { status: channelRet.error.status } }
+  if (categoryRet.isErr()) return { props: { status: categoryRet.error.status } }
+  const channels = channelRet.value
+  const categories = categoryRet.value
+  return { props: { ...translations, channels, categories } }
 }
 
 interface Props {
   status: number
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function PictureCreatePage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/video/create.tsx
+++ b/frontend/src/pages/manage/video/create.tsx
@@ -1,21 +1,26 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import ErrorCheck from 'components/widgets/Error/Check'
 import VideoCreate from 'components/templates/manage/video/create'
 
 export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
-  const ret = await getChannels(req)
-  if (ret.isErr()) return { props: { status: ret.error.status } }
-  const channels = ret.value
-  return { props: { ...translations, channels } }
+  const [channelRet, categoryRet] = await Promise.all([getChannels(req), getCategories(req)])
+  if (channelRet.isErr()) return { props: { status: channelRet.error.status } }
+  if (categoryRet.isErr()) return { props: { status: categoryRet.error.status } }
+  const channels = channelRet.value
+  const categories = categoryRet.value
+  return { props: { ...translations, channels, categories } }
 }
 
 interface Props {
   status: number
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function VideoCreatePage(props: Props): React.JSX.Element {

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -1,103 +1,69 @@
-export interface VideoIn {
+export interface MediaIn {
   channelUlid: string
   categoryUlid: string
   publish: boolean
   title: string
   content: string
+}
+
+export interface MediaUpdateIn {
+  title: string
+  content: string
+  publish: boolean
+}
+
+export interface VideoIn extends MediaIn {
   image?: File
   video?: File
 }
 
-export interface MusicIn {
-  channelUlid: string
-  categoryUlid: string
-  publish: boolean
-  title: string
-  content: string
+export interface MusicIn extends MediaIn {
   lyric: string
   download: boolean
   music?: File
 }
 
-export interface BlogIn {
-  channelUlid: string
-  categoryUlid: string
-  publish: boolean
-  title: string
-  content: string
+export interface BlogIn extends MediaIn {
   richtext: string
   delta: string
   image?: File
 }
 
-export interface ComicIn {
-  channelUlid: string
-  categoryUlid: string
-  publish: boolean
-  title: string
-  content: string
+export interface ComicIn extends MediaIn {
   image?: File
   pages?: File[]
 }
 
-export interface PictureIn {
-  channelUlid: string
-  categoryUlid: string
-  publish: boolean
-  title: string
-  content: string
+export interface PictureIn extends MediaIn {
   image?: File
 }
 
-export interface ChatIn {
-  channelUlid: string
-  categoryUlid: string
-  publish: boolean
-  title: string
-  content: string
+export interface ChatIn extends MediaIn {
   period: string
 }
 
-export interface VideoUpdateIn {
-  title: string
-  content: string
-  publish: boolean
+export interface VideoUpdateIn extends MediaUpdateIn {
   image?: File
 }
 
-export interface MusicUpdateIn {
-  title: string
-  content: string
+export interface MusicUpdateIn extends MediaUpdateIn {
   lyric: string
   download: boolean
-  publish: boolean
 }
 
-export interface BlogUpdateIn {
-  title: string
-  content: string
+export interface BlogUpdateIn extends MediaUpdateIn {
   richtext: string
-  publish: boolean
   image?: File
 }
 
-export interface ComicUpdateIn {
-  title: string
-  content: string
-  publish: boolean
+export interface ComicUpdateIn extends MediaUpdateIn {
   image?: File
 }
 
-export interface PictureUpdateIn {
-  title: string
-  content: string
-  publish: boolean
+export interface PictureUpdateIn extends MediaUpdateIn {
   image?: File
 }
 
-export interface ChatUpdateIn {
-  title: string
-  content: string
+export interface ChatUpdateIn extends MediaUpdateIn {
   period: string
-  publish: boolean
 }

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -1,5 +1,6 @@
 export interface VideoIn {
   channelUlid: string
+  categoryUlid: string
   publish: boolean
   title: string
   content: string
@@ -9,6 +10,7 @@ export interface VideoIn {
 
 export interface MusicIn {
   channelUlid: string
+  categoryUlid: string
   publish: boolean
   title: string
   content: string
@@ -30,6 +32,7 @@ export interface BlogIn {
 
 export interface ComicIn {
   channelUlid: string
+  categoryUlid: string
   publish: boolean
   title: string
   content: string
@@ -39,6 +42,7 @@ export interface ComicIn {
 
 export interface PictureIn {
   channelUlid: string
+  categoryUlid: string
   publish: boolean
   title: string
   content: string
@@ -47,6 +51,7 @@ export interface PictureIn {
 
 export interface ChatIn {
   channelUlid: string
+  categoryUlid: string
   publish: boolean
   title: string
   content: string


### PR DESCRIPTION
## Summary
- Blog で先行導入したカテゴリー選択 UX を Video / Music / Comic / Picture / Chat の 5 メディアに横展開
- 各 `In` 型に `categoryUlid: string` を追加し、create 画面でチャンネル直下に `SelectBox` を配置
- ページ側で `getCategories` を `getChannels` と並列フェッチ

## 変更内容

### `frontend/src/types/internal/media/input.d.ts`
- `VideoIn` / `MusicIn` / `ComicIn` / `PictureIn` / `ChatIn` に `categoryUlid: string` を追加（必須）

### `frontend/src/pages/manage/{video,music,comic,picture,chat}/create.tsx`
- `getCategories` を `Promise.all` で `getChannels` と並列フェッチ、いずれかエラーなら status を伝搬
- `Props` に `categories: Category[]` を追加してテンプレートへ渡す

### `frontend/src/components/templates/manage/{video,music,comic,picture,chat}/create.tsx`
- `Props` / 初期 state / リセット処理に `categoryUlid` を追加
- `<SelectBox label="カテゴリー" ... required={isRequired} />` をチャンネル直下に配置（先頭オプションは `{ label: '未選択', value: '' }`）
- `isRequiredCheck` の対象に `categoryUlid` を含めて未選択時のサブミットをブロック

## 関連
- バック側対応: PR #774（5 メディアの create usecase に category 連携を追加）
- 親 PR: #765 (blog のカテゴリー選択追加) と同パターンで実装

## 確認
- `npm run lint` / `tsc --noEmit` 共に新規エラーなし