### PR TITLE
【back】パスワードリセット API を追加

### DIFF
--- a/myus/api/src/adapter/auth.py
+++ b/myus/api/src/adapter/auth.py
@@ -3,9 +3,9 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from ninja import Router
 from api.modules.logger import log
-from api.src.types.schema.auth import LoginIn, LoginOut, PasswordChangeIn, RefreshOut, SignupEmailIn, SignupIn, SignupVerifyOut, WithdrawalIn
+from api.src.types.schema.auth import LoginIn, LoginOut, PasswordChangeIn, PasswordResetEmailIn, PasswordResetIn, PasswordResetVerifyOut, RefreshOut, SignupEmailIn, SignupIn, SignupVerifyOut, WithdrawalIn
 from api.src.types.schema.common import ErrorOut
-from api.src.usecase.auth import auth_check, change_password, login_user, signup_send_email, signup_user, signup_verify_token, verify_user, withdraw_user
+from api.src.usecase.auth import auth_check, change_password, login_user, password_reset_send_email, password_reset_verify_token, reset_password, signup_send_email, signup_user, signup_verify_token, verify_user, withdraw_user
 from api.src.usecase.user import signup_check
 from api.utils.functions.token import access_token, refresh_token
 
@@ -172,6 +172,39 @@ class AuthAPI:
             return 400, ErrorOut(message=validation)
 
         return 204, ErrorOut(message="パスワードを変更しました!")
+
+    @staticmethod
+    @router.post("/password/reset/email", response={200: ErrorOut, 400: ErrorOut, 500: ErrorOut})
+    def password_reset_email(request: HttpRequest, input: PasswordResetEmailIn):
+        log.info("AuthAPI password_reset_email", email=input.email)
+
+        validation = password_reset_send_email(input.email)
+        if validation:
+            return 400, ErrorOut(message=validation)
+
+        return 200, ErrorOut(message="メールを送信しました!")
+
+    @staticmethod
+    @router.get("/password/reset/verify", response={200: PasswordResetVerifyOut, 401: ErrorOut})
+    def password_reset_verify(request: HttpRequest, token: str):
+        log.info("AuthAPI password_reset_verify")
+
+        email = password_reset_verify_token(token)
+        if email is None:
+            return 401, ErrorOut(message="リンクの有効期限が切れています!")
+
+        return 200, PasswordResetVerifyOut(email=email)
+
+    @staticmethod
+    @router.post("/password/reset", response={204: ErrorOut, 400: ErrorOut})
+    def password_reset(request: HttpRequest, input: PasswordResetIn):
+        log.info("AuthAPI password_reset")
+
+        validation = reset_password(input)
+        if validation:
+            return 400, ErrorOut(message=validation)
+
+        return 204, ErrorOut(message="パスワードをリセットしました!")
 
     @staticmethod
     @router.post("/withdrawal", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})

--- a/myus/api/src/adapter/auth.py
+++ b/myus/api/src/adapter/auth.py
@@ -189,10 +189,11 @@ class AuthAPI:
     def password_reset_verify(request: HttpRequest, token: str):
         log.info("AuthAPI password_reset_verify")
 
-        email = password_reset_verify_token(token)
-        if email is None:
+        result = password_reset_verify_token(token)
+        if result is None:
             return 401, ErrorOut(message="リンクの有効期限が切れています!")
 
+        _, email = result
         return 200, PasswordResetVerifyOut(email=email)
 
     @staticmethod

--- a/myus/api/src/domain/entity/user/repository.py
+++ b/myus/api/src/domain/entity/user/repository.py
@@ -33,6 +33,8 @@ class UserRepository(UserInterface):
             q_list.append(Q(id=filter.id))
         if filter.ulid:
             q_list.append(Q(ulid=filter.ulid))
+        if filter.email:
+            q_list.append(Q(email=filter.email))
 
         qs = User.objects.filter(*q_list)
 

