### PR TITLE
【front】Input 系コンポーネントのエラー API を error?: string に統一

### DIFF
--- a/frontend/src/components/parts/Input/File/index.tsx
+++ b/frontend/src/components/parts/Input/File/index.tsx
@@ -4,23 +4,21 @@ import style from '../Input.module.scss'
 
 interface Props {
   label?: string
-  errorText?: string
   accept?: string
+  error?: string
   className?: string
-  error?: boolean
   required?: boolean
   multiple?: boolean
   onChange?: (files: File | File[]) => void
 }
 
 export default function InputFile(props: Props): React.JSX.Element {
-  const { label, errorText, accept, className, error = false, required = false, multiple, onChange } = props
+  const { label, accept, error, className, required = false, multiple, onChange } = props
 
   const inputEl = useRef<HTMLInputElement>(null)
   const [fileNames, setFileNames] = useState<string[]>([])
 
-  const isRequired = required && fileNames.length === 0
-  const isErrorText = !isRequired && error
+  const isError = !!error || (error === '' && required && fileNames.length === 0)
 
   const handleClick = () => inputEl.current?.click()
 
@@ -39,12 +37,12 @@ export default function InputFile(props: Props): React.JSX.Element {
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
+          {required && <span className={style.required}>*</span>}
         </label>
       )}
       <input id={label} ref={inputEl} type="file" accept={accept} onChange={handleChange} multiple={multiple} hidden />
-      <input placeholder="ファイル選択..." value={fileNames.join(', ')} required={required} onClick={handleClick} className={cx(style.input, isRequired && style.error)} />
-      {isRequired && <p className={style.error_text}>※必須入力です！</p>}
-      {isErrorText && <p className={style.error_text}>{errorText}</p>}
+      <input placeholder="ファイル選択..." value={fileNames.join(', ')} required={required} onClick={handleClick} className={cx(style.input, isError && style.error)} />
+      {error && <p className={style.error_text}>{error}</p>}
     </div>
   )
 }

--- a/frontend/src/components/parts/Input/Input.module.scss
+++ b/frontend/src/components/parts/Input/Input.module.scss
@@ -7,6 +7,12 @@
     display: block;
     font-size: 14px;
     color: rgb(50, 50, 50);
+
+    .required {
+      margin-left: 4px;
+      font-family: sans-serif;
+      color: rgb(220, 0, 0);
+    }
   }
 
   .input {

--- a/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
+++ b/frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss
@@ -7,6 +7,12 @@
     display: block;
     font-size: 14px;
     color: rgb(50, 50, 50);
+
+    .required {
+      margin-left: 4px;
+      font-family: sans-serif;
+      color: rgb(220, 0, 0);
+    }
   }
 
   .select_box {

--- a/frontend/src/components/parts/Input/SelectBox/index.tsx
+++ b/frontend/src/components/parts/Input/SelectBox/index.tsx
@@ -6,32 +6,34 @@ import style from './SelectBox.module.scss'
 
 interface Props {
   label?: string
-  name?: string
   value: string
-  options: Option[]
+  name?: string
   placeholder?: string
+  error?: string
+  className?: string
+  options: Option[]
   required?: boolean
   disabled?: boolean
-  className?: string
   onChange?: (e: ChangeEvent<HTMLSelectElement>) => void
 }
 
 export default function SelectBox(props: Props): React.JSX.Element {
-  const { label, value, required = false, className, ...rest } = props
+  const { label, value, error, className, required = false, ...rest } = props
 
-  const isRequired = required && !value
+  const isError = !!error || (error === '' && required && !value)
 
   return (
     <div className={cx(style.box, className)}>
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
+          {required && <span className={style.required}>*</span>}
         </label>
       )}
       <div className={style.select_box}>
-        <Select {...rest} value={value} id={label} className={cx(style.select, isRequired && style.error)} />
+        <Select {...rest} value={value} id={label} className={cx(style.select, isError && style.error)} />
       </div>
-      {isRequired && <p className={style.error_text}>※必須入力です！</p>}
+      {error && <p className={style.error_text}>{error}</p>}
     </div>
   )
 }

