### PR TITLE
【front】SelectBox に省略表示を追加し管理画面の SCSS を整理

### DIFF
--- a/frontend/src/components/layout/Main/Main.module.scss
+++ b/frontend/src/components/layout/Main/Main.module.scss
@@ -20,6 +20,7 @@
     font-size: 24px;
     color: rgb(50, 70, 140);
     user-select: none;
+    white-space: nowrap;
 
     span {
       font-size: 18px;

--- a/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
+++ b/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
@@ -15,9 +15,10 @@
     .select {
       width: 100%;
       height: 36px;
-      padding: 6px 12px;
+      padding: 6px 20px 6px 12px;
       appearance: none;
       font-size: 14px;
+      text-overflow: ellipsis;
       border: 1px solid rgb(200, 200, 200);
       border-radius: 5px;
       background: rgb(255, 255, 255);

--- a/frontend/src/components/parts/Modal/Modal.module.scss
+++ b/frontend/src/components/parts/Modal/Modal.module.scss
@@ -104,7 +104,6 @@
 
 @media (max-width: 640px) {
   .container {
-
     &.s,
     &.m,
     &.l {

--- a/frontend/src/components/templates/manage/Media.module.scss
+++ b/frontend/src/components/templates/manage/Media.module.scss
@@ -1,9 +1,3 @@
-.manage {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
 .header_actions {
   display: flex;
   align-items: center;
@@ -14,10 +8,6 @@
     color: rgb(80, 80, 80);
     white-space: nowrap;
   }
-}
-
-.filter {
-  width: 240px;
 }
 
 .thumbnail {
@@ -62,10 +52,6 @@
 
 .datetime {
   width: 120px;
-}
-
-.center {
-  text-align: center;
 }
 
 .number {

--- a/frontend/src/components/templates/manage/_container/Header/Header.module.scss
+++ b/frontend/src/components/templates/manage/_container/Header/Header.module.scss
@@ -1,7 +1,7 @@
 .header {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 
   .count {
     font-size: 13px;
@@ -9,7 +9,7 @@
     white-space: nowrap;
   }
 
-  .filter {
-    width: 240px;
+  .select_box {
+    width: 200px;
   }
 }

--- a/frontend/src/components/templates/manage/_container/Header/index.tsx
+++ b/frontend/src/components/templates/manage/_container/Header/index.tsx
@@ -27,7 +27,7 @@ export default function ManageHeader(props: Props): React.JSX.Element {
         </>
       )}
       <Button color="blue" size="s" name="投稿管理" onClick={() => router.push('/manage')} />
-      <SelectBox value={ulid} options={options} className={style.filter} onChange={onChange} />
+      <SelectBox value={ulid} options={options} className={style.select_box} onChange={onChange} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `SelectBox` の `<select>` にテキスト省略表示を追加し、▼アイコンとの重なりを解消
- 投稿管理ヘッダの `filter` クラスを `select_box` にリネームし width を 200px に調整
- 未使用 SCSS クラスの整理と細かな調整

## 変更内容

### `parts/Input/SelectBox`
- `.select` に `text-overflow: ellipsis` を追加し、収まりきらないテキストは「...」で省略表示
- `padding` を `6px 12px` → `6px 20px 6px 12px` に変更し ▼アイコン分の右余白を確保

### `templates/manage/_container/Header`
- `.filter` クラスを `.select_box` にリネーム（用途を明確化）
- `width: 240px` → `200px` に変更
- 各要素間の `gap` を `12px` → `8px` に調整
- `index.tsx` のクラス名参照を更新

### `templates/manage/Media.module.scss`
- 未使用クラスを削除：
  - `.manage`（`_container/Table` の同名クラスと重複）
  - `.filter`（`_container/Header` の同名クラスと重複）
  - `.center`（参照箇所なし）

### その他
- `layout/Main`: タイトルの折り返しを抑制するため `white-space: nowrap` を追加
- `parts/Modal`: メディアクエリ内の不要な空行を削除