### PR TITLE
【front】広告管理 API のクライアント関数と型定義を追加

### DIFF
--- a/frontend/src/api/internal/manage/create.ts
+++ b/frontend/src/api/internal/manage/create.ts
@@ -1,8 +1,9 @@
 import { apiClient } from 'lib/axios/internal'
 import { apiOut, ApiOut } from 'lib/error'
+import { Advertise, AdvertiseIn } from 'types/internal/advertise'
 import { VideoIn, MusicIn, BlogIn, ComicIn, PictureIn, ChatIn } from 'types/internal/media/input'
 import { Video, Music, Blog, Comic, Picture, Chat } from 'types/internal/media/output'
-import { apiVideos, apiMusics, apiBlogs, apiComics, apiPictures, apiChats } from 'api/uri'
+import { apiManageAdvertises, apiVideos, apiMusics, apiBlogs, apiComics, apiPictures, apiChats } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const postVideoCreate = async (request: VideoIn): Promise<ApiOut<Video>> => {
@@ -27,4 +28,8 @@ export const postPictureCreate = async (request: PictureIn): Promise<ApiOut<Pict
 
 export const postChatCreate = async (request: ChatIn): Promise<ApiOut<Chat>> => {
   return await apiOut(apiClient('form').post(apiChats, camelSnake(request)))
+}
+
+export const postAdvertiseCreate = async (request: AdvertiseIn): Promise<ApiOut<Advertise>> => {
+  return await apiOut(apiClient('form').post(apiManageAdvertises, camelSnake(request)))
 }

--- a/frontend/src/api/internal/manage/delete.ts
+++ b/frontend/src/api/internal/manage/delete.ts
@@ -1,7 +1,7 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageVideos, apiManageMusics, apiManageBlogs, apiManageComics, apiManagePictures, apiManageChats } from 'api/uri'
+import { apiManageVideos, apiManageMusics, apiManageBlogs, apiManageComics, apiManagePictures, apiManageChats, apiManageAdvertises } from 'api/uri'
 
 export const deleteManageVideos = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageVideos, { data: { ulids } }))
@@ -25,4 +25,8 @@ export const deleteManagePictures = async (ulids: string[]): Promise<ApiOut<Erro
 
 export const deleteManageChats = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').delete(apiManageChats, { data: { ulids } }))
+}
+
+export const deleteManageAdvertises = async (ulids: string[]): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('json').delete(apiManageAdvertises, { data: { ulids } }))
 }

--- a/frontend/src/api/internal/manage/get.ts
+++ b/frontend/src/api/internal/manage/get.ts
@@ -2,6 +2,7 @@ import { apiClient } from 'lib/axios/internal'
 import { cookieHeader } from 'lib/config'
 import { ApiOut, apiOut } from 'lib/error'
 import { Req } from 'types/global'
