### PR TITLE
【back】メディア取得・更新で category_ulid を返却・保存できるように対応

### DIFF
--- a/myus/api/src/adapter/media.py
+++ b/myus/api/src/adapter/media.py
@@ -458,6 +458,7 @@ def convert_videos(objs: list[VideoData]) -> list[VideoOut]:
             created=x.created,
             updated=x.updated,
             channel=convert_channel(x.channel),
+            category_ulid=x.category_ulid,
         ) for x in objs
     ]
     return data
@@ -478,6 +479,7 @@ def convert_musics(objs: list[MusicData]) -> list[MusicOut]:
             created=x.created,
             updated=x.updated,
             channel=convert_channel(x.channel),
+            category_ulid=x.category_ulid,
         ) for x in objs
     ]
     return data
@@ -497,6 +499,7 @@ def convert_blogs(objs: list[BlogData]) -> list[BlogOut]:
             created=x.created,
             updated=x.updated,
             channel=convert_channel(x.channel),
+            category_ulid=x.category_ulid,
         ) for x in objs
     ]
     return data
@@ -515,6 +518,7 @@ def convert_comics(objs: list[ComicData]) -> list[ComicOut]:
             created=x.created,
             updated=x.updated,
             channel=convert_channel(x.channel),
+            category_ulid=x.category_ulid,
         ) for x in objs
     ]
     return data
@@ -533,6 +537,7 @@ def convert_pictures(objs: list[PictureData]) -> list[PictureOut]:
             created=x.created,
             updated=x.updated,
             channel=convert_channel(x.channel),
+            category_ulid=x.category_ulid,
         ) for x in objs
     ]
     return data
@@ -553,6 +558,7 @@ def convert_chats(objs: list[ChatData]) -> list[ChatOut]:
             created=x.created,
             updated=x.updated,
             channel=convert_channel(x.channel),
+            category_ulid=x.category_ulid,
         ) for x in objs
     ]
     return data

--- a/myus/api/src/domain/entity/media/blog/_convert.py
+++ b/myus/api/src/domain/entity/media/blog/_convert.py
@@ -6,6 +6,8 @@ from api.src.domain.interface.media.blog.data import BlogData
 
 
 def convert_data(obj: Blog) -> BlogData:
+    category = obj.category.first()
+    assert category is not None, "Category is required"
     return BlogData(
         id=obj.id,
         ulid=obj.ulid,
@@ -30,6 +32,7 @@ def convert_data(obj: Blog) -> BlogData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
+        category_ulid=category.ulid,
         hashtags=[HashtagData(id=bh.hashtag.id, ulid=bh.hashtag.ulid, name=bh.hashtag.name) for bh in obj.blog_hashtags.all()],
     )
 

