### PR TITLE
【front】6 メディアの edit 画面にカテゴリー選択を追加

### DIFF
--- a/frontend/src/components/templates/manage/blog/edit.tsx
+++ b/frontend/src/components/templates/manage/blog/edit.tsx
@@ -1,6 +1,7 @@
 import { useState, ChangeEvent } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { BlogUpdateIn } from 'types/internal/media/input'
 import { Blog } from 'types/internal/media/output'
@@ -26,22 +27,25 @@ const TextEditor = dynamic(() => import('components/widgets/TextEditor'), { ssr:
 interface Props {
   data: Blog
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageBlogEdit(props: Props): React.JSX.Element {
-  const { data, channels } = props
+  const { data, channels, categories } = props
 
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<BlogUpdateIn>({ title: data.title, content: data.content, richtext: data.richtext, publish: data.publish })
+  const [values, setValues] = useState<BlogUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, richtext: data.richtext, publish: data.publish })
 
   const handleBack = () => router.push('/manage/blog')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
@@ -52,8 +56,8 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
   }
 
   const handleForm = async () => {
-    const { title, content, richtext } = values
-    if (!isRequiredCheck({ title, content, richtext })) return
+    const { categoryUlid, title, content, richtext } = values
+    if (!isRequiredCheck({ categoryUlid, title, content, richtext })) return
     handleLoading(true)
     const ret = await putManageBlog(data.ulid, values)
     handleLoading(false)
@@ -77,6 +81,7 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />

--- a/frontend/src/components/templates/manage/chat/edit.tsx
+++ b/frontend/src/components/templates/manage/chat/edit.tsx
@@ -1,5 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { ChatUpdateIn } from 'types/internal/media/input'
 import { Chat } from 'types/internal/media/output'
@@ -23,28 +24,31 @@ import VStack from 'components/parts/Stack/Vertical'
 interface Props {
   data: Chat
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageChatEdit(props: Props): React.JSX.Element {
-  const { data, channels } = props
+  const { data, channels, categories } = props
 
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<ChatUpdateIn>({ title: data.title, content: data.content, period: formatDate(data.period), publish: data.publish })
+  const [values, setValues] = useState<ChatUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, period: formatDate(data.period), publish: data.publish })
 
   const handleBack = () => router.push('/manage/chat')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
 
   const handleForm = async () => {
-    const { title, content, period } = values
-    if (!isRequiredCheck({ title, content, period })) return
+    const { categoryUlid, title, content, period } = values
+    if (!isRequiredCheck({ categoryUlid, title, content, period })) return
     handleLoading(true)
     const ret = await putManageChat(data.ulid, values)
     handleLoading(false)
@@ -68,6 +72,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <Input label="期間" name="period" value={values.period} required={isRequired} onChange={handleInput} />

--- a/frontend/src/components/templates/manage/comic/edit.tsx
+++ b/frontend/src/components/templates/manage/comic/edit.tsx
@@ -1,5 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { ComicUpdateIn } from 'types/internal/media/input'
 import { Comic } from 'types/internal/media/output'
@@ -23,29 +24,32 @@ import VStack from 'components/parts/Stack/Vertical'
 interface Props {
   data: Comic
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageComicEdit(props: Props): React.JSX.Element {
-  const { data, channels } = props
+  const { data, channels, categories } = props
 
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<ComicUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
+  const [values, setValues] = useState<ComicUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, publish: data.publish })
 
   const handleBack = () => router.push('/manage/comic')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
-    const { title, content } = values
-    if (!isRequiredCheck({ title, content })) return
+    const { categoryUlid, title, content } = values
+    if (!isRequiredCheck({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManageComic(data.ulid, values)
     handleLoading(false)
@@ -69,6 +73,7 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />

--- a/frontend/src/components/templates/manage/music/edit.tsx
+++ b/frontend/src/components/templates/manage/music/edit.tsx
@@ -1,5 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { MusicUpdateIn } from 'types/internal/media/input'
 import { Music } from 'types/internal/media/output'
@@ -23,12 +24,14 @@ import VStack from 'components/parts/Stack/Vertical'
 interface Props {
   data: Music
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageMusicEdit(props: Props): React.JSX.Element {
-  const { data, channels } = props
+  const { data, channels, categories } = props
 
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
@@ -39,13 +42,14 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
 
   const handleBack = () => router.push('/manage/music')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.checked })
 
   const handleForm = async () => {
-    const { title, content, lyric } = values
-    if (!isRequiredCheck({ title, content, lyric })) return
+    const { categoryUlid, title, content, lyric } = values
+    if (!isRequiredCheck({ categoryUlid, title, content, lyric })) return
     handleLoading(true)
     const ret = await putManageMusic(data.ulid, values)
     handleLoading(false)
@@ -69,6 +73,7 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <Textarea label="歌詞" name="lyric" value={values.lyric} required={isRequired} onChange={handleText} />

--- a/frontend/src/components/templates/manage/picture/edit.tsx
+++ b/frontend/src/components/templates/manage/picture/edit.tsx
@@ -1,5 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { PictureUpdateIn } from 'types/internal/media/input'
 import { Picture } from 'types/internal/media/output'
@@ -23,29 +24,32 @@ import VStack from 'components/parts/Stack/Vertical'
 interface Props {
   data: Picture
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManagePictureEdit(props: Props): React.JSX.Element {
-  const { data, channels } = props
+  const { data, channels, categories } = props
 
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<PictureUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
+  const [values, setValues] = useState<PictureUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, publish: data.publish })
 
   const handleBack = () => router.push('/manage/picture')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
-    const { title, content } = values
-    if (!isRequiredCheck({ title, content })) return
+    const { categoryUlid, title, content } = values
+    if (!isRequiredCheck({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManagePicture(data.ulid, values)
     handleLoading(false)
@@ -69,6 +73,7 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <InputFile label="画像" accept="image/*" onChange={handleFile} />

--- a/frontend/src/components/templates/manage/video/edit.tsx
+++ b/frontend/src/components/templates/manage/video/edit.tsx
@@ -1,5 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import { useRouter } from 'next/router'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { VideoUpdateIn } from 'types/internal/media/input'
 import { Video } from 'types/internal/media/output'
@@ -23,29 +24,32 @@ import VStack from 'components/parts/Stack/Vertical'
 interface Props {
   data: Video
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageVideoEdit(props: Props): React.JSX.Element {
-  const { data, channels } = props
+  const { data, channels, categories } = props
 
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
+  const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<VideoUpdateIn>({ title: data.title, content: data.content, publish: data.publish })
+  const [values, setValues] = useState<VideoUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, publish: data.publish })
 
   const handleBack = () => router.push('/manage/video')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleFile = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
 
   const handleForm = async () => {
-    const { title, content } = values
-    if (!isRequiredCheck({ title, content })) return
+    const { categoryUlid, title, content } = values
+    if (!isRequiredCheck({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManageVideo(data.ulid, values)
     handleLoading(false)
@@ -69,6 +73,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />

--- a/frontend/src/pages/manage/blog/[ulid].tsx
+++ b/frontend/src/pages/manage/blog/[ulid].tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { Blog } from 'types/internal/media/output'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import { getManageBlog } from 'api/internal/manage/get'
 import ErrorCheck from 'components/widgets/Error/Check'
@@ -10,18 +12,21 @@ import ManageBlogEdit from 'components/templates/manage/blog/edit'
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const ulid = String(params?.ulid ?? '')
-  const [blogRet, channelsRet] = await Promise.all([getManageBlog(ulid, req), getChannels(req)])
+  const [blogRet, channelsRet, categoriesRet] = await Promise.all([getManageBlog(ulid, req), getChannels(req), getCategories(req)])
   if (blogRet.isErr()) return { props: { status: blogRet.error.status } }
   if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  if (categoriesRet.isErr()) return { props: { status: categoriesRet.error.status } }
   const data = blogRet.value
   const channels = channelsRet.value
-  return { props: { ...translations, data, channels } }
+  const categories = categoriesRet.value
+  return { props: { ...translations, data, channels, categories } }
 }
 
 interface Props {
   status: number
   data: Blog
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageBlogEditPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/chat/[ulid].tsx
+++ b/frontend/src/pages/manage/chat/[ulid].tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { Chat } from 'types/internal/media/output'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import { getManageChat } from 'api/internal/manage/get'
 import ErrorCheck from 'components/widgets/Error/Check'
@@ -10,18 +12,21 @@ import ManageChatEdit from 'components/templates/manage/chat/edit'
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const ulid = String(params?.ulid ?? '')
-  const [chatRet, channelsRet] = await Promise.all([getManageChat(ulid, req), getChannels(req)])
+  const [chatRet, channelsRet, categoriesRet] = await Promise.all([getManageChat(ulid, req), getChannels(req), getCategories(req)])
   if (chatRet.isErr()) return { props: { status: chatRet.error.status } }
   if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  if (categoriesRet.isErr()) return { props: { status: categoriesRet.error.status } }
   const data = chatRet.value
   const channels = channelsRet.value
-  return { props: { ...translations, data, channels } }
+  const categories = categoriesRet.value
+  return { props: { ...translations, data, channels, categories } }
 }
 
 interface Props {
   status: number
   data: Chat
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageChatEditPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/comic/[ulid].tsx
+++ b/frontend/src/pages/manage/comic/[ulid].tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { Comic } from 'types/internal/media/output'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import { getManageComic } from 'api/internal/manage/get'
 import ErrorCheck from 'components/widgets/Error/Check'
@@ -10,18 +12,21 @@ import ManageComicEdit from 'components/templates/manage/comic/edit'
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const ulid = String(params?.ulid ?? '')
-  const [comicRet, channelsRet] = await Promise.all([getManageComic(ulid, req), getChannels(req)])
+  const [comicRet, channelsRet, categoriesRet] = await Promise.all([getManageComic(ulid, req), getChannels(req), getCategories(req)])
   if (comicRet.isErr()) return { props: { status: comicRet.error.status } }
   if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  if (categoriesRet.isErr()) return { props: { status: categoriesRet.error.status } }
   const data = comicRet.value
   const channels = channelsRet.value
-  return { props: { ...translations, data, channels } }
+  const categories = categoriesRet.value
+  return { props: { ...translations, data, channels, categories } }
 }
 
 interface Props {
   status: number
   data: Comic
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageComicEditPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/music/[ulid].tsx
+++ b/frontend/src/pages/manage/music/[ulid].tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { Music } from 'types/internal/media/output'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import { getManageMusic } from 'api/internal/manage/get'
 import ErrorCheck from 'components/widgets/Error/Check'
@@ -10,18 +12,21 @@ import ManageMusicEdit from 'components/templates/manage/music/edit'
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const ulid = String(params?.ulid ?? '')
-  const [musicRet, channelsRet] = await Promise.all([getManageMusic(ulid, req), getChannels(req)])
+  const [musicRet, channelsRet, categoriesRet] = await Promise.all([getManageMusic(ulid, req), getChannels(req), getCategories(req)])
   if (musicRet.isErr()) return { props: { status: musicRet.error.status } }
   if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  if (categoriesRet.isErr()) return { props: { status: categoriesRet.error.status } }
   const data = musicRet.value
   const channels = channelsRet.value
-  return { props: { ...translations, data, channels } }
+  const categories = categoriesRet.value
+  return { props: { ...translations, data, channels, categories } }
 }
 
 interface Props {
   status: number
   data: Music
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageMusicEditPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/picture/[ulid].tsx
+++ b/frontend/src/pages/manage/picture/[ulid].tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { Picture } from 'types/internal/media/output'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import { getManagePicture } from 'api/internal/manage/get'
 import ErrorCheck from 'components/widgets/Error/Check'
@@ -10,18 +12,21 @@ import ManagePictureEdit from 'components/templates/manage/picture/edit'
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const ulid = String(params?.ulid ?? '')
-  const [pictureRet, channelsRet] = await Promise.all([getManagePicture(ulid, req), getChannels(req)])
+  const [pictureRet, channelsRet, categoriesRet] = await Promise.all([getManagePicture(ulid, req), getChannels(req), getCategories(req)])
   if (pictureRet.isErr()) return { props: { status: pictureRet.error.status } }
   if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  if (categoriesRet.isErr()) return { props: { status: categoriesRet.error.status } }
   const data = pictureRet.value
   const channels = channelsRet.value
-  return { props: { ...translations, data, channels } }
+  const categories = categoriesRet.value
+  return { props: { ...translations, data, channels, categories } }
 }
 
 interface Props {
   status: number
   data: Picture
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManagePictureEditPage(props: Props): React.JSX.Element {

--- a/frontend/src/pages/manage/video/[ulid].tsx
+++ b/frontend/src/pages/manage/video/[ulid].tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Category } from 'types/internal/category'
 import { Channel } from 'types/internal/channel'
 import { Video } from 'types/internal/media/output'
+import { getCategories } from 'api/internal/category'
 import { getChannels } from 'api/internal/channel'
 import { getManageVideo } from 'api/internal/manage/get'
 import ErrorCheck from 'components/widgets/Error/Check'
@@ -10,18 +12,21 @@ import ManageVideoEdit from 'components/templates/manage/video/edit'
 export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
   const translations = await serverSideTranslations(String(locale), ['common'])
   const ulid = String(params?.ulid ?? '')
-  const [videoRet, channelsRet] = await Promise.all([getManageVideo(ulid, req), getChannels(req)])
+  const [videoRet, channelsRet, categoriesRet] = await Promise.all([getManageVideo(ulid, req), getChannels(req), getCategories(req)])
   if (videoRet.isErr()) return { props: { status: videoRet.error.status } }
   if (channelsRet.isErr()) return { props: { status: channelsRet.error.status } }
+  if (categoriesRet.isErr()) return { props: { status: categoriesRet.error.status } }
   const data = videoRet.value
   const channels = channelsRet.value
-  return { props: { ...translations, data, channels } }
+  const categories = categoriesRet.value
+  return { props: { ...translations, data, channels, categories } }
 }
 
 interface Props {
   status: number
   data: Video
   channels: Channel[]
+  categories: Category[]
 }
 
 export default function ManageVideoEditPage(props: Props): React.JSX.Element {

--- a/frontend/src/types/internal/media/input.d.ts
+++ b/frontend/src/types/internal/media/input.d.ts
@@ -6,12 +6,6 @@ export interface MediaIn {
   content: string
 }
 
-export interface MediaUpdateIn {
-  title: string
-  content: string
-  publish: boolean
-}
-
 export interface VideoIn extends MediaIn {
   image?: File
   video?: File
@@ -40,6 +34,13 @@ export interface PictureIn extends MediaIn {
 
 export interface ChatIn extends MediaIn {
   period: string
+}
+
+export interface MediaUpdateIn {
+  categoryUlid: string
+  title: string
+  content: string
+  publish: boolean
 }
 
 export interface VideoUpdateIn extends MediaUpdateIn {

--- a/frontend/src/types/internal/media/output.d.ts
+++ b/frontend/src/types/internal/media/output.d.ts
@@ -29,6 +29,7 @@ export interface Media {
   created: Date
   updated: Date
   channel: Channel
+  categoryUlid: string
   mediaUser: MediaUser
 }
 


### PR DESCRIPTION
## Summary
- 6 メディア（Video / Music / Blog / Comic / Picture / Chat）の edit 画面にカテゴリー選択 `SelectBox` を追加
- 既存値（`data.categoryUlid`）を初期表示し、保存時は `categoryUlid` を含めて PUT
- 共通基底型（`Media` / `MediaUpdateIn`）に `categoryUlid` を追加して継承で伝搬

## 変更内容

### `frontend/src/types/internal/media/output.d.ts`
- `Media` 基底型に `categoryUlid: string` を追加（`Video` / `Music` / `Blog` / `Comic` / `Picture` / `Chat` に継承で伝搬）

### `frontend/src/types/internal/media/input.d.ts`
- `MediaUpdateIn` 基底型に `categoryUlid: string` を追加（6 つの `*UpdateIn` に伝搬）

### `frontend/src/pages/manage/{video,music,blog,comic,picture,chat}/[ulid].tsx`
- `getCategories` を `Promise.all` に追加（既存の `getMedia` / `getChannels` と並列取得）
- `Props` に `categories: Category[]` を追加してテンプレートに渡す

### `frontend/src/components/templates/manage/{video,music,blog,comic,picture,chat}/edit.tsx`
- `Props` に `categories: Category[]` を追加
- `categoryOptions` を構築（先頭に `{ label: '未選択', value: '' }`）
- 初期 state `useState<*UpdateIn>` に `categoryUlid: data.categoryUlid` を追加（既存値を表示）
- `handleSelect` 追加、`isRequiredCheck` に `categoryUlid` を含める
- チャンネル `SelectBox` の直下にカテゴリー `SelectBox`（`required={isRequired}`）を配置

## 関連
- バック: PR #776（dataclass / Out / UpdateIn / update_manage_* に category_ulid を組み込み）と同時にリリースが必要

## 確認
- `npm run lint` / `tsc --noEmit` 共に新規エラーなし