### PR TITLE
【front】広告配信側 API のクライアント関数と URI を追加

### DIFF
--- a/frontend/src/api/internal/advertise.ts
+++ b/frontend/src/api/internal/advertise.ts
@@ -1,0 +1,14 @@
+import { apiClient } from 'lib/axios/internal'
+import { cookieHeader } from 'lib/config'
+import { ApiOut, apiOut } from 'lib/error'
+import { Req } from 'types/global'
+import { AdvertiseList } from 'types/internal/advertise'
+import { apiAdvertiseRead, apiAdvertiseUser } from 'api/uri'
+
+export const getUserAdvertises = async (userUlid: string, req?: Req): Promise<ApiOut<AdvertiseList>> => {
+  return await apiOut(apiClient('json').get(apiAdvertiseUser(userUlid), cookieHeader(req)))
+}
+
+export const postAdvertiseRead = async (ulid: string): Promise<ApiOut<{ read: number }>> => {
+  return await apiOut(apiClient('json').post(apiAdvertiseRead(ulid)))
+}

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -92,5 +92,8 @@ export const apiManageChat = (ulid: string) => base + `/manage/media/chat/${ulid
 export const apiManageAdvertises = base + '/manage/advertise'
 export const apiManageAdvertise = (ulid: string) => base + `/manage/advertise/${ulid}`
 
+export const apiAdvertiseUser = (userUlid: string) => base + `/advertise/user/${userUlid}`
+export const apiAdvertiseRead = (ulid: string) => base + `/advertise/${ulid}/read`
+
 // 外部API
 export const apiAddress = base + '/search'


### PR DESCRIPTION
## Summary
- 広告配信用エンドポイント `/api/advertise/user/{userUlid}` と `/api/advertise/{ulid}/read` の URI を追加
- 対応する API クライアント関数（`getUserAdvertises` / `postAdvertiseRead`）を新設

## 変更内容

### URI 追加
- `api/uri.ts`
  - `apiAdvertiseUser(userUlid)` = `/api/advertise/user/{userUlid}`
  - `apiAdvertiseRead(ulid)` = `/api/advertise/{ulid}/read`

### API クライアント
- `api/internal/advertise.ts` 新規
  - `getUserAdvertises(userUlid, req?)`: ユーザーの公開広告一覧（`AdvertiseList` を返す）。SSR でも使えるよう `req` パラメータを受け取る
  - `postAdvertiseRead(ulid)`: 広告閲覧数を +1。レスポンスは `{ read: number }`

## 補足
- 本 PR はバックエンド側の配信 API PR (#798) を依存先とする
- 実際にメディア詳細画面等で広告枠を描画する UI 実装は別タスク