### PR TITLE
【front】投稿管理に広告管理画面を追加

### DIFF
--- a/frontend/src/components/parts/Icon/Advertise.tsx
+++ b/frontend/src/components/parts/Icon/Advertise.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  size: string
+  className?: string
+}
+
+export default function IconAdvertise(props: Props): React.JSX.Element {
+  const { size, className } = props
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" width={size} height={size} className={className}>
+      <path d="M13 2.5a1.5 1.5 0 0 1 3 0v11a1.5 1.5 0 0 1-3 0v-.214c-2.162-1.241-4.49-1.843-6.912-2.083l.405 2.712A1 1 0 0 1 5.51 15.1h-.548a1 1 0 0 1-.916-.599l-1.85-3.49a68.14 68.14 0 0 0-.202-.003A2.014 2.014 0 0 1 0 9V7a2.02 2.02 0 0 1 1.992-2.013 74.663 74.663 0 0 0 2.483-.075c3.043-.154 6.148-.849 8.525-2.199V2.5zm1 0v11a.5.5 0 0 0 1 0v-11a.5.5 0 0 0-1 0zm-1 1.35c-2.344 1.205-5.209 1.842-8 2.033v4.233c.18.01.359.022.537.036 2.568.189 5.093.744 7.463 1.993V3.85z" />
+    </svg>
+  )
+}

