### PR TITLE
【front】パスワード変更画面の初期表示で必須エラーが出る不具合を修正

### DIFF
--- a/frontend/src/api/internal/auth.ts
+++ b/frontend/src/api/internal/auth.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
-import { LoginIn, SignupIn, SignupVerifyOut } from 'types/internal/auth'
-import { apiLogin, apiLogout, apiSignup, apiSignupEmail, apiSignupVerify } from 'api/uri'
+import { LoginIn, PasswordChangeIn, SignupIn, SignupVerifyOut } from 'types/internal/auth'
+import { apiLogin, apiLogout, apiPasswordChange, apiSignup, apiSignupEmail, apiSignupVerify } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const postLogin = async (request: LoginIn): Promise<ApiOut<void>> => {
@@ -26,4 +26,8 @@ export const getSignupVerify = async (token: string): Promise<ApiOut<SignupVerif
 
 export const postReset = async (email: string): Promise<ApiOut<void>> => {
   return await apiOut(apiClient('json').post(apiSignup, email))
+}
+
+export const postPasswordChange = async (request: PasswordChangeIn): Promise<ApiOut<void>> => {
+  return await apiOut(apiClient('json').post(apiPasswordChange, camelSnake(request)))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -8,6 +8,7 @@ export const apiSignupEmail = base + '/auth/signup/email'
 export const apiSignupVerify = base + '/auth/signup/verify'
 export const apiLogin = base + '/auth/login'
 export const apiLogout = base + '/auth/logout'
+export const apiPasswordChange = base + '/auth/password/change'
 
 // User
 export const apiUser = base + '/user/me'

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -1,4 +1,6 @@
+import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
+import { useRequired } from 'components/hooks/useRequired'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
@@ -6,27 +8,64 @@ import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
 import style from '../Setting.module.scss'
 
+interface Values {
+  oldPassword: string
+  newPassword1: string
+  newPassword2: string
+}
+
 export default function PasswordChange(): React.JSX.Element {
   const router = useRouter()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const [values, setValues] = useState<Values>({ oldPassword: '', newPassword1: '', newPassword2: '' })
+
   const handleBack = () => router.push('/setting/profile')
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleSubmit = () => {
+    const { oldPassword, newPassword1, newPassword2 } = values
+    if (!isRequiredCheck({ oldPassword, newPassword1, newPassword2 })) return
+  }
 
   return (
     <Main title="パスワード変更">
       <article className={style.article_pass}>
         <form method="POST" action="" className={style.form_account}>
-          <ul className={style.messages_password_change}>
-            <li>{/* { form.old_password.errors } */}</li>
-            <li>{/* { form.new_password2.errors } */}</li>
-          </ul>
-
           <VStack gap="8">
-            <Input type="password" name="old_password" minLength={8} maxLength={16} placeholder="現在パスワード" required />
-            <Input type="password" name="new_password1" minLength={8} maxLength={16} placeholder="新規パスワード(英数字8~16文字)" required />
-            <Input type="password" name="new_password2" minLength={8} maxLength={16} placeholder="新規パスワード(確認用)" required />
+            <Input
+              type="password"
+              name="oldPassword"
+              minLength={8}
+              maxLength={16}
+              placeholder="現在パスワード"
+              value={values.oldPassword}
+              required={isRequired}
+              onChange={handleInput}
+            />
+            <Input
+              type="password"
+              name="newPassword1"
+              minLength={8}
+              maxLength={16}
+              placeholder="新規パスワード(英数字8~16文字)"
+              value={values.newPassword1}
+              required={isRequired}
+              onChange={handleInput}
+            />
+            <Input
+              type="password"
+              name="newPassword2"
+              minLength={8}
+              maxLength={16}
+              placeholder="新規パスワード(確認用)"
+              value={values.newPassword2}
+              required={isRequired}
+              onChange={handleInput}
+            />
           </VStack>
 
           <VStack gap="12" className="mv_40">
-            <Button color="red" size="l" name="退会する" />
+            <Button color="green" size="l" name="変更する" onClick={handleSubmit} />
             <Button color="blue" size="l" name="戻る" onClick={handleBack} />
           </VStack>
         </form>

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -1,6 +1,11 @@
 import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
+import { postPasswordChange } from 'api/internal/auth'
+import { FetchError } from 'utils/constants/enum'
+import { encrypt } from 'utils/functions/encrypt'
+import { useIsLoading } from 'components/hooks/useIsLoading'
 import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
@@ -16,19 +21,38 @@ interface Values {
 
 export default function PasswordChange(): React.JSX.Element {
   const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
   const [values, setValues] = useState<Values>({ oldPassword: '', newPassword1: '', newPassword2: '' })
 
   const handleBack = () => router.push('/setting/profile')
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const { oldPassword, newPassword1, newPassword2 } = values
     if (!isRequiredCheck({ oldPassword, newPassword1, newPassword2 })) return
+    if (newPassword1 !== newPassword2) {
+      handleToast('新規パスワードが一致しません', true)
+      return
+    }
+    handleLoading(true)
+    const request = {
+      oldPassword: encrypt(oldPassword),
+      newPassword1: encrypt(newPassword1),
+      newPassword2: encrypt(newPassword2),
+    }
+    const ret = await postPasswordChange(request)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleToast(FetchError.Post, true)
+      return
+    }
+    router.push('/setting/password/change-done')
   }
 
   return (
-    <Main title="パスワード変更">
+    <Main title="パスワード変更" toast={toast}>
       <article className={style.article_pass}>
         <form method="POST" action="" className={style.form_account}>
           <VStack gap="8">
@@ -65,7 +89,7 @@ export default function PasswordChange(): React.JSX.Element {
           </VStack>
 
           <VStack gap="12" className="mv_40">
-            <Button color="green" size="l" name="変更する" onClick={handleSubmit} />
+            <Button color="green" size="l" name="変更する" loading={isLoading} onClick={handleSubmit} />
             <Button color="blue" size="l" name="戻る" onClick={handleBack} />
           </VStack>
         </form>

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
+import { PasswordChangeIn } from 'types/internal/auth'
 import { postPasswordChange } from 'api/internal/auth'
 import { FetchError } from 'utils/constants/enum'
 import { encrypt } from 'utils/functions/encrypt'
@@ -13,18 +14,12 @@ import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
 import style from '../Setting.module.scss'
 
-interface Values {
-  oldPassword: string
-  newPassword1: string
-  newPassword2: string
-}
-
 export default function PasswordChange(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<Values>({ oldPassword: '', newPassword1: '', newPassword2: '' })
+  const [values, setValues] = useState<PasswordChangeIn>({ oldPassword: '', newPassword1: '', newPassword2: '' })
 
   const handleBack = () => router.push('/setting/profile')
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -37,7 +32,7 @@ export default function PasswordChange(): React.JSX.Element {
       return
     }
     handleLoading(true)
-    const request = {
+    const request: PasswordChangeIn = {
       oldPassword: encrypt(oldPassword),
       newPassword1: encrypt(newPassword1),
       newPassword2: encrypt(newPassword2),

--- a/frontend/src/types/internal/auth.d.ts
+++ b/frontend/src/types/internal/auth.d.ts
@@ -23,3 +23,9 @@ export interface SignupIn {
 export interface SignupVerifyOut {
   email: string
 }
+
+export interface PasswordChangeIn {
+  oldPassword: string
+  newPassword1: string
+  newPassword2: string
+}


### PR DESCRIPTION
## Summary
- パスワード変更画面で `<Input ... required />` を静的に `true` にしていたため、初期表示で「※必須入力です！」が出てしまう不具合を修正
- `useRequired` パターン（`login.tsx` 等で採用済み）に揃え、サブミット時の検証で初めて必須エラーを表示する形に変更
- 誤って置かれていた「退会する」ボタンを「変更する」(緑) に修正

## 変更内容

### `frontend/src/components/templates/setting/password/change.tsx`
- `useRequired` フックを導入し、`isRequired` / `isRequiredCheck` を取得
- `useState<Values>` で `oldPassword` / `newPassword1` / `newPassword2` を管理
- `handleInput` で各フィールドの値を更新
- `handleSubmit` で `isRequiredCheck` を呼び、空欄があればエラー表示（API 接続は未実装、別 PR で追加予定）
- 各 `<Input>` の `required` を `required={isRequired}` に変更（初期は `false`）
- `<Input>` の `name` を camelCase 化（`old_password` → `oldPassword` 等、コードベース規約準拠）
- 「退会する」(赤) ボタンを「変更する」(緑) に修正（パスワード変更画面に退会ボタンは誤配置）
- 未使用のコメントアウト済み `<ul className={style.messages_password_change}>` ブロックを削除

## 残タスク（別 PR）
- バックエンドにパスワード変更 API を追加し、`handleSubmit` から呼ぶ実装に拡張

## 確認
- `npm run lint` / `tsc --noEmit` 共に新規エラーなし
- 画面初期表示で必須エラーが出ないこと、サブミット時に空欄ならエラー表示されることを期待