### PR TITLE
【back】media bulk_get の N+1 を解消し category_ulid 順を統一

### DIFF
--- a/myus/api/src/domain/entity/media/blog/_convert.py
+++ b/myus/api/src/domain/entity/media/blog/_convert.py
@@ -6,7 +6,8 @@ from api.src.domain.interface.media.blog.data import BlogData
 
 
 def convert_data(obj: Blog) -> BlogData:
-    category = obj.category.first()
+    assert hasattr(obj, "like_count"), "like_count is required"
+    category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return BlogData(
         id=obj.id,
@@ -17,10 +18,11 @@ def convert_data(obj: Blog) -> BlogData:
         delta=obj.delta.html if obj.delta else "",
         image=obj.image.name if obj.image else "",
         read=obj.read,
-        like=obj.like.count(),
+        like=obj.like_count,
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
+        category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,
             ulid=obj.channel.ulid,
@@ -32,8 +34,7 @@ def convert_data(obj: Blog) -> BlogData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        category_ulid=category.ulid,
-        hashtags=[HashtagData(id=bh.hashtag.id, ulid=bh.hashtag.ulid, name=bh.hashtag.name) for bh in obj.blog_hashtags.all()],
+        hashtags=[HashtagData(id=t.id, ulid=t.ulid, name=t.name) for t in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/blog/repository.py
+++ b/myus/api/src/domain/entity/media/blog/repository.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.db.models.query import QuerySet
 from api.db.models.media import Blog
 from api.src.domain.entity.media.blog._convert import convert_data, marshal_data
@@ -13,7 +14,7 @@ BLOG_FIELDS = ["channel_id", "title", "content", "richtext", "image", "read", "p
 
 class BlogRepository(BlogInterface):
     def queryset(self) -> QuerySet[Blog]:
-        return Blog.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
+        return Blog.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(like_count=Count("like"))
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Blog.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/chat/_convert.py
+++ b/myus/api/src/domain/entity/media/chat/_convert.py
@@ -6,7 +6,8 @@ from api.src.domain.interface.media.chat.data import ChatData
 
 
 def convert_data(obj: Chat) -> ChatData:
-    category = obj.category.first()
+    assert hasattr(obj, "like_count"), "like_count is required"
+    category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return ChatData(
         id=obj.id,
@@ -14,13 +15,14 @@ def convert_data(obj: Chat) -> ChatData:
         title=obj.title,
         content=obj.content,
         read=obj.read,
-        like=obj.like.count(),
+        like=obj.like_count,
         period=obj.period,
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
         thread_count=obj.thread_count(),
         joined_count=obj.joined_count(),
+        category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,
             ulid=obj.channel.ulid,
@@ -32,8 +34,7 @@ def convert_data(obj: Chat) -> ChatData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        category_ulid=category.ulid,
-        hashtags=[HashtagData(id=ch.hashtag.id, ulid=ch.hashtag.ulid, name=ch.hashtag.name) for ch in obj.chat_hashtags.all()],
+        hashtags=[HashtagData(id=t.id, ulid=t.ulid, name=t.name) for t in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/chat/repository.py
+++ b/myus/api/src/domain/entity/media/chat/repository.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.db.models.query import QuerySet
 from api.db.models.media import Chat
 from api.src.domain.entity.media.chat._convert import convert_data, marshal_data
@@ -13,7 +14,7 @@ CHAT_FIELDS = ["channel_id", "title", "content", "read", "period", "publish"]
 
 class ChatRepository(ChatInterface):
     def queryset(self) -> QuerySet[Chat]:
-        return Chat.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
+        return Chat.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(like_count=Count("like"))
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Chat.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/comic/_convert.py
+++ b/myus/api/src/domain/entity/media/comic/_convert.py
@@ -6,7 +6,8 @@ from api.src.domain.interface.media.comic.data import ComicData
 
 
 def convert_data(obj: Comic) -> ComicData:
-    category = obj.category.first()
+    assert hasattr(obj, "like_count"), "like_count is required"
+    category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return ComicData(
         id=obj.id,
@@ -16,10 +17,11 @@ def convert_data(obj: Comic) -> ComicData:
         image=obj.image.name if obj.image else "",
         pages=[p.image.name for p in obj.comic.all() if p.image],
         read=obj.read,
-        like=obj.like.count(),
+        like=obj.like_count,
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
+        category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,
             ulid=obj.channel.ulid,
@@ -31,8 +33,7 @@ def convert_data(obj: Comic) -> ComicData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        category_ulid=category.ulid,
-        hashtags=[HashtagData(id=ch.hashtag.id, ulid=ch.hashtag.ulid, name=ch.hashtag.name) for ch in obj.comic_hashtags.all()],
+        hashtags=[HashtagData(id=t.id, ulid=t.ulid, name=t.name) for t in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/comic/repository.py
+++ b/myus/api/src/domain/entity/media/comic/repository.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Count, Prefetch
 from django.db.models.query import QuerySet
 from api.db.models.media import Comic, ComicPage
 from api.src.domain.entity.media.comic._convert import convert_data, marshal_data
@@ -16,7 +16,7 @@ COMIC_FIELDS = ["channel_id", "title", "content", "image", "read", "publish"]
 class ComicRepository(ComicInterface):
     def queryset(self) -> QuerySet[Comic]:
         pages_prefetch = Prefetch("comic", queryset=ComicPage.objects.order_by("sequence"))
-        return Comic.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category", pages_prefetch)
+        return Comic.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category", pages_prefetch).annotate(like_count=Count("like"))
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Comic.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/music/_convert.py
+++ b/myus/api/src/domain/entity/media/music/_convert.py
@@ -6,7 +6,8 @@ from api.src.domain.interface.media.music.data import MusicData
 
 
 def convert_data(obj: Music) -> MusicData:
-    category = obj.category.first()
+    assert hasattr(obj, "like_count"), "like_count is required"
+    category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return MusicData(
         id=obj.id,
@@ -16,11 +17,12 @@ def convert_data(obj: Music) -> MusicData:
         lyric=obj.lyric,
         music=obj.music.name if obj.music else "",
         read=obj.read,
-        like=obj.like.count(),
+        like=obj.like_count,
         download=obj.download,
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
+        category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,
             ulid=obj.channel.ulid,
@@ -32,8 +34,7 @@ def convert_data(obj: Music) -> MusicData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        category_ulid=category.ulid,
-        hashtags=[HashtagData(id=mh.hashtag.id, ulid=mh.hashtag.ulid, name=mh.hashtag.name) for mh in obj.music_hashtags.all()],
+        hashtags=[HashtagData(id=t.id, ulid=t.ulid, name=t.name) for t in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/music/repository.py
+++ b/myus/api/src/domain/entity/media/music/repository.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.db.models.query import QuerySet
 from api.db.models.media import Music
 from api.src.domain.entity.media.music._convert import convert_data, marshal_data
@@ -13,7 +14,7 @@ MUSIC_FIELDS = ["channel_id", "title", "content", "lyric", "music", "read", "dow
 
 class MusicRepository(MusicInterface):
     def queryset(self) -> QuerySet[Music]:
-        return Music.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
+        return Music.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(like_count=Count("like"))
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Music.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/picture/_convert.py
+++ b/myus/api/src/domain/entity/media/picture/_convert.py
@@ -6,7 +6,8 @@ from api.src.domain.interface.media.picture.data import PictureData
 
 
 def convert_data(obj: Picture) -> PictureData:
-    category = obj.category.first()
+    assert hasattr(obj, "like_count"), "like_count is required"
+    category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return PictureData(
         id=obj.id,
@@ -15,10 +16,11 @@ def convert_data(obj: Picture) -> PictureData:
         content=obj.content,
         image=obj.image.name if obj.image else "",
         read=obj.read,
-        like=obj.like.count(),
+        like=obj.like_count,
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
+        category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,
             ulid=obj.channel.ulid,
@@ -30,8 +32,7 @@ def convert_data(obj: Picture) -> PictureData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        category_ulid=category.ulid,
-        hashtags=[HashtagData(id=t.hashtag.id, ulid=t.hashtag.ulid, name=t.hashtag.name) for t in obj.picture_hashtags.all()],
+        hashtags=[HashtagData(id=t.id, ulid=t.ulid, name=t.name) for t in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/picture/repository.py
+++ b/myus/api/src/domain/entity/media/picture/repository.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.db.models.query import QuerySet
 from api.db.models.media import Picture
 from api.src.domain.entity.media.picture._convert import convert_data, marshal_data
@@ -13,7 +14,7 @@ PICTURE_FIELDS = ["channel_id", "title", "content", "image", "read", "publish"]
 
 class PictureRepository(PictureInterface):
     def queryset(self) -> QuerySet[Picture]:
-        return Picture.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
+        return Picture.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(like_count=Count("like"))
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Picture.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/entity/media/video/_convert.py
+++ b/myus/api/src/domain/entity/media/video/_convert.py
@@ -6,7 +6,8 @@ from api.src.domain.interface.media.video.data import VideoData
 
 
 def convert_data(obj: Video) -> VideoData:
-    category = obj.category.first()
+    assert hasattr(obj, "like_count"), "like_count is required"
+    category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return VideoData(
         id=obj.id,
@@ -17,10 +18,11 @@ def convert_data(obj: Video) -> VideoData:
         video=obj.video.name if obj.video else "",
         convert=obj.convert.name if obj.convert else "",
         read=obj.read,
-        like=obj.like.count(),
+        like=obj.like_count,
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
+        category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,
             ulid=obj.channel.ulid,
@@ -32,8 +34,7 @@ def convert_data(obj: Video) -> VideoData:
             is_default=obj.channel.is_default,
             count=obj.channel.count,
         ),
-        category_ulid=category.ulid,
-        hashtags=[HashtagData(id=t.hashtag.id, ulid=t.hashtag.ulid, name=t.hashtag.name) for t in obj.video_hashtags.all()],
+        hashtags=[HashtagData(id=t.id, ulid=t.ulid, name=t.name) for t in obj.hashtag.all()],
     )
 
 

--- a/myus/api/src/domain/entity/media/video/repository.py
+++ b/myus/api/src/domain/entity/media/video/repository.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.db.models.query import QuerySet
 from api.db.models.media import Video
 from api.src.domain.entity.media.video._convert import convert_data, marshal_data
@@ -13,7 +14,7 @@ VIDEO_FIELDS = ["channel_id", "title", "content", "image", "video", "convert", "
 
 class VideoRepository(VideoInterface):
     def queryset(self) -> QuerySet[Video]:
-        return Video.objects.select_related("channel", "channel__owner").prefetch_related("like", "hashtag", "category")
+        return Video.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(like_count=Count("like"))
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Video.objects.filter(*filter_q_list(filter, exclude))

--- a/myus/api/src/domain/interface/media/blog/data.py
+++ b/myus/api/src/domain/interface/media/blog/data.py
@@ -18,6 +18,6 @@ class BlogData:
     publish: bool
     created: datetime
     updated: datetime
-    channel: ChannelData
     category_ulid: str
+    channel: ChannelData
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/chat/data.py
+++ b/myus/api/src/domain/interface/media/chat/data.py
@@ -18,6 +18,6 @@ class ChatData:
     updated: datetime
     thread_count: int
     joined_count: int
-    channel: ChannelData
     category_ulid: str
+    channel: ChannelData
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/comic/data.py
+++ b/myus/api/src/domain/interface/media/comic/data.py
@@ -17,6 +17,6 @@ class ComicData:
     publish: bool
     created: datetime
     updated: datetime
-    channel: ChannelData
     category_ulid: str
+    channel: ChannelData
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/music/data.py
+++ b/myus/api/src/domain/interface/media/music/data.py
@@ -18,6 +18,6 @@ class MusicData:
     publish: bool
     created: datetime
     updated: datetime
-    channel: ChannelData
     category_ulid: str
+    channel: ChannelData
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/picture/data.py
+++ b/myus/api/src/domain/interface/media/picture/data.py
@@ -16,6 +16,6 @@ class PictureData:
     publish: bool
     created: datetime
     updated: datetime
-    channel: ChannelData
     category_ulid: str
+    channel: ChannelData
     hashtags: list[HashtagData]

--- a/myus/api/src/domain/interface/media/video/data.py
+++ b/myus/api/src/domain/interface/media/video/data.py
@@ -18,6 +18,6 @@ class VideoData:
     publish: bool
     created: datetime
     updated: datetime
-    channel: ChannelData
     category_ulid: str
+    channel: ChannelData
     hashtags: list[HashtagData]

--- a/myus/api/src/types/schema/media/output.py
+++ b/myus/api/src/types/schema/media/output.py
@@ -19,8 +19,8 @@ class MediaOut(BaseModel):
     publish: bool
     created: datetime
     updated: datetime
-    channel: ChannelOut
     category_ulid: str
+    channel: ChannelOut
 
 
 class HashtagOut(BaseModel):


### PR DESCRIPTION
## Summary
- 6 media タイプ（video/music/blog/comic/picture/chat）の `bulk_get` における3パターンの N+1 を解消
- `category_ulid` のフィールド順を全 media で `channel` の前に統一

## 変更内容

### 1. N+1 解消（`_convert.py` × 6 + `repository.py` × 6）

`bulk_get` で30件取得すると **+90+ クエリ発火**していた箇所を修正：

| パターン | Before | After |
|---|---|---|
| いいね数 | `obj.like.count()`（毎回 COUNT 発火） | `annotate(like_count=Count(\"like\"))` + `obj.like_count` |
| ハッシュタグ | `obj.{type}_hashtags.all()` + `bh.hashtag.X`（through 未 prefetch） | `obj.hashtag.all()`（既存 prefetch を活用） |
| カテゴリ | `obj.category.first()`（prefetch キャッシュ非利用） | `next(iter(obj.category.all()), None)`（キャッシュ活用） |

`repository.queryset()`：
- `.prefetch_related(\"like\", \"hashtag\", \"category\")` → `.prefetch_related(\"hashtag\", \"category\").annotate(like_count=Count(\"like\"))`
- `like` 行は使わず数だけなので prefetch から外し annotate に置換

`_convert.py`：
- `assert hasattr(obj, \"like_count\")` で annotate 前提の契約を明示（既存 `comment/_convert.py` と同パターン）
- `obj.hashtag.all()` 直アクセスで through テーブル経由を撤廃

### 2. `category_ulid` フィールド順の統一

`channel` の前に配置するよう各層で揃える：

- `interface/media/{blog,chat,comic,music,picture,video}/data.py` — dataclass フィールド順
- `entity/media/{blog,chat,comic,music,picture,video}/_convert.py` — コンストラクタ引数順
- `types/schema/media/output.py` — `MediaOut` Pydantic フィールド順

統一後の並び：`... created, updated, category_ulid, channel, hashtags`

## 動作確認
- `uv run mypy`: 編集ファイルでエラー0件（pre-existing 28件は別ファイル）

## 補足（スコープ外）
- `chat/_convert.py:22-23` の `obj.thread_count()` / `obj.joined_count()` も同じ N+1 パターン。Subquery + annotate での修正が必要なため別 PR で対応予定
- FE 側の `Media` interface も同じ `categoryUlid` 順への変更が必要だが、ステージング外のため別 PR