### PR TITLE
【front】Media interface の categoryUlid を channel の前に並び替え

### DIFF
--- a/frontend/src/types/internal/media/output.d.ts
+++ b/frontend/src/types/internal/media/output.d.ts
@@ -28,8 +28,8 @@ export interface Media {
   publish: boolean
   created: Date
   updated: Date
-  channel: Channel
   categoryUlid: string
+  channel: Channel
   mediaUser: MediaUser
 }
 


### PR DESCRIPTION
## Summary
- `Media` interface のフィールド順を `categoryUlid → channel` に変更し、BE 側（PR #787）と並び順を統一

## 変更内容

### `frontend/src/types/internal/media/output.d.ts`
```diff
 export interface Media {
   ...
   created: Date
   updated: Date
-  channel: Channel
   categoryUlid: string
+  channel: Channel
   mediaUser: MediaUser
 }
```

## 関連
- BE 側: #787（同じ並び順を `interface/media/*/data.py` / `_convert.py` / `schema/media/output.py` で適用済み）
- 機能的な影響なし（TypeScript の interface はフィールド宣言順を強制しないため、object literal の構築側に影響はない）

## 動作確認
- `npx tsc --noEmit`: エラー0件