+import { Advertise, AdvertiseList, AdvertiseSearchParams } from 'types/internal/advertise'
 import { VideoList, MusicList, BlogList, ComicList, PictureList, ChatList } from 'types/internal/media/output'
 import { SearchParams, Video, Music, Blog, Comic, Picture, Chat } from 'types/internal/media/output'
 import {
@@ -17,6 +18,8 @@ import {
   apiManagePicture,
   apiManageChats,
   apiManageChat,
+  apiManageAdvertises,
+  apiManageAdvertise,
 } from 'api/uri'
 
 export const getManageVideos = async (params: SearchParams, req?: Req): Promise<ApiOut<VideoList>> => {
@@ -65,4 +68,12 @@ export const getManagePicture = async (ulid: string, req?: Req): Promise<ApiOut<
 
 export const getManageChat = async (ulid: string, req?: Req): Promise<ApiOut<Chat>> => {
   return await apiOut(apiClient('json').get(apiManageChat(ulid), cookieHeader(req)))
+}
+
+export const getManageAdvertises = async (params: AdvertiseSearchParams, req?: Req): Promise<ApiOut<AdvertiseList>> => {
+  return await apiOut(apiClient('json').get(apiManageAdvertises, cookieHeader(req, params)))
+}
+
+export const getManageAdvertise = async (ulid: string, req?: Req): Promise<ApiOut<Advertise>> => {
+  return await apiOut(apiClient('json').get(apiManageAdvertise(ulid), cookieHeader(req)))
 }

--- a/frontend/src/api/internal/manage/update.ts
+++ b/frontend/src/api/internal/manage/update.ts
@@ -1,8 +1,9 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
+import { AdvertiseUpdateIn } from 'types/internal/advertise'
 import { VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn } from 'types/internal/media/input'
 import { ErrorOut } from 'types/internal/other'
-import { apiManageVideo, apiManageMusic, apiManageBlog, apiManageComic, apiManagePicture, apiManageChat } from 'api/uri'
+import { apiManageVideo, apiManageMusic, apiManageBlog, apiManageComic, apiManagePicture, apiManageChat, apiManageAdvertise } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const putManageVideo = async (ulid: string, request: VideoUpdateIn): Promise<ApiOut<ErrorOut>> => {
@@ -27,4 +28,8 @@ export const putManagePicture = async (ulid: string, request: PictureUpdateIn): 
 
 export const putManageChat = async (ulid: string, request: ChatUpdateIn): Promise<ApiOut<ErrorOut>> => {
   return await apiOut(apiClient('json').put(apiManageChat(ulid), camelSnake(request)))
+}
+
+export const putManageAdvertise = async (ulid: string, request: AdvertiseUpdateIn): Promise<ApiOut<ErrorOut>> => {
+  return await apiOut(apiClient('form').put(apiManageAdvertise(ulid), camelSnake(request)))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -89,5 +89,8 @@ export const apiManagePicture = (ulid: string) => base + `/manage/media/picture/
 export const apiManageChats = base + '/manage/media/chat'
 export const apiManageChat = (ulid: string) => base + `/manage/media/chat/${ulid}`
 
+export const apiManageAdvertises = base + '/manage/advertise'
+export const apiManageAdvertise = (ulid: string) => base + `/manage/advertise/${ulid}`
+
 // 外部API
 export const apiAddress = base + '/search'

--- a/frontend/src/types/internal/advertise.d.ts
+++ b/frontend/src/types/internal/advertise.d.ts
@@ -1,0 +1,45 @@
+export interface AdvertiseIn {
+  title: string
+  url: string
+  content: string
+  publish: boolean
+  period: string | null
+  image?: File
+  video?: File
+}
+
+export interface AdvertiseUpdateIn {
+  title: string
+  url: string
+  content: string
+  publish: boolean
+  period: string | null
+  image?: File
+  video?: File
+}
+
+export interface Advertise {
+  ulid: string
+  title: string
+  url: string
+  content: string
+  image: string
+  video: string
+  read: number
+  type: string
+  period: string | null
+  publish: boolean
+  created: Date
+  updated: Date
+}
+
+export interface AdvertiseList {
+  datas: Advertise[]
+  total: number
+}
+
+export interface AdvertiseSearchParams {
+  search?: string
+  limit?: number
+  offset?: number
+}


### PR DESCRIPTION
## Summary
- 広告管理機能で利用する型定義（`AdvertiseIn` / `AdvertiseUpdateIn` / `Advertise` / `AdvertiseList`）を新規追加
- 広告 CRUD 用 API クライアント（list / get / create / update / delete）を追記
- `apiManageAdvertises` / `apiManageAdvertise` を `api/uri.ts` に追加

## 変更内容

### 型定義（新規）
- `types/internal/advertise.d.ts`
  - `AdvertiseIn`: 作成時の入力型（`title` / `url` / `content` / `publish` / `period` / `image?` / `video?`）
  - `AdvertiseUpdateIn`: 更新時の入力型（同上）
  - `Advertise`: API レスポンス型（read / type / created / updated 等を含む）
  - `AdvertiseList`: 一覧レスポンス型（`datas` + `total`）
  - `AdvertiseSearchParams`: 一覧 GET 時のクエリパラメータ

### URI 追加
- `api/uri.ts`
  - `apiManageAdvertises` = `/api/manage/advertise`
  - `apiManageAdvertise(ulid)` = `/api/manage/advertise/{ulid}`

### API クライアント関数
- `api/internal/manage/get.ts`: `getManageAdvertises` / `getManageAdvertise`
- `api/internal/manage/create.ts`: `postAdvertiseCreate`（multipart/form-data）
- `api/internal/manage/update.ts`: `putManageAdvertise`（multipart/form-data）
- `api/internal/manage/delete.ts`: `deleteManageAdvertises`（一括削除）

## 補足
本 PR は広告管理機能の API 層のみで、画面とテンプレートは別 PR で対応する。バックエンド側の `/api/manage/advertise` ルータも別 PR で実装する。