### PR TITLE
【front】投稿管理画面のヘッダ／一覧を共通コンポーネント化

### DIFF
--- a/frontend/src/components/templates/manage/_container/Header/Header.module.scss
+++ b/frontend/src/components/templates/manage/_container/Header/Header.module.scss
@@ -1,0 +1,15 @@
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .count {
+    font-size: 13px;
+    color: rgb(80, 80, 80);
+    white-space: nowrap;
+  }
+
+  .filter {
+    width: 240px;
+  }
+}

--- a/frontend/src/components/templates/manage/_container/Header/index.tsx
+++ b/frontend/src/components/templates/manage/_container/Header/index.tsx
@@ -1,0 +1,33 @@
+import { ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { Option } from 'types/internal/other'
+import Button from 'components/parts/Button'
+import SelectBox from 'components/parts/Input/SelectBox'
+import style from './Header.module.scss'
+
+interface Props {
+  count: number
+  ulid: string
+  options: Option[]
+  onDelete: () => void
+  onChange: (e: ChangeEvent<HTMLSelectElement>) => void
+}
+
+export default function ManageHeader(props: Props): React.JSX.Element {
+  const { count, ulid, options, onDelete, onChange } = props
+
+  const router = useRouter()
+
+  return (
+    <div className={style.header}>
+      {count > 0 && (
+        <>
+          <span className={style.count}>{count}件選択</span>
+          <Button color="red" size="s" name="一括削除" onClick={onDelete} />
+        </>
+      )}
+      <Button color="blue" size="s" name="投稿管理" onClick={() => router.push('/manage')} />
+      <SelectBox value={ulid} options={options} className={style.filter} onChange={onChange} />
+    </div>
+  )
+}

--- a/frontend/src/components/templates/manage/_container/List/List.module.scss
+++ b/frontend/src/components/templates/manage/_container/List/List.module.scss
@@ -1,0 +1,5 @@
+.manage {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/frontend/src/components/templates/manage/_container/List/index.tsx
+++ b/frontend/src/components/templates/manage/_container/List/index.tsx
@@ -1,0 +1,56 @@
+import DataTable, { Column } from 'components/parts/DataTable'
+import Pagination from 'components/parts/Pagination'
+import DeleteModal from 'components/widgets/Modal/Delete'
+import style from './List.module.scss'
+
+interface Props<T> {
+  table: {
+    datas: T[]
+    columns: Column<T>[]
+    rowKey: (row: T) => string
+  }
+  selection: {
+    keys: Set<string>
+    onChange: (keys: Set<string>) => void
+  }
+  pagination: {
+    current: number
+    total: number
+    onChange: (page: number) => void
+  }
+  deletion: {
+    label: string
+    open: boolean
+    loading: boolean
+    onClose: () => void
+    onAction: () => void
+  }
+}
+
+export default function ManageList<T>(props: Props<T>): React.JSX.Element {
+  const { table, selection, pagination, deletion } = props
+
+  return (
+    <>
+      <div className={style.manage}>
+        <DataTable
+          datas={table.datas}
+          columns={table.columns}
+          rowKey={table.rowKey}
+          selectable
+          selectedKeys={selection.keys}
+          onSelection={selection.onChange}
+          footer={<Pagination currentPage={pagination.current} totalPages={pagination.total} onChange={pagination.onChange} />}
+        />
+      </div>
+      <DeleteModal
+        open={deletion.open}
+        title={`${deletion.label}の削除`}
+        content={`${selection.keys.size}件の${deletion.label}を削除しますか？`}
+        loading={deletion.loading}
+        onClose={deletion.onClose}
+        onAction={deletion.onAction}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- 各メディア管理画面に重複していた「ヘッダ操作群」と「テーブル + 削除モーダル」を共通コンポーネント化
- `templates/manage/_container/` 配下に `Header` / `List` の 2 つを追加

## 変更内容

### `_container/Header`
ヘッダ右側のアクション群を集約。
- 「一括削除」ボタン（選択時のみ表示）
- 「投稿管理」ボタン（`/manage` メニューへ遷移）
- チャンネル選択 SelectBox

```ts
interface Props {
  count: number
  ulid: string
  options: Option[]
  onDelete: () => void
  onChange: (e: ChangeEvent<HTMLSelectElement>) => void
}
```

### `_container/List<T>`
テーブル本体と削除モーダルを集約。Props を 4 グループに整理：

```ts
interface Props<T> {
  table:      { datas: T[]; columns: Column<T>[]; rowKey: (row: T) => string }
  selection:  { keys: Set<string>; onChange: (keys: Set<string>) => void }
  pagination: { current: number; total: number; onChange: (page: number) => void }
  deletion:   { label: string; open: boolean; loading: boolean; onClose: () => void; onAction: () => void }
}
```

- `deletion.label` を渡すだけで削除モーダルの title / content（`{label}の削除` / `N件の{label}を削除しますか？`）が決まる
- 削除モーダルは MediaType ごとの差分が文言だけなので、これで完全共通化

### 配置
- `widgets/` ではなく `templates/manage/_container/` に配置（汎用的でなく manage 配下でしか使わないため）
- アンダースコア prefix で「ページ本体ではなく内部実装」であることを示す

## 補足
- 利用側（video / music / blog / comic / picture / chat / advertise の各管理画面）への差し替えは別 PR で対応
- ジェネリック `T` の推論が nested object 越しでは効かないので、利用側では `<ManageList<Video>` のように明示的な型引数指定が必要
- `delete` を Props キーにすると TS パーサが予約語として解釈して parse error になるため、`deletion` を採用