--- a/myus/api/src/domain/entity/media/blog/repository.py
+++ b/myus/api/src/domain/entity/media/blog/repository.py
@@ -13,7 +13,7 @@ BLOG_FIELDS = ["channel_id", "title", "content", "richtext", "image", "read", "p
 
 class BlogRepository(BlogInterface):
     def queryset(self) -> QuerySet[Blog]:
-        return Blog.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
+        return Blog.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Blog.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/chat/_convert.py
+++ b/myus/api/src/domain/entity/media/chat/_convert.py
@@ -6,6 +6,8 @@ from api.src.domain.interface.media.chat.data import ChatData
 
 
 def convert_data(obj: Chat) -> ChatData:
+    category = obj.category.first()
+    assert category is not None, "Category is required"
     return ChatData(
         id=obj.id,
         ulid=obj.ulid,
@@ -30,6 +32,7 @@ def convert_data(obj: Chat) -> ChatData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
+        category_ulid=category.ulid,
         hashtags=[HashtagData(id=ch.hashtag.id, ulid=ch.hashtag.ulid, name=ch.hashtag.name) for ch in obj.chat_hashtags.all()],
     )
 

--- a/myus/api/src/domain/entity/media/chat/repository.py
+++ b/myus/api/src/domain/entity/media/chat/repository.py
@@ -13,7 +13,7 @@ CHAT_FIELDS = ["channel_id", "title", "content", "read", "period", "publish"]
 
 class ChatRepository(ChatInterface):
     def queryset(self) -> QuerySet[Chat]:
-        return Chat.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
+        return Chat.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Chat.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/comic/_convert.py
+++ b/myus/api/src/domain/entity/media/comic/_convert.py
@@ -6,6 +6,8 @@ from api.src.domain.interface.media.comic.data import ComicData
 
 
 def convert_data(obj: Comic) -> ComicData:
+    category = obj.category.first()
+    assert category is not None, "Category is required"
     return ComicData(
         id=obj.id,
         ulid=obj.ulid,
@@ -29,6 +31,7 @@ def convert_data(obj: Comic) -> ComicData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
+        category_ulid=category.ulid,
         hashtags=[HashtagData(id=ch.hashtag.id, ulid=ch.hashtag.ulid, name=ch.hashtag.name) for ch in obj.comic_hashtags.all()],
     )
 

--- a/myus/api/src/domain/entity/media/comic/repository.py
+++ b/myus/api/src/domain/entity/media/comic/repository.py
@@ -16,7 +16,7 @@ COMIC_FIELDS = ["channel_id", "title", "content", "image", "read", "publish"]
 class ComicRepository(ComicInterface):
     def queryset(self) -> QuerySet[Comic]:
         pages_prefetch = Prefetch("comic", queryset=ComicPage.objects.order_by("sequence"))
-        return Comic.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", pages_prefetch)
+        return Comic.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category", pages_prefetch)
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Comic.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/music/_convert.py
+++ b/myus/api/src/domain/entity/media/music/_convert.py
@@ -6,6 +6,8 @@ from api.src.domain.interface.media.music.data import MusicData
 
 
 def convert_data(obj: Music) -> MusicData:
+    category = obj.category.first()
+    assert category is not None, "Category is required"
     return MusicData(
         id=obj.id,
         ulid=obj.ulid,
@@ -30,6 +32,7 @@ def convert_data(obj: Music) -> MusicData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
+        category_ulid=category.ulid,
         hashtags=[HashtagData(id=mh.hashtag.id, ulid=mh.hashtag.ulid, name=mh.hashtag.name) for mh in obj.music_hashtags.all()],
     )
 

--- a/myus/api/src/domain/entity/media/music/repository.py
+++ b/myus/api/src/domain/entity/media/music/repository.py
@@ -13,7 +13,7 @@ MUSIC_FIELDS = ["channel_id", "title", "content", "lyric", "music", "read", "dow
 
 class MusicRepository(MusicInterface):
     def queryset(self) -> QuerySet[Music]:
-        return Music.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
+        return Music.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Music.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/picture/_convert.py
+++ b/myus/api/src/domain/entity/media/picture/_convert.py
@@ -6,6 +6,8 @@ from api.src.domain.interface.media.picture.data import PictureData
 
 
 def convert_data(obj: Picture) -> PictureData:
+    category = obj.category.first()
+    assert category is not None, "Category is required"
     return PictureData(
         id=obj.id,
         ulid=obj.ulid,
@@ -28,6 +30,7 @@ def convert_data(obj: Picture) -> PictureData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
+        category_ulid=category.ulid,
         hashtags=[HashtagData(id=t.hashtag.id, ulid=t.hashtag.ulid, name=t.hashtag.name) for t in obj.picture_hashtags.all()],
     )
 

--- a/myus/api/src/domain/entity/media/picture/repository.py
+++ b/myus/api/src/domain/entity/media/picture/repository.py
@@ -13,7 +13,7 @@ PICTURE_FIELDS = ["channel_id", "title", "content", "image", "read", "publish"]
 
 class PictureRepository(PictureInterface):
     def queryset(self) -> QuerySet[Picture]:
-        return Picture.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
+        return Picture.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Picture.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/video/_convert.py
+++ b/myus/api/src/domain/entity/media/video/_convert.py
@@ -6,6 +6,8 @@ from api.src.domain.interface.media.video.data import VideoData
 
 
 def convert_data(obj: Video) -> VideoData:
+    category = obj.category.first()
+    assert category is not None, "Category is required"
     return VideoData(
         id=obj.id,
         ulid=obj.ulid,
@@ -30,6 +32,7 @@ def convert_data(obj: Video) -> VideoData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
+        category_ulid=category.ulid,
         hashtags=[HashtagData(id=t.hashtag.id, ulid=t.hashtag.ulid, name=t.hashtag.name) for t in obj.video_hashtags.all()],
     )
 

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -13,7 +13,7 @@ VIDEO_FIELDS = ["channel_id", "title", "content", "image", "video", "convert", "
 
 class VideoRepository(VideoInterface):
     def queryset(self) -> QuerySet[Video]:
-        return Video.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag")
+        return Video.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Video.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/interface/media/blog/data.py
+++ b/myus/api/src/domain/interface/media/blog/data.py
@@ -19,4 +19,5 @@ class BlogData:
     created: datetime
     updated: datetime
     channel: ChannelData
+    category_ulid: str
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/chat/data.py
+++ b/myus/api/src/domain/interface/media/chat/data.py
@@ -19,4 +19,5 @@ class ChatData:
     thread_count: int
     joined_count: int
     channel: ChannelData
+    category_ulid: str
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/comic/data.py
+++ b/myus/api/src/domain/interface/media/comic/data.py
@@ -18,4 +18,5 @@ class ComicData:
     created: datetime
     updated: datetime
     channel: ChannelData
+    category_ulid: str
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/music/data.py
+++ b/myus/api/src/domain/interface/media/music/data.py
@@ -19,4 +19,5 @@ class MusicData:
     created: datetime
     updated: datetime
     channel: ChannelData
+    category_ulid: str
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/picture/data.py
+++ b/myus/api/src/domain/interface/media/picture/data.py
@@ -17,4 +17,5 @@ class PictureData:
     created: datetime
     updated: datetime
     channel: ChannelData
+    category_ulid: str
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/video/data.py
+++ b/myus/api/src/domain/interface/media/video/data.py
@@ -19,4 +19,5 @@ class VideoData:
     created: datetime
     updated: datetime
     channel: ChannelData
+    category_ulid: str
     hashtags: list[HashtagData]

--- a/myus/api/src/types/schema/media/input.py
+++ b/myus/api/src/types/schema/media/input.py
@@ -54,12 +54,14 @@ class ChatIn(BaseModel):
 
 
 class VideoUpdateIn(BaseModel):
+    category_ulid: str
     title: str
     content: str
     publish: bool
 
 
 class MusicUpdateIn(BaseModel):
+    category_ulid: str
     title: str
     content: str
     lyric: str
@@ -68,6 +70,7 @@ class MusicUpdateIn(BaseModel):
 
 
 class BlogUpdateIn(BaseModel):
+    category_ulid: str
     title: str
     content: str
     richtext: str
@@ -75,18 +78,21 @@ class BlogUpdateIn(BaseModel):
 
 
 class ComicUpdateIn(BaseModel):
+    category_ulid: str
     title: str
     content: str
     publish: bool
 
 
 class PictureUpdateIn(BaseModel):
+    category_ulid: str
     title: str
     content: str
     publish: bool
 
 
 class ChatUpdateIn(BaseModel):
+    category_ulid: str
     title: str
     content: str
     period: str

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -20,6 +20,7 @@ class MediaOut(BaseModel):
     created: datetime
     updated: datetime
     channel: ChannelOut
+    category_ulid: str
 
 
 class HashtagOut(BaseModel):

--- a/myus/api/src/usecase/manage/media.py
+++ b/myus/api/src/usecase/manage/media.py
@@ -1,7 +1,10 @@
 from dataclasses import replace
 from datetime import date
+from django.db import transaction
 from ninja import UploadedFile
 from api.modules.logger import log
+from api.src.domain.interface.category.data import CategoryData
+from api.src.domain.interface.category.interface import CategoryInterface
 from api.src.domain.interface.media.video.data import VideoData
 from api.src.domain.interface.media.video.interface import VideoInterface
 from api.src.domain.interface.media.music.data import MusicData
@@ -17,7 +20,7 @@ from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PAGE_SIZE, PageOption, SortOption
 from api.src.injectors.container import injector
 from api.src.types.schema.media.input import VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
-from api.utils.enum.index import ImageUpload
+from api.utils.enum.index import ImageUpload, MediaType
 from api.utils.functions.index import create_url
 from api.utils.functions.media import save_upload
 
@@ -69,8 +72,13 @@ def update_manage_video(user_id: int, ulid: str, input: VideoUpdateIn, image: Up
     if image is not None:
         update_data = replace(update_data, image=save_upload(image, ImageUpload.VIDEO, obj.channel.ulid))
 
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
     try:
-        repository.bulk_save([update_data])
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+            category_repo.bulk_save(MediaType.VIDEO, obj.id, categories)
         return True
     except Exception as e:
         log.error("update_manage_video error", exc=e)
@@ -131,8 +139,13 @@ def update_manage_music(user_id: int, ulid: str, input: MusicUpdateIn) -> bool:
         return False
 
     update_data = replace(obj, title=input.title, content=input.content, lyric=input.lyric, download=input.download, publish=input.publish)
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
     try:
-        repository.bulk_save([update_data])
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+            category_repo.bulk_save(MediaType.MUSIC, obj.id, categories)
         return True
     except Exception as e:
         log.error("update_manage_music error", exc=e)
@@ -196,8 +209,13 @@ def update_manage_blog(user_id: int, ulid: str, input: BlogUpdateIn, image: Uplo
     if image is not None:
         update_data = replace(update_data, image=save_upload(image, ImageUpload.BLOG, obj.channel.ulid))
 
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
     try:
-        repository.bulk_save([update_data])
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+            category_repo.bulk_save(MediaType.BLOG, obj.id, categories)
         return True
     except Exception as e:
         log.error("update_manage_blog error", exc=e)
@@ -267,8 +285,13 @@ def update_manage_comic(user_id: int, ulid: str, input: ComicUpdateIn, image: Up
     if image is not None:
         update_data = replace(update_data, image=save_upload(image, ImageUpload.COMIC, obj.channel.ulid))
 
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
     try:
-        repository.bulk_save([update_data])
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+            category_repo.bulk_save(MediaType.COMIC, obj.id, categories)
         return True
     except Exception as e:
         log.error("update_manage_comic error", exc=e)
@@ -332,8 +355,13 @@ def update_manage_picture(user_id: int, ulid: str, input: PictureUpdateIn, image
     if image is not None:
         update_data = replace(update_data, image=save_upload(image, ImageUpload.PICTURE, obj.channel.ulid))
 
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
     try:
-        repository.bulk_save([update_data])
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+            category_repo.bulk_save(MediaType.PICTURE, obj.id, categories)
         return True
     except Exception as e:
         log.error("update_manage_picture error", exc=e)
@@ -391,8 +419,13 @@ def update_manage_chat(user_id: int, ulid: str, input: ChatUpdateIn) -> bool:
         return False
 
     update_data = replace(obj, title=input.title, content=input.content, period=date.fromisoformat(input.period), publish=input.publish)
+    category_repo = injector.get(CategoryInterface)
+    categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
+
     try:
-        repository.bulk_save([update_data])
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+            category_repo.bulk_save(MediaType.CHAT, obj.id, categories)
         return True
     except Exception as e:
         log.error("update_manage_chat error", exc=e)

--- a/myus/api/src/usecase/media.py
+++ b/myus/api/src/usecase/media.py
@@ -38,7 +38,6 @@ def create_video(input: VideoIn, image: UploadedFile, video: UploadedFile) -> Me
     if channel is None:
         return None
 
-    repository = injector.get(VideoInterface)
     video_path = save_upload(video, MediaUpload.VIDEO, channel.ulid)
 
     new_video = VideoData(
@@ -55,9 +54,11 @@ def create_video(input: VideoIn, image: UploadedFile, video: UploadedFile) -> Me
         created=datetime.min,
         updated=datetime.min,
         channel=channel,
+        category_ulid="",
         hashtags=[],
     )
 
+    repository = injector.get(VideoInterface)
     category_repo = injector.get(CategoryInterface)
     categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
@@ -87,8 +88,6 @@ def create_music(input: MusicIn, music: UploadedFile) -> MediaCreateDTO | None:
     if channel is None:
         return None
 
-    repository = injector.get(MusicInterface)
-
     new_music = MusicData(
         id=0,
         ulid="",
@@ -103,9 +102,11 @@ def create_music(input: MusicIn, music: UploadedFile) -> MediaCreateDTO | None:
         created=datetime.min,
         updated=datetime.min,
         channel=channel,
+        category_ulid="",
         hashtags=[],
     )
 
+    repository = injector.get(MusicInterface)
     category_repo = injector.get(CategoryInterface)
     categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
@@ -123,8 +124,6 @@ def create_blog(input: BlogIn, image: UploadedFile) -> MediaCreateDTO | None:
     if channel is None:
         return None
 
-    repository = injector.get(BlogInterface)
-
     new_blog = BlogData(
         id=0,
         ulid="",
@@ -139,9 +138,11 @@ def create_blog(input: BlogIn, image: UploadedFile) -> MediaCreateDTO | None:
         created=datetime.min,
         updated=datetime.min,
         channel=channel,
+        category_ulid="",
         hashtags=[],
     )
 
+    repository = injector.get(BlogInterface)
     category_repo = injector.get(CategoryInterface)
     categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
@@ -159,8 +160,6 @@ def create_comic(input: ComicIn, image: UploadedFile, pages: list[UploadedFile])
     if channel is None:
         return None
 
-    repository = injector.get(ComicInterface)
-
     new_comic = ComicData(
         id=0,
         ulid="",
@@ -174,9 +173,11 @@ def create_comic(input: ComicIn, image: UploadedFile, pages: list[UploadedFile])
         created=datetime.min,
         updated=datetime.min,
         channel=channel,
+        category_ulid="",
         hashtags=[],
     )
 
+    repository = injector.get(ComicInterface)
     category_repo = injector.get(CategoryInterface)
     categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
@@ -194,8 +195,6 @@ def create_picture(input: PictureIn, image: UploadedFile) -> MediaCreateDTO | No
     if channel is None:
         return None
 
-    repository = injector.get(PictureInterface)
-
     new_picture = PictureData(
         id=0,
         ulid="",
@@ -208,9 +207,11 @@ def create_picture(input: PictureIn, image: UploadedFile) -> MediaCreateDTO | No
         created=datetime.min,
         updated=datetime.min,
         channel=channel,
+        category_ulid="",
         hashtags=[],
     )
 
+    repository = injector.get(PictureInterface)
     category_repo = injector.get(CategoryInterface)
     categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 
@@ -228,8 +229,6 @@ def create_chat(input: ChatIn) -> MediaCreateDTO | None:
     if channel is None:
         return None
 
-    repository = injector.get(ChatInterface)
-
     new_chat = ChatData(
         id=0,
         ulid="",
@@ -244,9 +243,11 @@ def create_chat(input: ChatIn) -> MediaCreateDTO | None:
         thread_count=0,
         joined_count=0,
         channel=channel,
+        category_ulid="",
         hashtags=[],
     )
 
+    repository = injector.get(ChatInterface)
     category_repo = injector.get(CategoryInterface)
     categories = [CategoryData(id=0, ulid=input.category_ulid, jp_name="", en_name="")] if input.category_ulid else []
 


### PR DESCRIPTION
## Summary
- 6 メディアの dataclass / Out / UpdateIn / repository に `category_ulid` を組み込み、編集画面でカテゴリの取得と保存ができるようにする
- `update_manage_*` を `transaction.atomic` 化し、メディア本体と category M2M を一体ロールバック
- create と update のコード構造（`repository` と `category_repo` の隣接配置）を統一

## 変更内容

### Domain dataclass（`domain/interface/media/{video,music,blog,comic,picture,chat}/data.py`）
- 各 `*Data` に `category_ulid: str` を追加。必須フィールド（空文字不許容）

### Domain convert（`domain/entity/media/{video,music,blog,comic,picture,chat}/_convert.py`）
- `convert_data` 冒頭で:
  ```python
  category = obj.category.first()
  assert category is not None, "Category is required"
  ```
  を実行し、`category_ulid=category.ulid` で populate（`user/_convert.py:13` の assert パターン準拠）

### Repository prefetch（同 `repository.py` 6 ファイル）
- `prefetch_related(..., "category")` を追加して N+1 回避

### Output schema（`types/schema/media/output.py`）
- `MediaOut` 基底に `category_ulid: str` を追加 → `VideoOut` / `MusicOut` / `BlogOut` / `ComicOut` / `PictureOut` / `ChatOut` に伝搬

### Adapter（`adapter/media.py`）
- `convert_videos` / `convert_musics` / `convert_blogs` / `convert_comics` / `convert_pictures` / `convert_chats` に `category_ulid=x.category_ulid` を追加

### Update Schema（`types/schema/media/input.py`）
- 6 つの `*UpdateIn`（Video/Music/Blog/Comic/Picture/Chat）に `category_ulid: str` を追加

### Update usecase（`usecase/manage/media.py`）
- `update_manage_*` 6 関数を `with transaction.atomic():` で囲み、`CategoryRepository.bulk_save(MediaType.XXX, obj.id, categories)` を呼ぶ
- `category_ulid` が空文字なら categories=[] を渡しクリア（仕様上は発生しない想定だが防御）
- `from django.db import transaction` / `from api.utils.enum.index import MediaType` 等の import 追加

### Create usecase（`usecase/media.py`）
- `*Data` 構築時のダミー `category_ulid=""` を追加（直後の `category_repo.bulk_save` で正しい値を設定）
- `repository = injector.get(...)` を `*Data` 構築直後に移動し `category_repo = injector.get(...)` と隣接配置（コード構造統一）

## ロールバック
- create / update の両方で `transaction.atomic` 内に メディア本体保存 + category M2M 設定を集約
- 片方が失敗すると両方ロールバック → 「メディアだけ更新されてカテゴリが食い違う」状態を防止

## 確認
- mypy で新規エラーなし（既存の `period: date vs datetime` 警告のみ）

## 残タスク（別 PR）
- フロント: 6 つの edit 画面（pages / templates）にカテゴリー SelectBox を追加