### PR TITLE
【back】広告管理 API（adapter / usecase / schema / モデル拡張）を追加

### DIFF
--- a/myus/api/db/models/common.py
+++ b/myus/api/db/models/common.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django_ulid.models import ulid
 from api.db.models.user import User
+from api.utils.functions.file import advertise_image_upload, advertise_video_upload
 
 
 class AccessLog(models.Model):
@@ -30,11 +31,11 @@ class Advertise(models.Model):
     title   = models.CharField(max_length=100)
     url     = models.URLField()
     content = models.TextField()
-    image   = models.ImageField(blank=True)
-    video   = models.FileField(blank=True)
+    image   = models.ImageField(upload_to=advertise_image_upload, max_length=255, blank=True)
+    video   = models.FileField(upload_to=advertise_video_upload, max_length=255, blank=True)
     read    = models.IntegerField(default=0)
-    type    = models.CharField(choices=choice, max_length=3)
-    period  = models.DateField()
+    type    = models.CharField(choices=choice, max_length=3, default="one")
+    period  = models.DateField(blank=True, null=True)
     publish = models.BooleanField(default=True)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)

--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -2,12 +2,15 @@ from django.http import HttpRequest
 from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
 from api.src.adapter.media import convert_videos, convert_musics, convert_blogs, convert_comics, convert_pictures, convert_chats
+from api.src.domain.interface.advertise.data import AdvertiseData
+from api.src.types.schema.advertise import AdvertiseIn, AdvertiseListOut, AdvertiseOut, AdvertiseUpdateIn
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.media.input import BulkDeleteIn, VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
-from api.src.types.schema.media.output import VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut
+from api.src.types.schema.media.output import MediaCreateOut, VideoOut, MusicOut, BlogOut, ComicOut, PictureOut, ChatOut
 from api.src.types.schema.media.output import VideoListOut, MusicListOut, BlogListOut, ComicListOut, PictureListOut, ChatListOut
 from api.src.domain.interface.media.index import PAGE_SIZE
 from api.src.usecase.auth import auth_check
