### PR TITLE
【front】管理画面のタイトルを英語表記に統一し広告作成画面に戻るボタンを追加

### DIFF
--- a/frontend/src/components/templates/manage/advertise/create.tsx
+++ b/frontend/src/components/templates/manage/advertise/create.tsx
@@ -1,4 +1,5 @@
 import { useState, ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
 import { AdvertiseIn } from 'types/internal/advertise'
 import { postAdvertiseCreate } from 'api/internal/manage/create'
 import { FetchError } from 'utils/constants/enum'
@@ -11,14 +12,17 @@ import Input from 'components/parts/Input'
 import InputFile from 'components/parts/Input/File'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
+import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
 
 export default function AdvertiseCreate(): React.JSX.Element {
+  const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
   const { isRequired, isRequiredCheck } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<AdvertiseIn>({ title: '', url: '', content: '', publish: true, period: null })
 
+  const handleBack = () => router.push('/manage/advertise')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -40,8 +44,15 @@ export default function AdvertiseCreate(): React.JSX.Element {
     handleToast('作成しました', false)
   }
 
+  const button = (
+    <HStack gap="4">
+      <Button color="green" size="s" name="作成する" loading={isLoading} onClick={handleForm} />
+      <Button color="blue" size="s" name="戻る" onClick={handleBack} />
+    </HStack>
+  )
+
   return (
-    <Main title="広告作成" type="table" toast={toast} isFooter={false} button={<Button color="green" size="s" name="作成する" loading={isLoading} onClick={handleForm} />}>
+    <Main title="Advertise" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -65,7 +65,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="広告編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Advertise" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/advertise/index.tsx
+++ b/frontend/src/components/templates/manage/advertise/index.tsx
@@ -125,7 +125,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="広告管理"
+      title="Advertise"
       type="table"
       toast={toast}
       isFooter={false}
@@ -138,7 +138,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
             </>
           )}
           <Button color="blue" size="s" name="投稿管理" onClick={() => router.push('/manage')} />
-          <Button color="green" size="s" name={`作成 (${total}/${ADVERTISE_LIMIT})`} disabled={isLimitReached} onClick={handleCreate} />
+          <Button color="green" size="s" name="新規作成" disabled={isLimitReached} onClick={handleCreate} />
         </div>
       }
     >

--- a/frontend/src/components/templates/manage/blog/edit.tsx
+++ b/frontend/src/components/templates/manage/blog/edit.tsx
@@ -76,7 +76,7 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="ブログ編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Blog" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/blog/index.tsx
+++ b/frontend/src/components/templates/manage/blog/index.tsx
@@ -133,7 +133,7 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="ブログ管理"
+      title="Blog"
       type="table"
       toast={toast}
       isFooter={false}

--- a/frontend/src/components/templates/manage/chat/edit.tsx
+++ b/frontend/src/components/templates/manage/chat/edit.tsx
@@ -67,7 +67,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="チャット編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Chat" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/chat/index.tsx
+++ b/frontend/src/components/templates/manage/chat/index.tsx
@@ -144,7 +144,7 @@ export default function ManageChats(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="チャット管理"
+      title="Chat"
       type="table"
       toast={toast}
       isFooter={false}

--- a/frontend/src/components/templates/manage/comic/edit.tsx
+++ b/frontend/src/components/templates/manage/comic/edit.tsx
@@ -68,7 +68,7 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="漫画編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Comic" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/comic/index.tsx
+++ b/frontend/src/components/templates/manage/comic/index.tsx
@@ -133,7 +133,7 @@ export default function ManageComics(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="漫画管理"
+      title="Comic"
       type="table"
       toast={toast}
       isFooter={false}

--- a/frontend/src/components/templates/manage/music/edit.tsx
+++ b/frontend/src/components/templates/manage/music/edit.tsx
@@ -68,7 +68,7 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="音楽編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Music" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/music/index.tsx
+++ b/frontend/src/components/templates/manage/music/index.tsx
@@ -140,7 +140,7 @@ export default function ManageMusics(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="音楽管理"
+      title="Music"
       type="table"
       toast={toast}
       isFooter={false}

--- a/frontend/src/components/templates/manage/picture/edit.tsx
+++ b/frontend/src/components/templates/manage/picture/edit.tsx
@@ -68,7 +68,7 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="画像編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Picture" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/picture/index.tsx
+++ b/frontend/src/components/templates/manage/picture/index.tsx
@@ -133,7 +133,7 @@ export default function ManagePictures(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="画像管理"
+      title="Picture"
       type="table"
       toast={toast}
       isFooter={false}

--- a/frontend/src/components/templates/manage/video/edit.tsx
+++ b/frontend/src/components/templates/manage/video/edit.tsx
@@ -68,7 +68,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
   )
 
   return (
-    <Main title="動画編集" type="table" toast={toast} isFooter={false} button={button}>
+    <Main title="Video" type="table" toast={toast} isFooter={false} button={button}>
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -133,7 +133,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
 
   return (
     <Main
-      title="動画管理"
+      title="Video"
       type="table"
       toast={toast}
       isFooter={false}


### PR DESCRIPTION
## Summary
- 各管理画面（index / create / edit）の `title` を `/manage` メニューと同じ英語表記に統一
- 広告作成画面（`advertise/create.tsx`）に戻るボタンを追加
- 広告一覧の作成ボタン表記を `新規作成` に統一

## 変更内容

### タイトル統一
`/manage` メニューのラベル（`Video` / `Music` / `Blog` / `Comic` / `Picture` / `Chat` / `Advertise`）に合わせ、各管理画面のページタイトルを英語表記へ統一。

| カテゴリ | Before | After |
|----------|--------|-------|
| Video | 動画管理 / 動画編集 | Video |
| Music | 音楽管理 / 音楽編集 | Music |
| Blog | ブログ管理 / ブログ編集 | Blog |
| Comic | 漫画管理 / 漫画編集 | Comic |
| Picture | 画像管理 / 画像編集 | Picture |
| Chat | チャット管理 / チャット編集 | Chat |
| Advertise | 広告管理 / 広告作成 / 広告編集 | Advertise |

対象ファイル: 各カテゴリの `index.tsx` / `create.tsx`（advertise のみ） / `edit.tsx`

### `advertise/create.tsx` 戻るボタン追加
- `useRouter` / `HStack` の import 追加
- `handleBack = () => router.push('/manage/advertise')` を追加
- ヘッダボタンを `HStack` で「作成する」「戻る」の2つに変更（`edit.tsx` と同じパターン）

### `advertise/index.tsx` 作成ボタン表記統一
- 作成ボタンの表記を `作成 (X/N)` → `新規作成` に変更（他のリストと統一）