--- a/frontend/src/components/parts/Input/Textarea/Textarea.module.scss
+++ b/frontend/src/components/parts/Input/Textarea/Textarea.module.scss
@@ -7,6 +7,12 @@
     display: block;
     font-size: 14px;
     color: rgb(50, 50, 50);
+
+    .required {
+      margin-left: 4px;
+      font-family: sans-serif;
+      color: rgb(220, 0, 0);
+    }
   }
 
   .textarea {

--- a/frontend/src/components/parts/Input/Textarea/index.tsx
+++ b/frontend/src/components/parts/Input/Textarea/index.tsx
@@ -4,14 +4,13 @@ import style from './Textarea.module.scss'
 
 interface Props {
   label?: string
-  errorText?: string
-  name?: string
   value?: string
+  name?: string
   defaultValue?: string
   placeholder?: string
+  error?: string
   className?: string
   height?: number
-  error?: boolean
   required?: boolean
   disabled?: boolean
   focus?: boolean
@@ -19,13 +18,12 @@ interface Props {
 }
 
 export default function Textarea(props: Props): React.JSX.Element {
-  const { label, errorText, value, className, height, error = false, required = false, focus, onChange } = props
+  const { label, value, error, className, height, required = false, focus, onChange, ...rest } = props
 
   const ref = useRef<HTMLTextAreaElement>(null)
   const [isValue, setIsValue] = useState<boolean>(false)
 
-  const isRequired = required && !isValue
-  const isErrorText = !isRequired && error
+  const isError = !!error || (error === '' && required && !isValue && !value)
 
   const adjustHeight = (height?: number) => {
     if (ref.current) {
@@ -51,11 +49,11 @@ export default function Textarea(props: Props): React.JSX.Element {
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
+          {required && <span className={style.required}>*</span>}
         </label>
       )}
-      <textarea {...props} id={label} ref={ref} value={value} onChange={handleChange} className={cx(style.textarea, isRequired && style.error)} />
-      {isRequired && <p className={style.error_text}>※必須入力です！</p>}
-      {isErrorText && <p className={style.error_text}>{errorText}</p>}
+      <textarea {...rest} id={label} ref={ref} value={value} required={required} onChange={handleChange} className={cx(style.textarea, isError && style.error)} />
+      {error && <p className={style.error_text}>{error}</p>}
     </div>
   )
 }

--- a/frontend/src/components/parts/Input/index.tsx
+++ b/frontend/src/components/parts/Input/index.tsx
@@ -5,16 +5,15 @@ import style from './Input.module.scss'
 
 interface Props {
   label?: string
-  errorText?: string
+  value?: string
   type?: string
   name?: string
-  value?: string
   defaultValue?: string
   placeholder?: string
+  error?: string
   className?: string
   minLength?: number
   maxLength?: number
-  error?: boolean
   required?: boolean
   disabled?: boolean
   autoFocus?: boolean
@@ -23,13 +22,12 @@ interface Props {
 }
 
 export default function Input(props: Props): React.JSX.Element {
-  const { label, errorText, value, className, error = false, required = false, disabled = false, autoFocus, onChange } = props
+  const { label, error, className, required = false, disabled = false, autoFocus, onChange, ...rest } = props
 
   const inputFocus = useAutoFocus()
   const [isValue, setIsValue] = useState<boolean>(false)
 
-  const isRequired = required && !isValue && !value
-  const isErrorText = !isRequired && error
+  const isError = !!error || (error === '' && required && !isValue && !rest.value)
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -42,11 +40,19 @@ export default function Input(props: Props): React.JSX.Element {
       {label && (
         <label htmlFor={label} className={style.label}>
           {label}
+          {required && <span className={style.required}>*</span>}
         </label>
       )}
-      <input {...props} id={label} onChange={handleChange} ref={autoFocus ? inputFocus : undefined} className={cx(style.input, isRequired && style.error, disabled && style.disabled)} />
-      {isRequired && <p className={style.error_text}>※必須入力です！</p>}
-      {isErrorText && <p className={style.error_text}>{errorText}</p>}
+      <input
+        {...rest}
+        id={label}
+        required={required}
+        disabled={disabled}
+        onChange={handleChange}
+        ref={autoFocus ? inputFocus : undefined}
+        className={cx(style.input, isError && style.error, disabled && style.disabled)}
+      />
+      {error && <p className={style.error_text}>{error}</p>}
     </div>
   )
 }

--- a/frontend/src/components/widgets/TextEditor/TextEditor.module.scss
+++ b/frontend/src/components/widgets/TextEditor/TextEditor.module.scss
@@ -4,6 +4,12 @@
   display: block;
   font-size: 14px;
   color: rgb(50, 50, 50);
+
+  .required {
+    margin-left: 4px;
+    font-family: sans-serif;
+    color: rgb(220, 0, 0);
+  }
 }
 
 .editor {

--- a/frontend/src/components/widgets/TextEditor/index.tsx
+++ b/frontend/src/components/widgets/TextEditor/index.tsx
@@ -31,13 +31,14 @@ const extensions = [
 interface Props {
   label?: string
   value?: string
-  required?: boolean
+  error?: string
   className?: string
+  required?: boolean
   onChange?: (html: string) => void
 }
 
 export default function TextEditor(props: Props): React.JSX.Element {
-  const { label, value, required = false, className, onChange } = props
+  const { label, value, error, className, required = false, onChange } = props
 
   const onChangeRef = useRef(onChange)
   const suppressRef = useRef(false)
@@ -70,22 +71,23 @@ export default function TextEditor(props: Props): React.JSX.Element {
   }, [editor, value])
 
   const handleLabel = () => editor?.commands.focus()
-  const isRequired = required && value === ''
+  const isError = !!error || (error === '' && required && !value)
 
   return (
     <VStack gap="2" className={className}>
       {label && (
         <label className={style.label} onClick={handleLabel}>
           {label}
+          {required && <span className={style.required}>*</span>}
         </label>
       )}
       {editor && (
-        <div className={cx(style.editor, isRequired && style.error)}>
+        <div className={cx(style.editor, isError && style.error)}>
           <Toolbar editor={editor} />
           <EditorContent editor={editor} />
         </div>
       )}
-      {isRequired && <p className={style.error_text}>※必須入力です！</p>}
+      {error && <p className={style.error_text}>{error}</p>}
     </VStack>
   )
 }


### PR DESCRIPTION
## Summary
- Input / Textarea / SelectBox / File / TextEditor のエラー表現を `boolean + errorText` から `error?: string` に統一
- 必須項目ラベルに `*` マーカーを追加し、各 SCSS に `.required` スタイルを追加
- Props 宣言順を `label → value → error → className → required → onChange` の base 順に揃える

## 変更内容

### エラー API の統一
従来は `error?: boolean` と `errorText?: string` の 2 props で「必須エラー」と「カスタムエラー」を分けていたが、`error?: string` 1 つに集約。
- `error` が文字列なら表示
- 空文字 `''` のときは `required && !value` の条件で必須エラー扱い（メッセージは表示しない）
- 内部判定は `isError = !!error || (error === '' && required && !value)`

ハードコードされていた「※必須入力です！」を撤廃し、表示メッセージは呼び出し側から受け取る形に変更。

### 必須マーカー
ラベルの右に `*` を表示する `<span className={style.required}>*</span>` を追加。各モジュール SCSS に `.required` スタイル（赤字 / margin-left）を追加。

### Props 順の統一
全コンポーネントで以下の base 順を採用：
`label → value → error → className → required → onChange → (component-specific props)`

分割代入の順番も Props 宣言順に揃えた。

### 対象ファイル
- `frontend/src/components/parts/Input/index.tsx`
- `frontend/src/components/parts/Input/Input.module.scss`
- `frontend/src/components/parts/Input/File/index.tsx`
- `frontend/src/components/parts/Input/SelectBox/index.tsx`
- `frontend/src/components/parts/Input/SelectBox/SelectBox.module.scss`
- `frontend/src/components/parts/Input/Textarea/index.tsx`
- `frontend/src/components/parts/Input/Textarea/Textarea.module.scss`
- `frontend/src/components/widgets/TextEditor/index.tsx`
- `frontend/src/components/widgets/TextEditor/TextEditor.module.scss`