### PR TITLE
【front】メディア作成画面で default チャンネルを必須前提化（!.ulid 統一）

### DIFF
--- a/frontend/src/components/templates/manage/blog/create.tsx
+++ b/frontend/src/components/templates/manage/blog/create.tsx
@@ -28,7 +28,7 @@ interface Props {
 export default function BlogCreate(props: Props): React.JSX.Element {
   const { channels, categories } = props
 
-  const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+  const channelUlid = channels.find((c) => c.isDefault)!.ulid
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 

--- a/frontend/src/components/templates/manage/chat/create.tsx
+++ b/frontend/src/components/templates/manage/chat/create.tsx
@@ -25,7 +25,7 @@ interface Props {
 export default function ChatCreate(props: Props): React.JSX.Element {
   const { channels, categories } = props
 
-  const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+  const channelUlid = channels.find((c) => c.isDefault)!.ulid
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 

--- a/frontend/src/components/templates/manage/comic/create.tsx
+++ b/frontend/src/components/templates/manage/comic/create.tsx
@@ -25,7 +25,7 @@ interface Props {
 export default function ComicCreate(props: Props): React.JSX.Element {
   const { channels, categories } = props
 
-  const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+  const channelUlid = channels.find((c) => c.isDefault)!.ulid
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 

--- a/frontend/src/components/templates/manage/music/create.tsx
+++ b/frontend/src/components/templates/manage/music/create.tsx
@@ -26,7 +26,7 @@ interface Props {
 export default function MusicCreate(props: Props): React.JSX.Element {
   const { channels, categories } = props
 
-  const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+  const channelUlid = channels.find((c) => c.isDefault)!.ulid
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 

--- a/frontend/src/components/templates/manage/picture/create.tsx
+++ b/frontend/src/components/templates/manage/picture/create.tsx
@@ -25,7 +25,7 @@ interface Props {
 export default function PictureCreate(props: Props): React.JSX.Element {
   const { channels, categories } = props
 
-  const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+  const channelUlid = channels.find((c) => c.isDefault)!.ulid
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 

--- a/frontend/src/components/templates/manage/video/create.tsx
+++ b/frontend/src/components/templates/manage/video/create.tsx
@@ -25,7 +25,7 @@ interface Props {
 export default function VideoCreate(props: Props): React.JSX.Element {
   const { channels, categories } = props
 
-  const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+  const channelUlid = channels.find((c) => c.isDefault)!.ulid
   const channelOptions: Option[] = channels.map((c) => ({ label: c.name, value: c.ulid }))
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 


### PR DESCRIPTION
## Summary
- 6 つのメディア create テンプレートで `channels.find((c) => c.isDefault)?.ulid ?? ''` を `!.ulid` に統一
- default チャンネルは「必ず1つ以上存在する」仕様前提を型レベルで表明
- 既存の `setting/mypage` 系（`channels.find((c) => c.isDefault)!.ulid`）と書き方を揃える

## 変更内容

### 対象ファイル（6 ファイル）
- `components/templates/manage/blog/create.tsx`
- `components/templates/manage/chat/create.tsx`
- `components/templates/manage/comic/create.tsx`
- `components/templates/manage/music/create.tsx`
- `components/templates/manage/picture/create.tsx`
- `components/templates/manage/video/create.tsx`

### 変更内容（全 6 ファイルで同一の 1 行差分）
```diff
- const channelUlid = channels.find((c) => c.isDefault)?.ulid ?? ''
+ const channelUlid = channels.find((c) => c.isDefault)!.ulid
```

## 背景
- `channels` はバックエンドの `getChannels` API が「default フラグ付きを必ず含む配列」を返す前提
- 既存の `setting/mypage` 系（`useState<string>(channels.find((c) => c.isDefault)!.ulid)`）でも同じ前提で `!` を使用
- `?.ulid ?? ''` は仕様上発生しない `''` の分岐を残してしまうため、コードベース全体の認識統一として `!` に揃える

## 確認
- `npm run lint` / `tsc --noEmit` 共に新規エラーなし（既存警告のみ）
- `grep` で他に `?.ulid ?? ''` パターンが残っていないことを確認済み