--- a/myus/api/src/domain/interface/user/interface.py
+++ b/myus/api/src/domain/interface/user/interface.py
@@ -14,6 +14,7 @@ class SortType(Enum):
 class FilterOption:
     id: int = 0
     ulid: str = ""
+    email: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/myus/api/src/types/schema/auth.py
+++ b/myus/api/src/types/schema/auth.py
@@ -36,7 +36,21 @@ class WithdrawalIn(BaseModel):
     password: str
 
 
+class PasswordResetEmailIn(BaseModel):
+    email: str
+
+
+class PasswordResetIn(BaseModel):
+    token: str
+    new_password1: str
+    new_password2: str
+
+
 class SignupVerifyOut(BaseModel):
+    email: str
+
+
+class PasswordResetVerifyOut(BaseModel):
     email: str
 
 

--- a/myus/api/src/usecase/auth.py
+++ b/myus/api/src/usecase/auth.py
@@ -10,11 +10,11 @@ from django.template.loader import render_to_string
 from api.db.models.user import User
 from api.modules.logger import log
 from api.src.domain.interface.user.data import MyPageData, PlanData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
-from api.src.domain.interface.user.interface import UserInterface
+from api.src.domain.interface.user.interface import FilterOption, UserInterface
 from api.src.injectors.container import injector
-from api.src.types.schema.auth import PasswordChangeIn, SignupIn, WithdrawalIn
+from api.src.types.schema.auth import PasswordChangeIn, PasswordResetIn, SignupIn, WithdrawalIn
 from api.utils.functions.encrypt import decrypt
-from api.utils.functions.token import signup_token
+from api.utils.functions.token import password_reset_token, signup_token
 from api.utils.functions.validation import has_email
 
 
@@ -231,6 +231,112 @@ def change_password(user_id: int, input: PasswordChangeIn) -> str:
     except Exception as e:
         log.error("change_password error", exc=e)
         return "パスワードの変更に失敗しました!"