+from api.src.usecase.manage.advertise import get_manage_advertises, get_manage_advertise, create_manage_advertise, update_manage_advertise, delete_manage_advertise
 from api.src.usecase.manage.media import (
     get_manage_videos, get_manage_video, update_manage_video, delete_manage_video,
     get_manage_musics, get_manage_music, update_manage_music, delete_manage_music,
@@ -382,3 +385,99 @@ class ManageChatAPI:
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")
+
+
+class ManageAdvertiseAPI:
+    """ManageAdvertiseAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("", response={200: AdvertiseListOut, 401: ErrorOut})
+    def list(request: HttpRequest, search: str = "", limit: int = PAGE_SIZE, offset: int = 0):
+        log.info("ManageAdvertiseAPI list", search=search, limit=limit, offset=offset)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        objs, total = get_manage_advertises(user_id, search, limit, offset)
+        return 200, AdvertiseListOut(datas=convert_advertises(objs), total=total)
+
+    @staticmethod
+    @router.get("/{ulid}", response={200: AdvertiseOut, 401: ErrorOut, 404: ErrorOut})
+    def get(request: HttpRequest, ulid: str):
+        log.info("ManageAdvertiseAPI get", ulid=ulid)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = get_manage_advertise(user_id, ulid)
+        if obj is None:
+            return 404, ErrorOut(message="Advertise not found")
+
+        return 200, convert_advertises([obj])[0]
+
+    @staticmethod
+    @router.post("", response={201: MediaCreateOut, 400: ErrorOut, 401: ErrorOut})
+    def post(request: HttpRequest, input: AdvertiseIn = Form(...), image: UploadedFile = File(...), video: UploadedFile | None = File(None)):
+        log.info("ManageAdvertiseAPI post", input=input, image=image, video=video)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        obj = create_manage_advertise(user_id, input, image, video)
+        if obj is None:
+            return 400, ErrorOut(message="作成に失敗しました!")
+
+        return 201, MediaCreateOut(ulid=obj.ulid)
+
+    @staticmethod
+    @router.put("/{ulid}", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def put(request: HttpRequest, ulid: str, input: AdvertiseUpdateIn = Form(...), image: UploadedFile | None = File(None), video: UploadedFile | None = File(None)):
+        log.info("ManageAdvertiseAPI put", ulid=ulid, input=input, image=image, video=video)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not update_manage_advertise(user_id, ulid, input, image, video):
+            return 400, ErrorOut(message="保存に失敗しました!")
+
+        return 204, ErrorOut(message="保存しました!")
+
+    @staticmethod
+    @router.delete("", response={204: ErrorOut, 400: ErrorOut, 401: ErrorOut})
+    def delete(request: HttpRequest, input: BulkDeleteIn):
+        log.info("ManageAdvertiseAPI delete", ulids=input.ulids)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        if not delete_manage_advertise(user_id, input.ulids):
+            return 400, ErrorOut(message="削除に失敗しました!")
+
+        return 204, ErrorOut(message="削除しました!")
+
+
+def convert_advertises(objs: list[AdvertiseData]) -> list[AdvertiseOut]:
+    return [
+        AdvertiseOut(
+            ulid=o.ulid,
+            title=o.title,
+            url=o.url,
+            content=o.content,
+            image=o.image,
+            video=o.video,
+            read=o.read,
+            type=o.type,
+            period=o.period,
+            publish=o.publish,
+            created=o.created,
+            updated=o.updated,
+        )
+        for o in objs
+    ]

--- a/myus/api/src/injectors/index.py
+++ b/myus/api/src/injectors/index.py
@@ -8,6 +8,7 @@ from api.src.domain.entity.media.blog.repository import BlogRepository
 from api.src.domain.entity.media.comic.repository import ComicRepository
 from api.src.domain.entity.media.picture.repository import PictureRepository
 from api.src.domain.entity.media.chat.repository import ChatRepository
+from api.src.domain.entity.advertise.repository import AdvertiseRepository
 from api.src.domain.entity.comment.repository import CommentRepository
 from api.src.domain.entity.message.repository import MessageRepository
 from api.src.domain.entity.follow.repository import FollowRepository
@@ -25,6 +26,7 @@ from api.src.domain.interface.media.blog.interface import BlogInterface
 from api.src.domain.interface.media.comic.interface import ComicInterface
 from api.src.domain.interface.media.picture.interface import PictureInterface
 from api.src.domain.interface.media.chat.interface import ChatInterface
+from api.src.domain.interface.advertise.interface import AdvertiseInterface
 from api.src.domain.interface.comment.interface import CommentInterface
 from api.src.domain.interface.message.interface import MessageInterface
 from api.src.domain.interface.follow.interface import FollowInterface
@@ -125,3 +127,9 @@ class SubscribeModule(Module):
     @provider
     def provide_subscribe_repository(self) -> SubscribeInterface:
         return SubscribeRepository()
+
+
+class AdvertiseModule(Module):
+    @provider
+    def provide_advertise_repository(self) -> AdvertiseInterface:
+        return AdvertiseRepository()

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -3,7 +3,7 @@ from api.src.adapter.auth import AuthAPI
 from api.src.adapter.category import CategoryAPI
 from api.src.adapter.comment import CommentAPI
 from api.src.adapter.hashtag import MediaHashtagAPI
-from api.src.adapter.manage import ManageVideoAPI, ManageMusicAPI, ManageBlogAPI, ManageComicAPI, ManagePictureAPI, ManageChatAPI
+from api.src.adapter.manage import ManageVideoAPI, ManageMusicAPI, ManageBlogAPI, ManageComicAPI, ManagePictureAPI, ManageChatAPI, ManageAdvertiseAPI
 from api.src.adapter.media import HomeAPI, RecommendAPI, VideoAPI, MusicAPI, BlogAPI, ComicAPI, PictureAPI, ChatAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
@@ -26,6 +26,7 @@ api.add_router("/manage/media/blog", ManageBlogAPI().router, tags=["Manage Blog"
 api.add_router("/manage/media/comic", ManageComicAPI().router, tags=["Manage Comic"])
 api.add_router("/manage/media/picture", ManagePictureAPI().router, tags=["Manage Picture"])
 api.add_router("/manage/media/chat", ManageChatAPI().router, tags=["Manage Chat"])
+api.add_router("/manage/advertise", ManageAdvertiseAPI().router, tags=["Manage Advertise"])
 
 api.add_router("/channel", ChannelAPI().router, tags=["Channel"])
 api.add_router("/media/home", HomeAPI().router, tags=["Media Home"])

--- a/myus/api/src/types/schema/advertise.py
+++ b/myus/api/src/types/schema/advertise.py
@@ -1,0 +1,38 @@
+from datetime import date, datetime
+from pydantic import BaseModel
+
+
+class AdvertiseIn(BaseModel):
+    title: str
+    url: str
+    content: str
+    publish: bool
+    period: date | None = None
+
+
+class AdvertiseUpdateIn(BaseModel):
+    title: str
+    url: str
+    content: str
+    publish: bool
+    period: date | None = None
+
+
+class AdvertiseOut(BaseModel):
+    ulid: str
+    title: str
+    url: str
+    content: str
+    image: str
+    video: str
+    read: int
+    type: str
+    period: date | None
+    publish: bool
+    created: datetime
+    updated: datetime
+
+
+class AdvertiseListOut(BaseModel):
+    datas: list[AdvertiseOut]
+    total: int

--- a/myus/api/src/usecase/manage/advertise.py
+++ b/myus/api/src/usecase/manage/advertise.py
@@ -1,0 +1,134 @@
+from dataclasses import replace
+from datetime import datetime
+from django.db import transaction
+from ninja import UploadedFile
+from api.modules.logger import log
+from api.src.domain.interface.advertise.data import AdvertiseData
+from api.src.domain.interface.advertise.interface import AdvertiseInterface
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PAGE_SIZE, PageOption, SortOption
+from api.src.injectors.container import injector
+from api.src.types.schema.advertise import AdvertiseIn, AdvertiseUpdateIn
+from api.src.usecase.user import get_user_data
+from api.utils.enum.index import ImageUpload, MediaUpload
+from api.utils.functions.index import create_url
+from api.utils.functions.media import save_upload
+
+
+ADVERTISE_TYPE_PERSONAL = "one"
+ADVERTISE_PERSONAL_LIMIT = 5
+
+
+def get_manage_advertises(user_id: int, search: str, limit: int = PAGE_SIZE, offset: int = 0) -> tuple[list[AdvertiseData], int]:
+    repository = injector.get(AdvertiseInterface)
+    filter = FilterOption(search=search, owner_id=user_id)
+    total = repository.count(filter)
+    ids = repository.get_ids(filter, ExcludeOption(), SortOption(), PageOption(limit=limit, offset=offset))
+    objs = repository.bulk_get(ids=ids)
+
+    data = [replace(o,
+        image=create_url(o.image),
+        video=create_url(o.video),
+    ) for o in objs]
+
+    return data, total
+
+
+def get_manage_advertise(user_id: int, ulid: str) -> AdvertiseData | None:
+    repository = injector.get(AdvertiseInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
+    if len(ids) == 0:
+        log.info("Advertise not found", ulid=ulid, user_id=user_id)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    return replace(obj,
+        image=create_url(obj.image),
+        video=create_url(obj.video),
+    )
+
+
+def create_manage_advertise(user_id: int, input: AdvertiseIn, image: UploadedFile, video: UploadedFile | None) -> AdvertiseData | None:
+    repository = injector.get(AdvertiseInterface)
+
+    count = repository.count(FilterOption(owner_id=user_id))
+    if count >= ADVERTISE_PERSONAL_LIMIT:
+        log.error("Advertise limit exceeded", user_id=user_id, count=count)
+        return None
+
+    user = get_user_data(user_id=user_id)
+    if user is None:
+        log.error("User not found", user_id=user_id)
+        return None
+
+    new_advertise = AdvertiseData(
+        id=0,
+        ulid="",
+        author_id=user_id,
+        title=input.title,
+        url=input.url,
+        content=input.content,
+        image=save_upload(image, ImageUpload.ADVERTISE, user.user.ulid),
+        video=save_upload(video, MediaUpload.ADVERTISE, user.user.ulid) if video is not None else "",
+        read=0,
+        type=ADVERTISE_TYPE_PERSONAL,
+        period=input.period,
+        publish=input.publish,
+        created=datetime.min,
+        updated=datetime.min,
+    )
+
+    with transaction.atomic():
+        new_ids = repository.bulk_save([new_advertise])
+        assert len(new_ids) == 1, "作成に失敗しました"
+
+    return repository.bulk_get(new_ids)[0]
+
+
+def update_manage_advertise(user_id: int, ulid: str, input: AdvertiseUpdateIn, image: UploadedFile | None, video: UploadedFile | None) -> bool:
+    repository = injector.get(AdvertiseInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
+    if len(ids) == 0:
+        log.error("Advertise not found", ulid=ulid, user_id=user_id)
+        return False
+
+    obj = repository.bulk_get(ids)[0]
+
+    user = get_user_data(user_id=user_id)
+    if user is None:
+        log.error("User not found", user_id=user_id)
+        return False
+
+    update_data = replace(obj,
+        title=input.title,
+        url=input.url,
+        content=input.content,
+        period=input.period,
+        publish=input.publish,
+    )
+    if image is not None:
+        update_data = replace(update_data, image=save_upload(image, ImageUpload.ADVERTISE, user.user.ulid))
+    if video is not None:
+        update_data = replace(update_data, video=save_upload(video, MediaUpload.ADVERTISE, user.user.ulid))
+
+    try:
+        with transaction.atomic():
+            repository.bulk_save([update_data])
+    except Exception as e:
+        log.error("Advertise update failed", ulid=ulid, error=str(e))
+        return False
+
+    return True
+
+
+def delete_manage_advertise(user_id: int, ulids: list[str]) -> bool:
+    repository = injector.get(AdvertiseInterface)
+    ids: list[int] = []
+    for ulid in ulids:
+        target = repository.get_ids(FilterOption(ulid=ulid, owner_id=user_id), ExcludeOption(), SortOption(), PageOption())
+        if len(target) == 0:
+            log.error("Advertise not found", ulid=ulid, user_id=user_id)
+            return False
+        ids.extend(target)
+
+    repository.bulk_delete(ids)
+    return True

--- a/myus/api/utils/enum/index.py
+++ b/myus/api/utils/enum/index.py
@@ -79,6 +79,7 @@ class ImageUpload(str, Enum):
     COMIC = "comic"
     COMIC_PAGE = "comic_page"
     PICTURE = "picture"
+    ADVERTISE = "advertise"
 
 
 class MediaUpload(str, Enum):

--- a/myus/api/utils/functions/file.py
+++ b/myus/api/utils/functions/file.py
@@ -27,6 +27,14 @@ def comic_path(ulid: str, filename: str) -> str:
     return f"comics/channel_{ulid}/{new_ulid()}_{filename}"
 
 
+def advertise_image_path(ulid: str, filename: str) -> str:
+    return f"images/advertise/user_{ulid}/{new_ulid()}_{filename}"
+
+
+def advertise_video_path(ulid: str, filename: str) -> str:
+    return f"videos/advertise/user_{ulid}/{new_ulid()}_{filename}"
+
+
 def avatar_upload(obj: Any, filename: str) -> str:
     type_map: dict[str, ImageUpload] = {
         "User": ImageUpload.USER,
@@ -59,3 +67,11 @@ def music_upload(obj: Any, filename: str) -> str:
 
 def comic_upload(obj: Any, filename: str) -> str:
     return comic_path(str(obj.channel.ulid), filename)
+
+
+def advertise_image_upload(obj: Any, filename: str) -> str:
+    return advertise_image_path(str(obj.author.ulid), filename)
+
+
+def advertise_video_upload(obj: Any, filename: str) -> str:
+    return advertise_video_path(str(obj.author.ulid), filename)

--- a/myus/api/utils/functions/media.py
+++ b/myus/api/utils/functions/media.py
@@ -10,7 +10,7 @@ from api.src.domain.interface.media.chat.interface import ChatInterface
 from api.src.injectors.container import injector
 from api.utils.enum.index import MediaType, ImageUpload, MediaUpload
 from api.utils.functions.convert.audio_converter import is_conversion, save_converted_mp3
-from api.utils.functions.file import avatar_path, comic_path, image_path, musics_path, video_path
+from api.utils.functions.file import advertise_image_path, advertise_video_path, avatar_path, comic_path, image_path, musics_path, video_path
 
 
 type MediaInterfaceType = VideoInterface | MusicInterface | BlogInterface | ComicInterface | PictureInterface | ChatInterface
@@ -44,8 +44,12 @@ def save_upload(file: UploadedFile, upload_type: UploadType, ulid: str) -> str:
             path = image_path(upload_type, ulid, filename)
         case ImageUpload.COMIC_PAGE:
             path = comic_path(ulid, filename)
-        case MediaUpload.VIDEO | MediaUpload.ADVERTISE:
+        case ImageUpload.ADVERTISE:
+            path = advertise_image_path(ulid, filename)
+        case MediaUpload.VIDEO:
             path = video_path(upload_type, ulid, filename)
+        case MediaUpload.ADVERTISE:
+            path = advertise_video_path(ulid, filename)
         case MediaUpload.MUSIC:
             path = musics_path(ulid, filename)
             if is_conversion(filename):


### PR DESCRIPTION
## Summary
- `/manage/advertise` の CRUD エンドポイント（list / get / post / put / delete）を新規追加
- 広告ユースケース（usecase）を追加し、作成上限 5 件のチェックや所有者検証を実装
- `Advertise` モデルに upload_to / period nullable / type デフォルトを設定し、広告用のファイルパスヘルパを追加

## 変更内容

### Schema
- `types/schema/advertise.py`
  - `AdvertiseIn` / `AdvertiseUpdateIn` / `AdvertiseOut` / `AdvertiseListOut`
  - `period: date | None = None`（任意項目）

### Usecase
- `usecase/manage/advertise.py`
  - `get_manage_advertises` / `get_manage_advertise` / `create_manage_advertise` / `update_manage_advertise` / `delete_manage_advertise`
  - `ADVERTISE_PERSONAL_LIMIT = 5` で個人広告の作成上限を強制
  - 取得 / 更新 / 削除はすべて `author_id` フィルタ越しなので、自分の広告以外には触れられない
  - `type` はフォームに出さず内部で `"one"` 固定

### Adapter / Routing
- `adapter/manage.py`
  - `ManageAdvertiseAPI` クラスを追加（list / get / post / put / delete）
  - `convert_advertises(list[AdvertiseData]) -> list[AdvertiseOut]` ヘルパ
- `routers.py`
  - `/manage/advertise` を tag `Manage Advertise` で登録

### DI
- `injectors/index.py`
  - `AdvertiseModule(Module)` の定義（`AdvertiseRepository → AdvertiseInterface`）

### Model
- `db/models/common.py`
  - `Advertise.image` / `video` に `upload_to=advertise_image_upload` / `advertise_video_upload` と `max_length=255`
  - `Advertise.period` を `blank=True, null=True` に
  - `Advertise.type` のデフォルトを `"one"` に

### Util
- `utils/enum/index.py`: `ImageUpload.ADVERTISE = "advertise"`
- `utils/functions/file.py`: `advertise_image_path` / `advertise_video_path` / `advertise_image_upload` / `advertise_video_upload`
  - パス形式: `images/advertise/user_{ulid}/{new_ulid}_{filename}` / `videos/advertise/user_{ulid}/{new_ulid}_{filename}`
- `utils/functions/media.py`: `save_upload` の `match` 文で `ImageUpload.ADVERTISE` / `MediaUpload.ADVERTISE` を分岐

## マイグレーション
`migrations/` は `.gitignore` 配下のため本 PR には含まれない。`Advertise.image` / `video` / `period` / `type` に対する `AlterField` を `makemigrations` で生成し適用する必要がある。

## 補足
- 本 PR はドメイン層の PR (#796) を依存先とする（`AdvertiseInterface` / `AdvertiseRepository` を import）
- 配信ロジック（実際にメディア詳細に広告枠を表示する処理）は別タスク