### PR TITLE
【back】頻出クエリパターンに対応する DB インデックスを追加

### DIFF
--- a/myus/api/db/models/channel.py
+++ b/myus/api/db/models/channel.py
@@ -24,3 +24,4 @@ class Channel(models.Model):
     class Meta:
         db_table = "channel"
         verbose_name_plural = "Channel"
+        indexes = [models.Index(fields=["owner", "is_default"], name="channel_owner_default_idx")]

--- a/myus/api/db/models/common.py
+++ b/myus/api/db/models/common.py
@@ -46,3 +46,4 @@ class Advertise(models.Model):
     class Meta:
         db_table = "advertise"
         verbose_name_plural = "12 広告設定"
+        indexes = [models.Index(fields=["author", "publish", "type"], name="advertise_author_pub_type_idx")]

--- a/myus/api/db/models/media.py
+++ b/myus/api/db/models/media.py
@@ -30,6 +30,10 @@ class Video(models.Model, MediaModel):
     class Meta:
         db_table = "video"
         verbose_name_plural = "01 Video"
+        indexes = [
+            models.Index(fields=["channel", "publish"], name="video_channel_publish_idx"),
+            models.Index(fields=["publish", "-created"], name="video_publish_created_idx"),
+        ]
 
 
 # Music
@@ -54,6 +58,10 @@ class Music(models.Model, MediaModel):
     class Meta:
         db_table = "music"
         verbose_name_plural = "02 Music"
+        indexes = [
+            models.Index(fields=["channel", "publish"], name="music_channel_publish_idx"),
+            models.Index(fields=["publish", "-created"], name="music_publish_created_idx"),
+        ]
 
 
 # Blog
@@ -77,6 +85,10 @@ class Blog(models.Model, MediaModel):
     class Meta:
         db_table = "blog"
         verbose_name_plural = "03 Blog"
+        indexes = [
+            models.Index(fields=["channel", "publish"], name="blog_channel_publish_idx"),
+            models.Index(fields=["publish", "-created"], name="blog_publish_created_idx"),
+        ]
 
 
 # Comic
@@ -99,6 +111,10 @@ class Comic(models.Model, MediaModel):
     class Meta:
         db_table = "comic"
         verbose_name_plural = "04 Comic"
+        indexes = [
+            models.Index(fields=["channel", "publish"], name="comic_channel_publish_idx"),
+            models.Index(fields=["publish", "-created"], name="comic_publish_created_idx"),
+        ]
 
 
 class ComicPage(models.Model):
@@ -136,6 +152,10 @@ class Picture(models.Model, MediaModel):
     class Meta:
         db_table = "picture"
         verbose_name_plural = "05 Picture"
+        indexes = [
+            models.Index(fields=["channel", "publish"], name="picture_channel_publish_idx"),
+            models.Index(fields=["publish", "-created"], name="picture_publish_created_idx"),
+        ]
 
 
 # Chat
@@ -176,3 +196,7 @@ class Chat(models.Model):
     class Meta:
         db_table = "chat"
         verbose_name_plural = "06 Chat"
+        indexes = [
+            models.Index(fields=["channel", "publish"], name="chat_channel_publish_idx"),
+            models.Index(fields=["publish", "-created"], name="chat_publish_created_idx"),
+        ]

--- a/myus/api/db/models/notification.py
+++ b/myus/api/db/models/notification.py
@@ -44,4 +44,5 @@ class Notification(models.Model):
         indexes = [
             models.Index(fields=["user_from", "user_to"], name="notification_from_to_idx"),
             models.Index(fields=["type_no", "object_id"], name="notification_type_object_idx"),
+            models.Index(fields=["user_to", "-created"], name="notification_to_created_idx"),
         ]

--- a/myus/api/db/models/users.py
+++ b/myus/api/db/models/users.py
@@ -17,6 +17,7 @@ class SearchTag(models.Model):
     class Meta:
         db_table = "searchtag"
         verbose_name_plural = "08 検索タグ"
+        indexes = [models.Index(fields=["author", "sequence"], name="searchtag_author_seq_idx")]
 
 
 class Follow(models.Model):


### PR DESCRIPTION
## Summary
- メディア 6 モデルに `(channel, publish)` と `(publish, -created)` の複合インデックスを追加
- Channel / Advertise / Notification / SearchTag に頻出クエリ向けの複合インデックスを追加
- 計 16 個のインデックスを追加し、`get_ids` / 配信 API / 投稿管理 / 通知一覧の絞り込みとソートを高速化

## 変更内容

### Media 系（6 モデル × 2 個）
| 用途 | フィールド |
|---|---|
| 投稿管理（自分のメディア）／チャンネル別公開取得 | `(channel, publish)` |
| 公開メディアの新着順／recommend 候補 | `(publish, -created)` |

対象: `Video` / `Music` / `Blog` / `Comic` / `Picture` / `Chat`（`api/db/models/media.py`）

### その他
| モデル | インデックス | 用途 |
|---|---|---|
| `Channel` | `(owner, is_default)` | デフォルトチャンネル取得（メディア作成時の頻出ルート）|
| `Advertise` | `(author, publish, type)` | 配信側 `list_by_user` の3条件 AND 絞り込み |
| `Notification` | `(user_to, -created)` | 受信通知の新着順 |
| `SearchTag` | `(author, sequence)` | ユーザーごとの順序付き取得 |

### 追加しなかったもの（理由）
- `Comment` / `Message`: 既に `parent` と `(type_no, object_id)` がカバー
- `Subscribe` / `Follow` / `AccessLog` / `Plan`: 既に十分
- `ComicPage`: `UniqueConstraint(comic, sequence)` が実質 index 化
- ハッシュタグ through テーブル: `unique_together(media, hashtag)` でカバー
- `User` / `Profile` / `MyPage` / `UserNotification` / `UserPlan`: `unique` / `OneToOne` で十分

## マイグレーション
`migrations/` は `.gitignore` 配下のため本 PR には含まれない。各環境で `uv run python manage.py makemigrations db && migrate` を実行（`AddIndex` のみの 16 操作になるよう、生成後に ulid 系 AlterField のノイズを除去するのが推奨）。

## 補足
- `-created` は MySQL 8.0+ の descending index。現行環境は MySQL 8.4 で問題なし
- `(publish, -created)` は `WHERE publish=true ORDER BY created DESC` の典型クエリで filesort を不要にできる
- 書き込みコストは上がるがメディア系は read-heavy なので妥当なトレードオフ