### PR TITLE
【front】退会機能を実装

### DIFF
--- a/frontend/src/api/internal/auth.ts
+++ b/frontend/src/api/internal/auth.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
-import { LoginIn, PasswordChangeIn, SignupIn, SignupVerifyOut } from 'types/internal/auth'
-import { apiLogin, apiLogout, apiPasswordChange, apiSignup, apiSignupEmail, apiSignupVerify } from 'api/uri'
+import { LoginIn, PasswordChangeIn, SignupIn, SignupVerifyOut, WithdrawalIn } from 'types/internal/auth'
+import { apiLogin, apiLogout, apiPasswordChange, apiSignup, apiSignupEmail, apiSignupVerify, apiWithdrawal } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const postLogin = async (request: LoginIn): Promise<ApiOut<void>> => {
@@ -30,4 +30,8 @@ export const postReset = async (email: string): Promise<ApiOut<void>> => {
 
 export const postPasswordChange = async (request: PasswordChangeIn): Promise<ApiOut<void>> => {
   return await apiOut(apiClient('json').post(apiPasswordChange, camelSnake(request)))
+}
+
+export const postWithdrawal = async (request: WithdrawalIn): Promise<ApiOut<void>> => {
+  return await apiOut(apiClient('json').post(apiWithdrawal, request))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -9,6 +9,7 @@ export const apiSignupVerify = base + '/auth/signup/verify'
 export const apiLogin = base + '/auth/login'
 export const apiLogout = base + '/auth/logout'
 export const apiPasswordChange = base + '/auth/password/change'
+export const apiWithdrawal = base + '/auth/withdrawal'
 
 // User
 export const apiUser = base + '/user/me'

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -1,4 +1,13 @@
+import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
+import { WithdrawalIn } from 'types/internal/auth'
+import { postWithdrawal } from 'api/internal/auth'
+import { FetchError } from 'utils/constants/enum'
+import { encrypt } from 'utils/functions/encrypt'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import { useUser } from 'components/hooks/useUser'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
@@ -8,19 +17,51 @@ import style from '../Setting.module.scss'
 
 export default function WithdrawalConfirm(): React.JSX.Element {
   const router = useRouter()
+  const { resetUser } = useUser()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const [values, setValues] = useState<WithdrawalIn>({ password: '' })
+
   const handleBack = () => router.push('/setting/withdrawal')
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+
+  const handleSubmit = async () => {
+    const { password } = values
+    if (!isRequiredCheck({ password })) return
+
+    handleLoading(true)
+    const request: WithdrawalIn = { password: encrypt(password) }
+    const ret = await postWithdrawal(request)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleToast(FetchError.Post, true)
+      return
+    }
+    resetUser()
+    router.push('/account/login')
+  }
 
   return (
-    <Main title="退会処理">
+    <Main title="退会処理" toast={toast}>
       <article className={style.article_pass}>
         <form method="POST" action="" className={style.form_account}>
           <VStack gap="8">
             <p className="red">本当に退会しますか？</p>
-            <Input type="password" name="password2" placeholder="パスワード" minLength={8} maxLength={16} required />
+            <Input
+              type="password"
+              name="password"
+              minLength={8}
+              maxLength={16}
+              placeholder="パスワード"
+              value={values.password}
+              required={isRequired}
+              onChange={handleInput}
+            />
           </VStack>
 
           <VStack gap="12" className="mv_40">
-            <Button color="red" size="l" name="退会する" />
+            <Button color="red" size="l" name="退会する" loading={isLoading} onClick={handleSubmit} />
             <Button color="blue" size="l" name="戻る" onClick={handleBack} />
           </VStack>
         </form>

--- a/frontend/src/components/templates/setting/withdrawal/index.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/index.tsx
@@ -2,42 +2,28 @@ import { useRouter } from 'next/router'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
-import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
 import style from '../Setting.module.scss'
 
 export default function Withdrawal(): React.JSX.Element {
   const router = useRouter()
   const handleBack = () => router.push('/')
-  const handleWithdrawal = () => router.push('/setting/withdrawal/confirm')
-
-  const messages = false
-  const message = '退会URL'
-  const tokenSigned = false
-  const expiredSeconds = 60
+  const handleNext = () => router.push('/setting/withdrawal/confirm')
 
   return (
     <Main title="退会処理">
       <article className={style.article_pass}>
-        <form method="POST" action="" className={style.form_account}>
-          {messages && (
-            <ul className={style.messages_password_change}>
-              <li>{messages}</li>
-            </ul>
-          )}
-
-          <VStack gap="12">
-            <p>{expiredSeconds}秒有効なURLを生成します</p>
-            <Input type="password" name="password" placeholder="パスワード" minLength={8} maxLength={16} required />
+        <div className={style.form_account}>
+          <VStack gap="8" className="ws_nowrap">
+            <p>退会するとアカウントが利用できなくなります！</p>
+            <p className="red">この操作は取り消しできません。</p>
           </VStack>
 
           <VStack gap="12" className="mv_40">
-            <Button color="green" size="l" name="退会URL生成" />
-            {tokenSigned && <Button color="red" size="l" name="退会する" onClick={handleWithdrawal} />}
-            {message && <Button color="red" size="l" name={message} />}
+            <Button color="red" size="l" name="退会画面に進む" onClick={handleNext} />
             <Button color="blue" size="l" name="ホーム" onClick={handleBack} />
           </VStack>
-        </form>
+        </div>
       </article>
       <Footer />
     </Main>

--- a/frontend/src/types/internal/auth.d.ts
+++ b/frontend/src/types/internal/auth.d.ts
@@ -29,3 +29,7 @@ export interface PasswordChangeIn {
   newPassword1: string
   newPassword2: string
 }
+
+export interface WithdrawalIn {
+  password: string
+}


### PR DESCRIPTION
## Summary
- `/setting/withdrawal` を「退会の最終確認画面」、`/setting/withdrawal/confirm` を「パスワード入力＋退会実行」の2段構成で実装
- 退会成功時はユーザー情報をリセットしてログイン画面に遷移

## 変更内容
### `frontend/src/api/uri.ts`
- `apiWithdrawal` (`/api/auth/withdrawal`) を追加

### `frontend/src/types/internal/auth.d.ts`
- `WithdrawalIn { password: string }` を追加

### `frontend/src/api/internal/auth.ts`
- `postWithdrawal(request)` を追加
- リクエストフィールドが `password` 1個のみのため `camelSnake` 不要

### `frontend/src/components/templates/setting/withdrawal/index.tsx`
- 既存のパスワード入力欄／URL生成ボタン等の未配線 UI を削除
- 退会の注意文＋「退会画面に進む / ホーム」のシンプルな確認画面に変更

### `frontend/src/components/templates/setting/withdrawal/confirm.tsx`
- `useState<WithdrawalIn>` でパスワードを管理
- `useRequired` で必須チェック、`encrypt` で暗号化してから `postWithdrawal` を呼ぶ
- 成功時に `resetUser()` → `/account/login` にリダイレクト
- 失敗時は `useToast` でエラー通知

### 動作フロー
1. `/setting/withdrawal` で説明を確認 → 「退会画面に進む」
2. `/setting/withdrawal/confirm` でパスワード入力 → 「退会する」
3. backend が `is_active=False` でユーザーを論理削除 → Cookie を削除
4. フロントは `resetUser()` → ログイン画面へ