### PR TITLE
【back】広告の配信側 API（公開取得・閲覧数増分）を追加

### DIFF
--- a/myus/api/src/adapter/advertise.py
+++ b/myus/api/src/adapter/advertise.py
@@ -1,0 +1,52 @@
+from django.http import HttpRequest
+from ninja import Router
+from api.modules.logger import log
+from api.src.domain.interface.advertise.data import AdvertiseData
+from api.src.types.schema.advertise import AdvertiseListOut, AdvertiseOut, AdvertiseReadOut
+from api.src.types.schema.common import ErrorOut
+from api.src.usecase.advertise import get_user_advertises, increment_advertise_read
+
+
+class AdvertiseAPI:
+    """AdvertiseAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.get("/user/{user_ulid}", response={200: AdvertiseListOut})
+    def list_by_user(request: HttpRequest, user_ulid: str):
+        log.info("AdvertiseAPI list_by_user", user_ulid=user_ulid)
+
+        objs = get_user_advertises(user_ulid)
+        return 200, AdvertiseListOut(datas=convert_advertises(objs), total=len(objs))
+
+    @staticmethod
+    @router.post("/{ulid}/read", response={200: AdvertiseReadOut, 404: ErrorOut})
+    def post_read(request: HttpRequest, ulid: str):
+        log.info("AdvertiseAPI post_read", ulid=ulid)
+
+        new_count = increment_advertise_read(ulid)
+        if new_count is None:
+            return 404, ErrorOut(message="Advertise not found")
+
+        return 200, AdvertiseReadOut(read=new_count)
+
+
+def convert_advertises(objs: list[AdvertiseData]) -> list[AdvertiseOut]:
+    return [
+        AdvertiseOut(
+            ulid=o.ulid,
+            title=o.title,
+            url=o.url,
+            content=o.content,
+            image=o.image,
+            video=o.video,
+            read=o.read,
+            type=o.type,
+            period=o.period,
+            publish=o.publish,
+            created=o.created,
+            updated=o.updated,
+        )
+        for o in objs
+    ]

--- a/myus/api/src/adapter/manage.py
+++ b/myus/api/src/adapter/manage.py
@@ -1,8 +1,8 @@
 from django.http import HttpRequest
 from ninja import File, Form, Router, UploadedFile
 from api.modules.logger import log
+from api.src.adapter.advertise import convert_advertises
 from api.src.adapter.media import convert_videos, convert_musics, convert_blogs, convert_comics, convert_pictures, convert_chats
-from api.src.domain.interface.advertise.data import AdvertiseData
 from api.src.types.schema.advertise import AdvertiseIn, AdvertiseListOut, AdvertiseOut, AdvertiseUpdateIn
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.media.input import BulkDeleteIn, VideoUpdateIn, MusicUpdateIn, BlogUpdateIn, ComicUpdateIn, PictureUpdateIn, ChatUpdateIn
@@ -461,23 +461,3 @@ class ManageAdvertiseAPI:
             return 400, ErrorOut(message="削除に失敗しました!")
 
         return 204, ErrorOut(message="削除しました!")
-
-
-def convert_advertises(objs: list[AdvertiseData]) -> list[AdvertiseOut]:
-    return [
-        AdvertiseOut(
-            ulid=o.ulid,
-            title=o.title,
-            url=o.url,
-            content=o.content,
-            image=o.image,
-            video=o.video,
-            read=o.read,
-            type=o.type,
-            period=o.period,
-            publish=o.publish,
-            created=o.created,
-            updated=o.updated,
-        )
-        for o in objs
-    ]

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -1,4 +1,5 @@
 from ninja import NinjaAPI
+from api.src.adapter.advertise import AdvertiseAPI
 from api.src.adapter.auth import AuthAPI
 from api.src.adapter.category import CategoryAPI
 from api.src.adapter.comment import CommentAPI
@@ -42,3 +43,5 @@ api.add_router("/media/category", CategoryAPI().router, tags=["Media Category"])
 api.add_router("/media/hashtag", MediaHashtagAPI().router, tags=["Media Hashtag"])
 api.add_router("/media/comment", CommentAPI().router, tags=["Media Comment"])
 api.add_router("/media/message", MessageAPI().router, tags=["Media Message"])
+
+api.add_router("/advertise", AdvertiseAPI().router, tags=["Advertise"])

--- a/myus/api/src/types/schema/advertise.py
+++ b/myus/api/src/types/schema/advertise.py
@@ -36,3 +36,7 @@ class AdvertiseOut(BaseModel):
 class AdvertiseListOut(BaseModel):
     datas: list[AdvertiseOut]
     total: int
+
+
+class AdvertiseReadOut(BaseModel):
+    read: int

--- a/myus/api/src/usecase/advertise.py
+++ b/myus/api/src/usecase/advertise.py
@@ -1,0 +1,58 @@
+import random
+from dataclasses import replace
+from datetime import date
+from django.utils import timezone
+from api.modules.logger import log
+from api.src.domain.interface.advertise.data import AdvertiseData
+from api.src.domain.interface.advertise.interface import AdvertiseInterface
+from api.src.domain.interface.media.index import ExcludeOption, FilterOption, PageOption, SortOption
+from api.src.injectors.container import injector
+from api.src.usecase.user import get_user_data
+from api.utils.functions.index import create_url
+
+
+def get_user_advertises(user_ulid: str) -> list[AdvertiseData]:
+    user = get_user_data(ulid=user_ulid)
+    if user is None:
+        log.info("User not found", user_ulid=user_ulid)
+        return []
+
+    max_count = user.user_plan.plan.max_advertise
+    if max_count <= 0:
+        return []
+
+    repository = injector.get(AdvertiseInterface)
+    ids = repository.get_ids(FilterOption(owner_id=user.user.id, publish=True), ExcludeOption(), SortOption(), PageOption())
+    if len(ids) == 0:
+        return []
+
+    objs = repository.bulk_get(ids)
+    today = timezone.now().date()
+    active = [o for o in objs if is_active(o, today)]
+    if len(active) == 0:
+        return []
+
+    sample_size = min(max_count, len(active))
+    picked = random.sample(active, sample_size)
+    return [replace(a, image=create_url(a.image), video=create_url(a.video)) for a in picked]
+
+
+def increment_advertise_read(ulid: str) -> int | None:
+    repository = injector.get(AdvertiseInterface)
+    ids = repository.get_ids(FilterOption(ulid=ulid, publish=True), ExcludeOption(), SortOption(), PageOption())
+    if len(ids) == 0:
+        log.info("Advertise not found", ulid=ulid)
+        return None
+
+    obj = repository.bulk_get(ids)[0]
+    updated = replace(obj, read=obj.read + 1)
+    repository.bulk_save([updated])
+    return updated.read
+
+
+def is_active(ad: AdvertiseData, today: date) -> bool:
+    if ad.type != "one":
+        return False
+    if ad.period is None:
+        return True
+    return ad.period >= today


### PR DESCRIPTION
## Summary
- 旧 `app.views` の `UserPageAdvertise` / `advertise_read` 相当を新 API に移行
- `GET /advertise/user/{user_ulid}` でユーザーの公開広告をプランの `max_advertise` 件までランダム取得
- `POST /advertise/{ulid}/read` で閲覧数を +1

## 変更内容

### 新規ファイル
- `usecase/advertise.py`
  - `get_user_advertises(user_ulid)`: 該当ユーザーの公開広告を `get_ids` + `bulk_get` で取得し、`is_active` (`type='one'` かつ `period` が null または未来) で絞り込み、`Plan.max_advertise` 件を `random.sample`
  - `increment_advertise_read(ulid)`: `bulk_get` で 1 件取得 → `replace` で `read+1` → `bulk_save` で保存
  - `is_active`: 配信可能性判定の純粋関数
- `adapter/advertise.py`
  - `AdvertiseAPI` クラス：`list_by_user` (GET) / `post_read` (POST)
  - `convert_advertises`: `AdvertiseData -> AdvertiseOut` の変換関数（`adapter/manage.py` から移管）

### 変更
- `types/schema/advertise.py`: `AdvertiseReadOut(read: int)` を追加
- `adapter/manage.py`: `convert_advertises` の重複定義を削除し、`adapter/advertise.py` から import
- `routers.py`: `/advertise` を `tags=["Advertise"]` で登録

## 仕様補足
- 旧 view と異なり、新 API は **既存の repository インターフェース（`get_ids` / `bulk_get` / `bulk_save` / `count`）のみ**で実装。専用メソッドは生やさない方針
- 個人広告は最大 5 件まで作成可能なので、`bulk_get` 後に Python 側で `is_active` 絞り込みしても性能影響は無視できる
- `get_user_advertises` は **未認証でもアクセス可能**（広告は公開対象）
- `post_read` も **未認証でアクセス可能**。クリック計測用途で IP / ユーザーバインドはしない

## マージ順序
- 本 PR は `back_feat_advertise_domain` (#796) と `back_feat_advertise_api` (#797) を依存先とする
- `AdvertiseInterface` / `AdvertiseRepository` / 既存 schema が前提