### PR TITLE
【back】通知の object_type マッチで網羅性を保証する

### DIFF
--- a/myus/api/src/domain/entity/notification/repository.py
+++ b/myus/api/src/domain/entity/notification/repository.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, assert_never
 
 from django.db.models import Q
 from django.db.models.query import QuerySet
@@ -52,31 +52,33 @@ class NotificationRepository(NotificationInterface):
         objs = list(self.queryset().filter(id__in=ids))
         sorted_objs = sort_ids(objs, ids)
 
-        groups: dict[str, list[int]] = {}
+        groups: dict[NotificationObjectType, list[int]] = {}
         for n in sorted_objs:
-            groups.setdefault(n.object_type, []).append(n.object_id)
+            groups.setdefault(NotificationObjectType(n.object_type), []).append(n.object_id)
 
         content_map: dict[str, Any] = {}
         for object_type, obj_ids in groups.items():
             match object_type:
                 case NotificationObjectType.VIDEO:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Video.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Video.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.MUSIC:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Music.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Music.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.BLOG:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Blog.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Blog.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.COMIC:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Comic.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Comic.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.PICTURE:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Picture.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Picture.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.CHAT:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Chat.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Chat.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.FOLLOW:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Follow.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Follow.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.COMMENT:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Comment.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Comment.objects.filter(id__in=obj_ids)})
                 case NotificationObjectType.MESSAGE:
-                    content_map.update({f"{object_type}:{o.id}": o for o in Message.objects.filter(id__in=obj_ids)})
+                    content_map.update({f"{object_type.value}:{o.id}": o for o in Message.objects.filter(id__in=obj_ids)})
+                case _:
+                    assert_never(object_type)
 
         return [
             convert_data(obj, content_map.get(f"{obj.object_type}:{obj.object_id}"))


### PR DESCRIPTION
## Summary
- `NotificationRepository.bulk_get` の `object_type` マッチに `assert_never` を追加し、enum 追加時の silent fail を防止
- DB の文字列 `object_type` を `NotificationObjectType` enum に変換することで型安全な dispatch に変更

## 変更内容

### `api/src/domain/entity/notification/repository.py`
- `from typing import Any, assert_never` を追加
- `groups` のキー型を `dict[str, list[int]]` → `dict[NotificationObjectType, list[int]]` に変更
- ループ内で `NotificationObjectType(n.object_type)` で enum へ変換して登録（DB に enum 定義外の値があれば `ValueError` で fail-fast）
- `match` の末尾に `case _: assert_never(object_type)` を追加 → 将来 `NotificationObjectType` に新メンバが追加されたら mypy が型エラーで検知
- f-string 内を `f"{object_type.value}:{o.id}"` に変更（lookup 側の `f"{obj.object_type}:{obj.object_id}"` と同じキー形式を維持）

## なぜこの修正か
旧コードでは新しい `NotificationObjectType` 変数を追加しても match ブランチが追従しないと `content` が silent に空になる問題があった。`assert_never` で網羅性を静的に保証することで、enum 追加時の修正漏れを防げる（backend.md の「網羅性チェック: assert_never推奨」に準拠）。