### PR TITLE
【back】パスワード変更 API を追加

### DIFF
--- a/myus/api/src/adapter/auth.py
+++ b/myus/api/src/adapter/auth.py
@@ -3,9 +3,9 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from ninja import Router
 from api.modules.logger import log
-from api.src.types.schema.auth import LoginIn, LoginOut, RefreshOut, SignupEmailIn, SignupIn, SignupVerifyOut
+from api.src.types.schema.auth import LoginIn, LoginOut, PasswordChangeIn, RefreshOut, SignupEmailIn, SignupIn, SignupVerifyOut
 from api.src.types.schema.common import ErrorOut
-from api.src.usecase.auth import login_user, signup_send_email, signup_user, signup_verify_token, verify_user
+from api.src.usecase.auth import auth_check, change_password, login_user, signup_send_email, signup_user, signup_verify_token, verify_user
 from api.src.usecase.user import signup_check
 from api.utils.functions.token import access_token, refresh_token
 
@@ -157,6 +157,21 @@ class AuthAPI:
         response.set_cookie("refresh_token", refresh, max_age=60 * 60 * 24 * 30, httponly=True)
 
         return 200, LoginOut(access=access, refresh=refresh)
+
+    @staticmethod
+    @router.post("/password/change", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def password_change(request: HttpRequest, input: PasswordChangeIn):
+        log.info("AuthAPI password_change")
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        validation = change_password(user_id, input)
+        if validation:
+            return 400, ErrorOut(message=validation)
+
+        return 204, ErrorOut(message="パスワードを変更しました!")
 
     @staticmethod
     @router.post("/logout", response={204: None, 500: ErrorOut})

--- a/myus/api/src/types/schema/auth.py
+++ b/myus/api/src/types/schema/auth.py
@@ -26,6 +26,12 @@ class LoginIn(BaseModel):
     password: str
 
 
+class PasswordChangeIn(BaseModel):
+    old_password: str
+    new_password1: str
+    new_password2: str
+
+
 class SignupVerifyOut(BaseModel):
     email: str
 

--- a/myus/api/src/usecase/auth.py
+++ b/myus/api/src/usecase/auth.py
@@ -1,7 +1,9 @@
 import jwt
+from dataclasses import replace
 from datetime import date, datetime
 from django.conf import settings
 from django.contrib.auth import authenticate
+from django.contrib.auth.hashers import check_password, make_password
 from django.core.mail import send_mail
 from django.http import HttpRequest
 from django.template.loader import render_to_string
@@ -10,7 +12,7 @@ from api.modules.logger import log
 from api.src.domain.interface.user.data import MyPageData, PlanData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
 from api.src.domain.interface.user.interface import UserInterface
 from api.src.injectors.container import injector
-from api.src.types.schema.auth import SignupIn
+from api.src.types.schema.auth import PasswordChangeIn, SignupIn
 from api.utils.functions.encrypt import decrypt
 from api.utils.functions.token import signup_token
 from api.utils.functions.validation import has_email
@@ -189,3 +191,43 @@ def signup_user(input: SignupIn) -> bool:
     except Exception as e:
         log.error("Signup error", exc=e)
         return False
+
+
+PASSWORD_MIN_LENGTH = 8
+PASSWORD_MAX_LENGTH = 16
+
+
+def change_password(user_id: int, input: PasswordChangeIn) -> str:
+    try:
+        old_password = decrypt(input.old_password)
+        new_password1 = decrypt(input.new_password1)
+        new_password2 = decrypt(input.new_password2)
+    except Exception:
+        log.error("Decrypt error")
+        return "復号に失敗しました!"
+
+    if new_password1 != new_password2:
+        return "新規パスワードが一致しません!"
+
+    if len(new_password1) < PASSWORD_MIN_LENGTH or len(new_password1) > PASSWORD_MAX_LENGTH:
+        return "新規パスワードは英数字8~16文字で入力してください!"
+
+    repository = injector.get(UserInterface)
+    users = repository.bulk_get([user_id])
+    if len(users) == 0:
+        log.error("User not found", user_id=user_id)
+        return "ユーザーが見つかりません!"
+
+    user_data = users[0]
+    if not check_password(old_password, user_data.user.password):
+        return "現在のパスワードが違います!"
+
+    new_user = replace(user_data.user, password=make_password(new_password1))
+    new_data = replace(user_data, user=new_user)
+
+    try:
+        repository.bulk_save([new_data])
+        return ""
+    except Exception as e:
+        log.error("change_password error", exc=e)
+        return "パスワードの変更に失敗しました!"


### PR DESCRIPTION
## Summary
- ログインユーザーが現在パスワード + 新規パスワードで自身のパスワードを変更できる API を追加
- `POST /api/auth/password/change`（認証必須、暗号化されたパスワードを decrypt → 検証 → ハッシュ化 → repository 経由で保存）
- フロント (PR #779) の `postPasswordChange` から呼ばれる前提

## 変更内容

### `api/src/types/schema/auth.py`
- `PasswordChangeIn(old_password, new_password1, new_password2)` を追加（フロントの camelSnake 変換と整合）

### `api/src/usecase/auth.py`
- `PASSWORD_MIN_LENGTH = 8` / `PASSWORD_MAX_LENGTH = 16` 定数を追加（フロントの `minLength`/`maxLength` と一致）
- `change_password(user_id, input) -> str` を追加
  - `decrypt` で 3 つの暗号化済みパスワードを復号（`login_user` と同形のエラーハンドリング）
  - `new_password1 == new_password2` 検証
  - 長さ 8〜16 文字検証
  - `injector.get(UserInterface)` + `repository.bulk_get([user_id])` で UserAllData を取得（`verify_user` と同形）
  - Django hashers の `check_password(old_password, user_data.user.password)` で旧パスワード照合
  - `make_password(new_password1)` でハッシュ化 → `replace()` で UserAllData を更新 → `repository.bulk_save([new_data])`
  - 戻り値は str（空 = 成功、それ以外 = エラーメッセージ。`signup_send_email` と同形）

### `api/src/adapter/auth.py`
- `POST /password/change` エンドポイントを追加
  - `auth_check(request)` で認証 → 401
  - `change_password(user_id, input)` の結果文字列が空でなければ 400、空なら 204
- 既存 `auth_check` / `change_password` を import

## アーキテクチャ準拠
- `docs/backend.md` の「層の責務: usecase は interface（injector経由）」に従い、`User.objects.get` 等の ORM 直接アクセスは使わず repository 経由
- `_convert.py:131` の `password=make_password(data.password) if data.id == 0 else data.password`（id != 0 なら data.password そのまま渡る）と整合し、usecase 側でハッシュ化済み値を渡す
- 既存パターン（`verify_user` の `bulk_get`、`signup_user` の `bulk_save`、`signup_send_email` の str 返却）を踏襲

## 確認
- `uv run mypy api/src/usecase/auth.py` で新規エラーなし