### PR TITLE
【back】chat bulk_get の thread_count / joined_count の N+1 を解消

### DIFF
--- a/myus/api/src/domain/entity/media/chat/_convert.py
+++ b/myus/api/src/domain/entity/media/chat/_convert.py
@@ -7,6 +7,8 @@ from api.src.domain.interface.media.chat.data import ChatData
 
 def convert_data(obj: Chat) -> ChatData:
     assert hasattr(obj, "like_count"), "like_count is required"
+    assert hasattr(obj, "thread_total"), "thread_total is required"
+    assert hasattr(obj, "joined_total"), "joined_total is required"
     category = next(iter(obj.category.all()), None)
     assert category is not None, "Category is required"
     return ChatData(
@@ -20,8 +22,8 @@ def convert_data(obj: Chat) -> ChatData:
         publish=obj.publish,
         created=obj.created,
         updated=obj.updated,
-        thread_count=obj.thread_count(),
-        joined_count=obj.joined_count(),
+        thread_count=obj.thread_total,
+        joined_count=obj.joined_total,
         category_ulid=category.ulid,
         channel=ChannelData(
             id=obj.channel.id,

--- a/myus/api/src/domain/entity/media/chat/repository.py
+++ b/myus/api/src/domain/entity/media/chat/repository.py
@@ -1,4 +1,4 @@
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.db.models.query import QuerySet
 from api.db.models.media import Chat
 from api.src.domain.entity.media.chat._convert import convert_data, marshal_data
@@ -14,7 +14,11 @@ CHAT_FIELDS = ["channel_id", "title", "content", "read", "period", "publish"]
 
 class ChatRepository(ChatInterface):
     def queryset(self) -> QuerySet[Chat]:
-        return Chat.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(like_count=Count("like"))
+        return Chat.objects.select_related("channel", "channel__owner").prefetch_related("hashtag", "category").annotate(
+            like_count=Count("like", distinct=True),
+            thread_total=Count("message", distinct=True, filter=Q(message__parent__isnull=True)),
+            joined_total=Count("message__author", distinct=True),
+        )
 
     def get_ids(self, filter: FilterOption, exclude: ExcludeOption, sort: SortOption, page: PageOption, user_id: int | None = None) -> list[int]:
         qs = Chat.objects.filter(*filter_q_list(filter, exclude))


### PR DESCRIPTION
## Summary
- ChatRepository の `bulk_get` で発生していた `obj.thread_count()` / `obj.joined_count()` 呼び出しによる N+1 を解消
- 30件取得時に +60 クエリ発火していた箇所を annotate に置き換えて 0 クエリに削減

## 変更内容

### `api/src/domain/entity/media/chat/repository.py`
queryset に2つの annotation を追加：
\`\`\`python
.annotate(
    like_count=Count("like", distinct=True),
    thread_total=Count("message", distinct=True, filter=Q(message__parent__isnull=True)),
    joined_total=Count("message__author", distinct=True),
)
\`\`\`

- `thread_total`: parent NULL のメッセージ数（= スレッド数）
- `joined_total`: distinct な author 数（= 参加者数）
- 既存 `like_count` にも `distinct=True` を追加（複数 annotate での cartesian product 対策）

### `api/src/domain/entity/media/chat/_convert.py`
- `obj.thread_count()` / `obj.joined_count()` メソッド呼び出しを `obj.thread_total` / `obj.joined_total` に置き換え
- `assert hasattr(obj, "thread_total")` / `assert hasattr(obj, "joined_total")` を追加して annotate 前提を明示（既存 `like_count` と同パターン）

## 設計判断

### annotation 名に `_total` を使った理由
モデルの `thread_count` / `joined_count` メソッドは admin (`list_display` / `readonly_fields`) と Django テンプレート (`chat_section_header.html` 等) で使われており、同名で annotate するとメソッドを shadow してしまう。`_total` サフィックスで明示的に annotation 由来と分かるようにし、メソッドはそのまま温存。

### `distinct=True` を全 Count に追加した理由
`Count("like")` + `Count("message", ...)` + `Count("message__author", ...)` を同一クエリで annotate すると、複数の JOIN による cartesian product で結果が水増しされる（Django の有名な落とし穴）。`distinct=True` で重複行を除去。

## 動作確認
- `uv run mypy`: 編集ファイルでエラー0件