### PR TITLE
【back】退会 API を追加

### DIFF
--- a/myus/api/src/adapter/auth.py
+++ b/myus/api/src/adapter/auth.py
@@ -3,9 +3,9 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from ninja import Router
 from api.modules.logger import log
-from api.src.types.schema.auth import LoginIn, LoginOut, PasswordChangeIn, RefreshOut, SignupEmailIn, SignupIn, SignupVerifyOut
+from api.src.types.schema.auth import LoginIn, LoginOut, PasswordChangeIn, RefreshOut, SignupEmailIn, SignupIn, SignupVerifyOut, WithdrawalIn
 from api.src.types.schema.common import ErrorOut
-from api.src.usecase.auth import auth_check, change_password, login_user, signup_send_email, signup_user, signup_verify_token, verify_user
+from api.src.usecase.auth import auth_check, change_password, login_user, signup_send_email, signup_user, signup_verify_token, verify_user, withdraw_user
 from api.src.usecase.user import signup_check
 from api.utils.functions.token import access_token, refresh_token
 
@@ -172,6 +172,23 @@ class AuthAPI:
             return 400, ErrorOut(message=validation)
 
         return 204, ErrorOut(message="パスワードを変更しました!")
+
+    @staticmethod
+    @router.post("/withdrawal", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def withdrawal(request: HttpRequest, response: HttpResponse, input: WithdrawalIn):
+        log.info("AuthAPI withdrawal")
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        validation = withdraw_user(user_id, input)
+        if validation:
+            return 400, ErrorOut(message=validation)
+
+        response.delete_cookie("access_token")
+        response.delete_cookie("refresh_token")
+        return 204, ErrorOut(message="退会しました!")
 
     @staticmethod
     @router.post("/logout", response={204: None, 500: ErrorOut})

--- a/myus/api/src/types/schema/auth.py
+++ b/myus/api/src/types/schema/auth.py
@@ -32,6 +32,10 @@ class PasswordChangeIn(BaseModel):
     new_password2: str
 
 
+class WithdrawalIn(BaseModel):
+    password: str
+
+
 class SignupVerifyOut(BaseModel):
     email: str
 

--- a/myus/api/src/usecase/auth.py
+++ b/myus/api/src/usecase/auth.py
@@ -12,7 +12,7 @@ from api.modules.logger import log
 from api.src.domain.interface.user.data import MyPageData, PlanData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
 from api.src.domain.interface.user.interface import UserInterface
 from api.src.injectors.container import injector
-from api.src.types.schema.auth import PasswordChangeIn, SignupIn
+from api.src.types.schema.auth import PasswordChangeIn, SignupIn, WithdrawalIn
 from api.utils.functions.encrypt import decrypt
 from api.utils.functions.token import signup_token
 from api.utils.functions.validation import has_email
@@ -231,3 +231,31 @@ def change_password(user_id: int, input: PasswordChangeIn) -> str:
     except Exception as e:
         log.error("change_password error", exc=e)
         return "パスワードの変更に失敗しました!"
+
+
+def withdraw_user(user_id: int, input: WithdrawalIn) -> str:
+    try:
+        password = decrypt(input.password)
+    except Exception:
+        log.error("Decrypt error")
+        return "復号に失敗しました!"
+
+    repository = injector.get(UserInterface)
+    users = repository.bulk_get([user_id])
+    if len(users) == 0:
+        log.error("User not found", user_id=user_id)
+        return "ユーザーが見つかりません!"
+
+    user_data = users[0]
+    if not check_password(password, user_data.user.password):
+        return "パスワードが違います!"
+
+    new_user = replace(user_data.user, is_active=False)
+    new_data = replace(user_data, user=new_user)
+
+    try:
+        repository.bulk_save([new_data])
+        return ""
+    except Exception as e:
+        log.error("withdraw_user error", exc=e)
+        return "退会処理に失敗しました!"


### PR DESCRIPTION
## Summary
- `POST /auth/withdrawal` を新設し、ログイン中ユーザーの論理削除（`is_active=False`）を行う
- 退会成功時は access/refresh Cookie を削除して 204 を返却

## 変更内容
### `myus/api/src/types/schema/auth.py`
- `WithdrawalIn { password: str }` を追加（暗号化済みパスワードを受け取る）

### `myus/api/src/usecase/auth.py`
- `withdraw_user(user_id, input) -> str` を追加
- 流れ: `decrypt` → `bulk_get` でユーザー取得 → `check_password` で照合 → `is_active=False` に書き換えて `bulk_save`
- 失敗時はユーザー向けメッセージを文字列で返す（既存の `change_password` と同じパターン）

### `myus/api/src/adapter/auth.py`
- `POST /auth/withdrawal` エンドポイントを追加
- `auth_check` で認証 → `withdraw_user` 呼び出し → 成功時に `delete_cookie("access_token")` / `delete_cookie("refresh_token")` を行い 204 を返す

## 設計判断
- 物理削除ではなく **論理削除（`is_active=False`）** を採用
  - 物理削除だと `OneToOneField(on_delete=CASCADE)` で profile / mypage / notification / user_plan が一斉削除され、メディア側の FK 設定によっては大量データが巻き込まれるため
  - `login_user` は `is_active=False` を弾くので再ログイン不可になる
- usecase の関数名は `change_password` と並ぶ動詞形 `withdraw_user` に統一（adapter のメソッド名 `withdrawal` と衝突回避も兼ねる）