+
+
+def password_reset_send_email(email: str) -> str:
+    if has_email(email):
+        return "メールアドレスの形式が違います!"
+
+    repository = injector.get(UserInterface)
+    user_ids = repository.get_ids(FilterOption(email=email))
+    if len(user_ids) == 0:
+        return "メールアドレスが登録されていません!"
+
+    users = repository.bulk_get(user_ids)
+    user_data = users[0]
+    if not user_data.user.is_active:
+        return "メールアドレスが登録されていません!"
+
+    token = password_reset_token(user_data.user.id, email)
+    subject = render_to_string("registration/email/reset/subject.txt").strip()
+    message = render_to_string(
+        "registration/email/reset/message.txt",
+        {"frontend_url": settings.FRONTEND_URL, "token": token, "nickname": user_data.user.nickname},
+    )
+
+    try:
+        send_mail(subject, message, None, [email])
+    except Exception as e:
+        log.error("Password reset email send error", exc=e)
+        return "メールの送信に失敗しました!"
+
+    if settings.DEBUG:
+        url = f"{settings.FRONTEND_URL}/account/reset/confirm?token={token}"
+        log.info("Password reset URL (dev)", url=url)
+
+    return ""
+
+
+def password_reset_verify_token(token: str) -> str | None:
+    try:
+        payload = jwt.decode(jwt=token, key=settings.SECRET_KEY, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        log.warning("Password reset token expired")
+        return None
+    except jwt.exceptions.DecodeError:
+        log.warning("Password reset token decode error")
+        return None
+
+    if payload.get("type") != "password_reset":
+        log.warning("Invalid password reset token type")
+        return None
+
+    email = payload.get("email")
+    if not isinstance(email, str) or len(email) == 0:
+        log.warning("Invalid password reset token email")
+        return None
+
+    return email
+
+
+def reset_password(input: PasswordResetIn) -> str:
+    try:
+        payload = jwt.decode(jwt=input.token, key=settings.SECRET_KEY, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        log.warning("Password reset token expired")
+        return "リンクの有効期限が切れています!"
+    except jwt.exceptions.DecodeError:
+        log.warning("Password reset token decode error")
+        return "リンクが不正です!"
+
+    if payload.get("type") != "password_reset":
+        log.warning("Invalid password reset token type")
+        return "リンクが不正です!"
+
+    user_id = payload.get("user_id")
+    if not isinstance(user_id, int):
+        log.warning("Invalid password reset token user_id")
+        return "リンクが不正です!"
+
+    try:
+        new_password1 = decrypt(input.new_password1)
+        new_password2 = decrypt(input.new_password2)
+    except Exception:
+        log.error("Decrypt error")
+        return "復号に失敗しました!"
+
+    if new_password1 != new_password2:
+        return "新規パスワードが一致しません!"
+
+    if len(new_password1) < PASSWORD_MIN_LENGTH or len(new_password1) > PASSWORD_MAX_LENGTH:
+        return "新規パスワードは英数字8~16文字で入力してください!"
+
+    repository = injector.get(UserInterface)
+    users = repository.bulk_get([user_id])
+    if len(users) == 0:
+        log.error("User not found", user_id=user_id)
+        return "ユーザーが見つかりません!"
+
+    user_data = users[0]
+    new_user = replace(user_data.user, password=make_password(new_password1))
+    new_data = replace(user_data, user=new_user)
+
+    try:
+        repository.bulk_save([new_data])
+        return ""
+    except Exception as e:
+        log.error("reset_password error", exc=e)
+        return "パスワードのリセットに失敗しました!"
 
 
 def withdraw_user(user_id: int, input: WithdrawalIn) -> str:

--- a/myus/api/src/usecase/auth.py
+++ b/myus/api/src/usecase/auth.py
@@ -7,7 +7,6 @@ from django.contrib.auth.hashers import check_password, make_password
 from django.core.mail import send_mail
 from django.http import HttpRequest
 from django.template.loader import render_to_string
-from api.db.models.user import User
 from api.modules.logger import log
 from api.src.domain.interface.user.data import MyPageData, PlanData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
 from api.src.domain.interface.user.interface import FilterOption, UserInterface
@@ -74,7 +73,9 @@ def signup_send_email(email: str) -> str:
     if has_email(email):
         return "メールアドレスの形式が違います!"
 
-    if User.objects.filter(email=email).exists():
+    repository = injector.get(UserInterface)
+    user_ids = repository.get_ids(FilterOption(email=email))
+    if len(user_ids) > 0:
         return "メールアドレスは既に登録されています!"
 
     token = signup_token(email)
@@ -240,12 +241,12 @@ def password_reset_send_email(email: str) -> str:
     repository = injector.get(UserInterface)
     user_ids = repository.get_ids(FilterOption(email=email))
     if len(user_ids) == 0:
-        return "メールアドレスが登録されていません!"
+        return ""
 
     users = repository.bulk_get(user_ids)
     user_data = users[0]
     if not user_data.user.is_active:
-        return "メールアドレスが登録されていません!"
+        return ""
 
     token = password_reset_token(user_data.user.id, email)
     subject = render_to_string("registration/email/reset/subject.txt").strip()
@@ -267,7 +268,7 @@ def password_reset_send_email(email: str) -> str:
     return ""
 
 
-def password_reset_verify_token(token: str) -> str | None:
+def password_reset_verify_token(token: str) -> tuple[int, str] | None:
     try:
         payload = jwt.decode(jwt=token, key=settings.SECRET_KEY, algorithms=["HS256"])
     except jwt.ExpiredSignatureError:
@@ -281,32 +282,24 @@ def password_reset_verify_token(token: str) -> str | None:
         log.warning("Invalid password reset token type")
         return None
 
+    user_id = payload.get("user_id")
+    if not isinstance(user_id, int):
+        log.warning("Invalid password reset token user_id")
+        return None
+
     email = payload.get("email")
     if not isinstance(email, str) or len(email) == 0:
         log.warning("Invalid password reset token email")
         return None
 
-    return email
+    return (user_id, email)
 
 
 def reset_password(input: PasswordResetIn) -> str:
-    try:
-        payload = jwt.decode(jwt=input.token, key=settings.SECRET_KEY, algorithms=["HS256"])
-    except jwt.ExpiredSignatureError:
-        log.warning("Password reset token expired")
+    result = password_reset_verify_token(input.token)
+    if result is None:
         return "リンクの有効期限が切れています!"
-    except jwt.exceptions.DecodeError:
-        log.warning("Password reset token decode error")
-        return "リンクが不正です!"
-
-    if payload.get("type") != "password_reset":
-        log.warning("Invalid password reset token type")
-        return "リンクが不正です!"
-
-    user_id = payload.get("user_id")
-    if not isinstance(user_id, int):
-        log.warning("Invalid password reset token user_id")
-        return "リンクが不正です!"
+    user_id, _ = result
 
     try:
         new_password1 = decrypt(input.new_password1)

--- a/myus/api/utils/functions/token.py
+++ b/myus/api/utils/functions/token.py
@@ -31,3 +31,14 @@ def signup_token(email: str) -> str:
         "iat": datetime.datetime.now(datetime.timezone.utc),
     }
     return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+
+def password_reset_token(user_id: int, email: str) -> str:
+    payload = {
+        "user_id": user_id,
+        "email": email,
+        "type": "password_reset",
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
+        "iat": datetime.datetime.now(datetime.timezone.utc),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")

--- a/myus/templates/registration/email/reset/message.txt
+++ b/myus/templates/registration/email/reset/message.txt
@@ -1,9 +1,10 @@
-{{ user.nickname }} 様
+{{ nickname }} 様
 
-下記URLリンクよりサイトにアクセスの上、新しいパスワードを再設定してください。
+下記URLから新しいパスワードを再設定してください。
+このリンクは1時間有効です。
 
-再設定用URL
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uid token %}
+パスワード再設定用URL
+{{ frontend_url }}/account/reset/confirm?token={{ token }}
 
 パスワードリセットに関するリクエストを行っていない場合、このメールを無視してください。
 


### PR DESCRIPTION
## Summary
- パスワードリセットの3エンドポイント（`/auth/password/reset/email` / `/auth/password/reset/verify` / `/auth/password/reset`）を追加
- リセット用 JWT トークン（有効期限1時間、user_id + email を payload に保持）を発行・検証
- フロント側のリセットフロー（PR #784）と接続

## 変更内容

### スキーマ・トークン
- `api/src/types/schema/auth.py`: `PasswordResetEmailIn` / `PasswordResetIn` / `PasswordResetVerifyOut` を追加
- `api/utils/functions/token.py`: `password_reset_token(user_id, email)` を追加（type=password_reset、exp=1時間）

### usecase
- `api/src/usecase/auth.py`:
  - `password_reset_send_email`: メール形式バリデーション → repository 経由で email でユーザー検索 → トークン生成 → メール送信
  - `password_reset_verify_token`: JWT 検証して email を返却
  - `reset_password`: トークン検証 → 復号 → パスワード一致・長さチェック → repository.bulk_save で更新

### adapter
- `api/src/adapter/auth.py`: `POST /password/reset/email` / `GET /password/reset/verify` / `POST /password/reset` を追加（既存の signup フローと対称）

### domain
- `api/src/domain/interface/user/interface.py`: `FilterOption.email` を追加（email でユーザー検索可能に）
- `api/src/domain/entity/user/repository.py`: `get_ids` の email フィルタ実装を追加

### テンプレート
- `templates/registration/email/reset/message.txt`: 旧 Django form ベースの URL から `{{ frontend_url }}/account/reset/confirm?token={{ token }}` 形式に変更