--- a/frontend/src/components/templates/manage/advertise/create.tsx
+++ b/frontend/src/components/templates/manage/advertise/create.tsx
@@ -1,0 +1,58 @@
+import { useState, ChangeEvent } from 'react'
+import { AdvertiseIn } from 'types/internal/advertise'
+import { postAdvertiseCreate } from 'api/internal/manage/create'
+import { FetchError } from 'utils/constants/enum'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import InputFile from 'components/parts/Input/File'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import VStack from 'components/parts/Stack/Vertical'
+
+export default function AdvertiseCreate(): React.JSX.Element {
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const [values, setValues] = useState<AdvertiseIn>({ title: '', url: '', content: '', publish: true, period: null })
+
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handlePeriod = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, period: e.target.value || null })
+  const handleImage = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
+  const handleVideo = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, video: files })
+
+  const handleForm = async () => {
+    const { title, url, content, image } = values
+    if (!isRequiredCheck({ title, url, content, image })) return
+    handleLoading(true)
+    const ret = await postAdvertiseCreate(values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleToast(FetchError.Post, true)
+      return
+    }
+    setValues({ title: '', url: '', content: '', publish: true, period: null })
+    handleToast('作成しました', false)
+  }
+
+  return (
+    <Main title="広告作成" type="table" toast={toast} isFooter={false} button={<Button color="green" size="s" name="作成する" loading={isLoading} onClick={handleForm} />}>
+      <form method="POST" action="" encType="multipart/form-data">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
+          <Input label="リンク URL" name="url" type="url" required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
+          <Input label="表示期限" name="period" type="date" onChange={handlePeriod} />
+          <InputFile label="画像（必須）" accept="image/*" required={isRequired} onChange={handleImage} />
+          <InputFile label="動画（任意）" accept="video/*" onChange={handleVideo} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -1,0 +1,82 @@
+import { useState, ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { Advertise, AdvertiseUpdateIn } from 'types/internal/advertise'
+import { putManageAdvertise } from 'api/internal/manage/update'
+import { FetchError } from 'utils/constants/enum'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { useRequired } from 'components/hooks/useRequired'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import Input from 'components/parts/Input'
+import InputFile from 'components/parts/Input/File'
+import Textarea from 'components/parts/Input/Textarea'
+import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
+import VStack from 'components/parts/Stack/Vertical'
+
+interface Props {
+  data: Advertise
+}
+
+export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
+  const { data } = props
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { isRequired, isRequiredCheck } = useRequired()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const [values, setValues] = useState<AdvertiseUpdateIn>({
+    title: data.title,
+    url: data.url,
+    content: data.content,
+    publish: data.publish,
+    period: data.period,
+  })
+
+  const handleBack = () => router.push('/manage/advertise')
+  const handlePublish = () => setValues({ ...values, publish: !values.publish })
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handlePeriod = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, period: e.target.value || null })
+  const handleImage = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
+  const handleVideo = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, video: files })
+
+  const handleForm = async () => {
+    const { title, url, content } = values
+    if (!isRequiredCheck({ title, url, content })) return
+    handleLoading(true)
+    const ret = await putManageAdvertise(data.ulid, values)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Put, ret.error.message)
+      return
+    }
+    handleToast('保存しました', false)
+  }
+
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="保存する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
+  return (
+    <Main title="広告編集" type="table" toast={toast} isFooter={false} button={button}>
+      <form method="POST" action="" encType="multipart/form-data">
+        <VStack gap="8">
+          <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
+          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
+          <Input label="リンク URL" name="url" type="url" value={values.url} required={isRequired} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <Input label="表示期限" name="period" type="date" value={values.period ?? ''} onChange={handlePeriod} />
+          <InputFile label="画像" accept="image/*" onChange={handleImage} />
+          <InputFile label="動画" accept="video/*" onChange={handleVideo} />
+        </VStack>
+      </form>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/advertise/index.tsx
+++ b/frontend/src/components/templates/manage/advertise/index.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { Advertise } from 'types/internal/advertise'
+import { deleteManageAdvertises } from 'api/internal/manage/delete'
+import { FetchError } from 'utils/constants/enum'
+import { formatDatetime } from 'utils/functions/datetime'
+import { useApiError } from 'components/hooks/useApiError'
+import { useIsLoading } from 'components/hooks/useIsLoading'
+import { usePagination } from 'components/hooks/usePagination'
+import { useToast } from 'components/hooks/useToast'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import DataTable, { Column } from 'components/parts/DataTable'
+import ExImage from 'components/parts/ExImage'
+import Toggle from 'components/parts/Input/Toggle'
+import Pagination from 'components/parts/Pagination'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from '../Media.module.scss'
+
+interface Props {
+  datas: Advertise[]
+  total: number
+  page: number
+}
+
+const ADVERTISE_LIMIT = 5
+
+export default function ManageAdvertises(props: Props): React.JSX.Element {
+  const { datas, total, page } = props
+
+  const router = useRouter()
+  const { isLoading, handleLoading } = useIsLoading()
+  const { toast, handleToast } = useToast()
+  const { handleError } = useApiError({ handleToast })
+  const { currentPage, totalPages, handlePage } = usePagination(total, page)
+  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
+
+  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleEdit = (advertise: Advertise) => router.push(`/manage/advertise/${advertise.ulid}`)
+  const handleCreate = () => router.push('/manage/advertise/create')
+
+  const handleDeleteSubmit = async () => {
+    const ulids = Array.from(selectedKeys)
+    if (ulids.length === 0) return
+
+    handleLoading(true)
+    const ret = await deleteManageAdvertises(ulids)
+    handleLoading(false)
+    if (ret.isErr()) {
+      handleError(FetchError.Delete, ret.error.message)
+      return
+    }
+    setSelectedKeys(new Set())
+    handleDelete()
+    router.replace(router.asPath)
+  }
+
+  const isLimitReached = total >= ADVERTISE_LIMIT
+
+  const columns: Column<Advertise>[] = [
+    {
+      key: 'thumbnail',
+      header: '画像',
+      className: style.thumbnail,
+      cell: (a) => a.image && <ExImage src={a.image} width="96" height="54" />,
+    },
+    {
+      key: 'title',
+      header: 'タイトル',
+      sortable: true,
+      sortValue: (a) => a.title,
+      className: style.title,
+      cell: (a) => (
+        <a className={style.title_link} onClick={() => handleEdit(a)}>
+          {a.title}
+        </a>
+      ),
+    },
+    {
+      key: 'url',
+      header: 'URL',
+      className: style.content,
+      cell: (a) => a.url,
+    },
+    {
+      key: 'read',
+      header: '閲覧',
+      align: 'right',
+      sortable: true,
+      sortValue: (a) => a.read,
+      className: style.normal,
+      cellClass: style.number,
+      cell: (a) => a.read,
+    },
+    {
+      key: 'period',
+      header: '表示期限',
+      align: 'center',
+      className: style.normal,
+      cell: (a) => a.period ?? '-',
+    },
+    {
+      key: 'publish',
+      header: '公開',
+      align: 'center',
+      sortable: true,
+      sortValue: (a) => (a.publish ? 1 : 0),
+      className: style.narrow,
+      cellClass: style.publish,
+      cell: (a) => (
+        <div className={style.publish_inner}>
+          <Toggle isActive={a.publish} disable />
+        </div>
+      ),
+    },
+    {
+      key: 'created',
+      header: '作成日時',
+      sortable: true,
+      sortValue: (a) => new Date(a.created).getTime(),
+      className: style.datetime,
+      cell: (a) => formatDatetime(a.created),
+    },
+  ]
+
+  return (
+    <Main
+      title="広告管理"
+      type="table"
+      toast={toast}
+      isFooter={false}
+      button={
+        <div className={style.header_actions}>
+          {selectedKeys.size > 0 && (
+            <>
+              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
+              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
+            </>
+          )}
+          <Button color="green" size="s" name={`作成 (${total}/${ADVERTISE_LIMIT})`} disabled={isLimitReached} onClick={handleCreate} />
+        </div>
+      }
+    >
+      <div className={style.manage}>
+        <DataTable
+          datas={datas}
+          columns={columns}
+          rowKey={(a) => a.ulid}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelection={setSelectedKeys}
+          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
+        />
+      </div>
+      <DeleteModal
+        open={isDeleteModal}
+        title="広告の削除"
+        content={`${selectedKeys.size}件の広告を削除しますか？`}
+        loading={isLoading}
+        onClose={handleDelete}
+        onAction={handleDeleteSubmit}
+      />
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/manage/index.tsx
+++ b/frontend/src/components/templates/manage/index.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router'
 import Main from 'components/layout/Main'
+import IconAdvertise from 'components/parts/Icon/Advertise'
 import IconBlog from 'components/parts/Icon/Blog'
 import IconChat from 'components/parts/Icon/Chat'
 import IconComic from 'components/parts/Icon/Comic'
@@ -15,6 +16,7 @@ const menus = [
   { label: 'Comic', icon: <IconComic size="2em" />, path: 'comic' },
   { label: 'Picture', icon: <IconPicture size="2em" />, path: 'picture' },
   { label: 'Chat', icon: <IconChat size="2em" />, path: 'chat' },
+  { label: 'Advertise', icon: <IconAdvertise size="2em" />, path: 'advertise' },
 ]
 
 export default function Manage(): React.JSX.Element {

--- a/frontend/src/pages/manage/advertise/[ulid].tsx
+++ b/frontend/src/pages/manage/advertise/[ulid].tsx
@@ -1,0 +1,28 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Advertise } from 'types/internal/advertise'
+import { getManageAdvertise } from 'api/internal/manage/get'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageAdvertiseEdit from 'components/templates/manage/advertise/edit'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, params, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ulid = String(params?.ulid ?? '')
+  const advertiseRet = await getManageAdvertise(ulid, req)
+  if (advertiseRet.isErr()) return { props: { status: advertiseRet.error.status } }
+  const data = advertiseRet.value
+  return { props: { ...translations, data } }
+}
+
+interface Props {
+  status: number
+  data: Advertise
+}
+
+export default function ManageAdvertiseEditPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageAdvertiseEdit {...props} />
+    </ErrorCheck>
+  )
+}

