### PR TITLE
【front】各管理画面を共通 Header / List コンポーネントへ差し替え

### DIFF
--- a/frontend/src/components/templates/manage/advertise/index.tsx
+++ b/frontend/src/components/templates/manage/advertise/index.tsx
@@ -138,6 +138,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
               <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
             </>
           )}
+          <Button color="blue" size="s" name="投稿管理" onClick={() => router.push('/manage')} />
           <Button color="green" size="s" name={`作成 (${total}/${ADVERTISE_LIMIT})`} disabled={isLimitReached} onClick={handleCreate} />
         </div>
       }

--- a/frontend/src/components/templates/manage/blog/index.tsx
+++ b/frontend/src/components/templates/manage/blog/index.tsx
@@ -11,14 +11,12 @@ import { useIsLoading } from 'components/hooks/useIsLoading'
 import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
-import Button from 'components/parts/Button'
-import DataTable, { Column } from 'components/parts/DataTable'
+import { Column } from 'components/parts/DataTable'
 import ExImage from 'components/parts/ExImage'
-import SelectBox from 'components/parts/Input/SelectBox'
 import Toggle from 'components/parts/Input/Toggle'
-import Pagination from 'components/parts/Pagination'
-import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
+import ManageHeader from '../_container/Header'
+import ManageList from '../_container/List'
 
 interface Props {
   datas: Blog[]
@@ -139,36 +137,13 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={
-        <div className={style.header_actions}>
-          {selectedKeys.size > 0 && (
-            <>
-              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
-            </>
-          )}
-          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
-        </div>
-      }
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
     >
-      <div className={style.manage}>
-        <DataTable
-          datas={datas}
-          columns={columns}
-          rowKey={(b) => b.ulid}
-          selectable
-          selectedKeys={selectedKeys}
-          onSelection={setSelectedKeys}
-          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
-        />
-      </div>
-      <DeleteModal
-        open={isDeleteModal}
-        title="ブログの削除"
-        content={`${selectedKeys.size}件のブログを削除しますか？`}
-        loading={isLoading}
-        onClose={handleDelete}
-        onAction={handleDeleteSubmit}
+      <ManageList<Blog>
+        table={{ datas, columns, rowKey: (b) => b.ulid }}
+        selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
+        pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
+        deletion={{ label: 'ブログ', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/chat/index.tsx
+++ b/frontend/src/components/templates/manage/chat/index.tsx
@@ -11,13 +11,11 @@ import { useIsLoading } from 'components/hooks/useIsLoading'
 import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
-import Button from 'components/parts/Button'
-import DataTable, { Column } from 'components/parts/DataTable'
-import SelectBox from 'components/parts/Input/SelectBox'
+import { Column } from 'components/parts/DataTable'
 import Toggle from 'components/parts/Input/Toggle'
-import Pagination from 'components/parts/Pagination'
-import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
+import ManageHeader from '../_container/Header'
+import ManageList from '../_container/List'
 
 interface Props {
   datas: Chat[]
@@ -150,36 +148,13 @@ export default function ManageChats(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={
-        <div className={style.header_actions}>
-          {selectedKeys.size > 0 && (
-            <>
-              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
-            </>
-          )}
-          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
-        </div>
-      }
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
     >
-      <div className={style.manage}>
-        <DataTable
-          datas={datas}
-          columns={columns}
-          rowKey={(c) => c.ulid}
-          selectable
-          selectedKeys={selectedKeys}
-          onSelection={setSelectedKeys}
-          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
-        />
-      </div>
-      <DeleteModal
-        open={isDeleteModal}
-        title="チャットの削除"
-        content={`${selectedKeys.size}件のチャットを削除しますか？`}
-        loading={isLoading}
-        onClose={handleDelete}
-        onAction={handleDeleteSubmit}
+      <ManageList<Chat>
+        table={{ datas, columns, rowKey: (c) => c.ulid }}
+        selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
+        pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
+        deletion={{ label: 'チャット', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/comic/index.tsx
+++ b/frontend/src/components/templates/manage/comic/index.tsx
@@ -11,14 +11,12 @@ import { useIsLoading } from 'components/hooks/useIsLoading'
 import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
-import Button from 'components/parts/Button'
-import DataTable, { Column } from 'components/parts/DataTable'
+import { Column } from 'components/parts/DataTable'
 import ExImage from 'components/parts/ExImage'
-import SelectBox from 'components/parts/Input/SelectBox'
 import Toggle from 'components/parts/Input/Toggle'
-import Pagination from 'components/parts/Pagination'
-import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
+import ManageHeader from '../_container/Header'
+import ManageList from '../_container/List'
 
 interface Props {
   datas: Comic[]
@@ -139,36 +137,13 @@ export default function ManageComics(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={
-        <div className={style.header_actions}>
-          {selectedKeys.size > 0 && (
-            <>
-              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
-            </>
-          )}
-          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
-        </div>
-      }
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
     >
-      <div className={style.manage}>
-        <DataTable
-          datas={datas}
-          columns={columns}
-          rowKey={(c) => c.ulid}
-          selectable
-          selectedKeys={selectedKeys}
-          onSelection={setSelectedKeys}
-          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
-        />
-      </div>
-      <DeleteModal
-        open={isDeleteModal}
-        title="漫画の削除"
-        content={`${selectedKeys.size}件の漫画を削除しますか？`}
-        loading={isLoading}
-        onClose={handleDelete}
-        onAction={handleDeleteSubmit}
+      <ManageList<Comic>
+        table={{ datas, columns, rowKey: (c) => c.ulid }}
+        selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
+        pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
+        deletion={{ label: '漫画', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/music/index.tsx
+++ b/frontend/src/components/templates/manage/music/index.tsx
@@ -11,13 +11,11 @@ import { useIsLoading } from 'components/hooks/useIsLoading'
 import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
-import Button from 'components/parts/Button'
-import DataTable, { Column } from 'components/parts/DataTable'
-import SelectBox from 'components/parts/Input/SelectBox'
+import { Column } from 'components/parts/DataTable'
 import Toggle from 'components/parts/Input/Toggle'
-import Pagination from 'components/parts/Pagination'
-import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
+import ManageHeader from '../_container/Header'
+import ManageList from '../_container/List'
 
 interface Props {
   datas: Music[]
@@ -146,36 +144,13 @@ export default function ManageMusics(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={
-        <div className={style.header_actions}>
-          {selectedKeys.size > 0 && (
-            <>
-              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
-            </>
-          )}
-          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
-        </div>
-      }
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
     >
-      <div className={style.manage}>
-        <DataTable
-          datas={datas}
-          columns={columns}
-          rowKey={(m) => m.ulid}
-          selectable
-          selectedKeys={selectedKeys}
-          onSelection={setSelectedKeys}
-          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
-        />
-      </div>
-      <DeleteModal
-        open={isDeleteModal}
-        title="音楽の削除"
-        content={`${selectedKeys.size}件の音楽を削除しますか？`}
-        loading={isLoading}
-        onClose={handleDelete}
-        onAction={handleDeleteSubmit}
+      <ManageList<Music>
+        table={{ datas, columns, rowKey: (m) => m.ulid }}
+        selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
+        pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
+        deletion={{ label: '音楽', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/picture/index.tsx
+++ b/frontend/src/components/templates/manage/picture/index.tsx
@@ -11,14 +11,12 @@ import { useIsLoading } from 'components/hooks/useIsLoading'
 import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
-import Button from 'components/parts/Button'
-import DataTable, { Column } from 'components/parts/DataTable'
+import { Column } from 'components/parts/DataTable'
 import ExImage from 'components/parts/ExImage'
-import SelectBox from 'components/parts/Input/SelectBox'
 import Toggle from 'components/parts/Input/Toggle'
-import Pagination from 'components/parts/Pagination'
-import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
+import ManageHeader from '../_container/Header'
+import ManageList from '../_container/List'
 
 interface Props {
   datas: Picture[]
@@ -139,36 +137,13 @@ export default function ManagePictures(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={
-        <div className={style.header_actions}>
-          {selectedKeys.size > 0 && (
-            <>
-              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
-            </>
-          )}
-          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
-        </div>
-      }
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
     >
-      <div className={style.manage}>
-        <DataTable
-          datas={datas}
-          columns={columns}
-          rowKey={(p) => p.ulid}
-          selectable
-          selectedKeys={selectedKeys}
-          onSelection={setSelectedKeys}
-          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
-        />
-      </div>
-      <DeleteModal
-        open={isDeleteModal}
-        title="画像の削除"
-        content={`${selectedKeys.size}件の画像を削除しますか？`}
-        loading={isLoading}
-        onClose={handleDelete}
-        onAction={handleDeleteSubmit}
+      <ManageList<Picture>
+        table={{ datas, columns, rowKey: (p) => p.ulid }}
+        selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
+        pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
+        deletion={{ label: '画像', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -11,14 +11,12 @@ import { useIsLoading } from 'components/hooks/useIsLoading'
 import { usePagination } from 'components/hooks/usePagination'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
-import Button from 'components/parts/Button'
-import DataTable, { Column } from 'components/parts/DataTable'
+import { Column } from 'components/parts/DataTable'
 import ExImage from 'components/parts/ExImage'
-import SelectBox from 'components/parts/Input/SelectBox'
 import Toggle from 'components/parts/Input/Toggle'
-import Pagination from 'components/parts/Pagination'
-import DeleteModal from 'components/widgets/Modal/Delete'
 import style from '../Media.module.scss'
+import ManageHeader from '../_container/Header'
+import ManageList from '../_container/List'
 
 interface Props {
   datas: Video[]
@@ -139,36 +137,13 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={
-        <div className={style.header_actions}>
-          {selectedKeys.size > 0 && (
-            <>
-              <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
-            </>
-          )}
-          <SelectBox value={channelUlid} options={channelOptions} className={style.filter} onChange={handleChannel} />
-        </div>
-      }
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
     >
-      <div className={style.manage}>
-        <DataTable
-          datas={datas}
-          columns={columns}
-          rowKey={(v) => v.ulid}
-          selectable
-          selectedKeys={selectedKeys}
-          onSelection={setSelectedKeys}
-          footer={<Pagination currentPage={currentPage} totalPages={totalPages} onChange={handlePage} />}
-        />
-      </div>
-      <DeleteModal
-        open={isDeleteModal}
-        title="動画の削除"
-        content={`${selectedKeys.size}件の動画を削除しますか？`}
-        loading={isLoading}
-        onClose={handleDelete}
-        onAction={handleDeleteSubmit}
+      <ManageList<Video>
+        table={{ datas, columns, rowKey: (v) => v.ulid }}
+        selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
+        pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
+        deletion={{ label: '動画', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )


### PR DESCRIPTION
## Summary
- 6 メディアの管理画面 (video / music / blog / comic / picture / chat) のヘッダ操作群と一覧テーブルを `_container/Header` / `_container/List<T>` に差し替え
- 削除モーダル文言を `deletion.label` から自動生成
- 重複していた合計 200 行超を削除

## 変更内容

### ヘッダ部 (各 media)
変更前:
```tsx
<div className={style.header_actions}>
  {selectedKeys.size > 0 && (...)}
  <Button color="blue" size="s" name="投稿管理" onClick={...} />
  <SelectBox value={channelUlid} options={channelOptions} ... />
</div>
```

変更後:
```tsx
<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />
```

### 一覧 + 削除モーダル部 (各 media)
変更前:
```tsx
<div className={style.manage}>
  <DataTable datas={...} columns={...} rowKey={...} selectable selectedKeys={...} onSelection={...} footer={<Pagination ... />} />
</div>
<DeleteModal open={isDeleteModal} title="動画の削除" content={`${selectedKeys.size}件の動画を削除しますか？`} ... />
```

変更後:
```tsx
<ManageList<Video>
  table={{ datas, columns, rowKey: (v) => v.ulid }}
  selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
  pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
  deletion={{ label: '動画', open: isDeleteModal, loading: isLoading, onClose: handleDelete, onAction: handleDeleteSubmit }}
/>
```

ジェネリック `T` の推論が nested object 越しでは効かないため、各画面で `<ManageList<MediaType>` の型引数を明示。

### import 整理
共通化に伴い、各画面で不要となった `Button` / `SelectBox` / `DataTable` / `Pagination` / `DeleteModal` の import を削除。`Column` 型のみ DataTable から残置。

### advertise
`advertise/index.tsx` はチャンネル選択がなく作成ボタンを持つ独自構造のため、Header のみ仮対応した状態（`import { useRouter }` の小さな整理のみ）。本格的な共通化は別途。

## 補足
- 本 PR は共通コンポーネント追加 PR (#801) を依存先とする
- マージ順序: `#801` (共通コンポーネント) → 本 PR (利用側) で安全