### PR TITLE
【front】site.webmanifest から存在しない 512x512 アイコン参照を削除

### DIFF
--- a/frontend/public/favicon/site.webmanifest
+++ b/frontend/public/favicon/site.webmanifest
@@ -6,11 +6,6 @@
             "src": "/favicon/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
-        },
-        {
-            "src": "/favicon/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
         }
     ],
     "theme_color": "#ffffff",


### PR DESCRIPTION
## Summary
- 存在しない `android-chrome-512x512.png` を webmanifest が参照していたため、開発サーバで 404 が頻発していた
- `frontend/public/favicon/` に存在する 192x192 のみを残し、512x512 のエントリを削除

## 変更内容

### `frontend/public/favicon/site.webmanifest`
- `android-chrome-512x512.png` のエントリを削除
- `frontend/public/favicon/` 配下に 512x512 のファイルは存在しないため、参照を削除して 404 を解消

### 補足
- 512x512 アイコンを追加したい場合は、画像ファイルを配置した上で webmanifest にエントリを戻す形で対応可能