--- a/frontend/src/pages/manage/advertise/create.tsx
+++ b/frontend/src/pages/manage/advertise/create.tsx
@@ -1,0 +1,12 @@
+import { GetStaticProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import AdvertiseCreate from 'components/templates/manage/advertise/create'
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  return { props: { ...translations } }
+}
+
+export default function AdvertiseCreatePage(): React.JSX.Element {
+  return <AdvertiseCreate />
+}

--- a/frontend/src/pages/manage/advertise/index.tsx
+++ b/frontend/src/pages/manage/advertise/index.tsx
@@ -1,0 +1,31 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { Advertise } from 'types/internal/advertise'
+import { getManageAdvertises } from 'api/internal/manage/get'
+import { pageParams } from 'utils/functions/common'
+import ErrorCheck from 'components/widgets/Error/Check'
+import ManageAdvertises from 'components/templates/manage/advertise'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale, query, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const { search, page, limit, offset } = pageParams(query)
+  const advertisesRet = await getManageAdvertises({ search, limit, offset }, req)
+  if (advertisesRet.isErr()) return { props: { status: advertisesRet.error.status } }
+  const { datas, total } = advertisesRet.value
+  return { props: { ...translations, datas, total, page } }
+}
+
+interface Props {
+  status: number
+  datas: Advertise[]
+  total: number
+  page: number
+}
+
+export default function ManageAdvertisesPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <ManageAdvertises {...props} />
+    </ErrorCheck>
+  )
+}


### PR DESCRIPTION
## Summary
- 投稿管理メニューに「Advertise」カードを追加し、広告の一覧 / 作成 / 編集ページを新設
- 個人広告の作成上限 5 件を一覧画面の作成ボタンに表示し、上限到達時は disabled に
- `IconAdvertise` アイコンを新規追加

## 変更内容

### 投稿管理メニュー
- `templates/manage/index.tsx`: 既存の Video / Music / Blog / Comic / Picture / Chat の末尾に Advertise カードを追加

### 一覧 (`/manage/advertise`)
- `templates/manage/advertise/index.tsx`
  - DataTable で 画像 / タイトル / URL / 閲覧 / 表示期限 / 公開 / 作成日時 を表示
  - 一括削除モーダル
  - 作成ボタンに `現在数 / 5` を表示し、上限到達時は disabled
  - ページネーション付き
- `pages/manage/advertise/index.tsx`: SSR で `getManageAdvertises` を呼び出し

### 作成 (`/manage/advertise/create`)
- `templates/manage/advertise/create.tsx`
  - タイトル / リンク URL / 内容 / 表示期限（任意） / 画像（必須） / 動画（任意）
  - `type` はフォームから選ばせず、バックエンドで `"one"` 固定
- `pages/manage/advertise/create.tsx`: 静的ページ

### 編集 (`/manage/advertise/[ulid]`)
- `templates/manage/advertise/edit.tsx`
  - 既存値をフォームに反映
  - 画像・動画は差し替え時のみ送信
- `pages/manage/advertise/[ulid].tsx`: SSR で `getManageAdvertise` を呼び出し

### アイコン
- `components/parts/Icon/Advertise.tsx`: bullhorn 形状の SVG アイコン

## 補足
- 本 PR は「広告管理 API クライアント追加」(#794) と「広告管理のバックエンド」(別 PR) を依存先とする。本 PR を単体で main にマージすると `getManageAdvertises` 等の import 解決と API 通信が両方失敗する
- 配信ロジック（メディア詳細ページに広告枠を表示する処理）は Phase 3 の別タスクで対応