### PR TITLE
【front】useRequired と呼び出し側を新しい Input エラー API に追従

### DIFF
--- a/frontend/src/components/hooks/useRequired.tsx
+++ b/frontend/src/components/hooks/useRequired.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'react'
 
 interface OutProps {
-  isRequired: boolean
-  isRequiredCheck: (values: Record<string, unknown>) => boolean
+  error?: string
+  validate: (values: Record<string, unknown>) => boolean
 }
 
 export const useRequired = (): OutProps => {
-  const [isRequired, setIsRequired] = useState(false)
+  const [error, setError] = useState<string | undefined>(undefined)
 
-  const isRequiredCheck = (values: Record<string, unknown>): boolean => {
+  const validate = (values: Record<string, unknown>): boolean => {
     const isFalsy = Object.values(values).some((value) => !value)
-    setIsRequired(isFalsy)
+    setError(isFalsy ? '' : undefined)
     return !isFalsy
   }
 
-  return { isRequired, isRequiredCheck }
+  return { error, validate }
 }

--- a/frontend/src/components/hooks/useRequired.tsx
+++ b/frontend/src/components/hooks/useRequired.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { isEmpty } from 'utils/functions/validation'
 
 interface OutProps {
   error?: string
@@ -9,7 +10,7 @@ export const useRequired = (): OutProps => {
   const [error, setError] = useState<string | undefined>(undefined)
 
   const validate = (values: Record<string, unknown>): boolean => {
-    const isFalsy = Object.values(values).some((value) => !value)
+    const isFalsy = Object.values(values).some(isEmpty)
     setError(isFalsy ? '' : undefined)
     return !isFalsy
   }

--- a/frontend/src/components/parts/Input/Textarea/index.tsx
+++ b/frontend/src/components/parts/Input/Textarea/index.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useState, useRef, useEffect } from 'react'
 import cx from 'utils/functions/cx'
+import { isEmpty } from 'utils/functions/validation'
 import style from './Textarea.module.scss'
 
 interface Props {
@@ -23,7 +24,7 @@ export default function Textarea(props: Props): React.JSX.Element {
   const ref = useRef<HTMLTextAreaElement>(null)
   const [isValue, setIsValue] = useState<boolean>(false)
 
-  const isError = !!error || (error === '' && required && !isValue && !value)
+  const isError = !!error || (error === '' && required && !isValue && isEmpty(value))
 
   const adjustHeight = (height?: number) => {
     if (ref.current) {
@@ -40,7 +41,7 @@ export default function Textarea(props: Props): React.JSX.Element {
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     adjustHeight()
-    setIsValue(e.target.value !== '')
+    setIsValue(!isEmpty(e.target.value))
     onChange?.(e)
   }
 

--- a/frontend/src/components/parts/Input/index.tsx
+++ b/frontend/src/components/parts/Input/index.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, useState } from 'react'
 import cx from 'utils/functions/cx'
+import { isEmpty } from 'utils/functions/validation'
 import { useAutoFocus } from 'components/hooks/useAutoFocus'
 import style from './Input.module.scss'
 
@@ -27,11 +28,10 @@ export default function Input(props: Props): React.JSX.Element {
   const inputFocus = useAutoFocus()
   const [isValue, setIsValue] = useState<boolean>(false)
 
-  const isError = !!error || (error === '' && required && !isValue && !rest.value)
+  const isError = !!error || (error === '' && required && !isValue && isEmpty(rest.value))
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    setIsValue(value !== '')
+    setIsValue(!isEmpty(e.target.value))
     onChange?.(e)
   }
 

--- a/frontend/src/components/templates/account/login.tsx
+++ b/frontend/src/components/templates/account/login.tsx
@@ -21,7 +21,7 @@ export default function Login(): React.JSX.Element {
   const router = useRouter()
   const { updateUser } = useUser()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { message, handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<LoginIn>({ username: '', password: '' })
@@ -33,7 +33,7 @@ export default function Login(): React.JSX.Element {
 
   const handleSubmit = async () => {
     const { username, password } = values
-    if (!isRequiredCheck({ username, password })) return
+    if (!validate({ username, password })) return
     handleLoading(true)
     const request = { username: encrypt(username), password: encrypt(password) }
     const ret = await postLogin(request)
@@ -60,8 +60,8 @@ export default function Login(): React.JSX.Element {
           )}
 
           <VStack gap="8">
-            <Input type="text" name="username" placeholder="ユーザー名 or メールアドレス" required={isRequired} onChange={handleInput} />
-            <Input type="password" name="password" placeholder="パスワード" minLength={8} maxLength={16} required={isRequired} onChange={handleInput} />
+            <Input type="text" name="username" placeholder="ユーザー名 or メールアドレス" required error={error} onChange={handleInput} />
+            <Input type="password" name="password" placeholder="パスワード" minLength={8} maxLength={16} required error={error} onChange={handleInput} />
             <p className="password_reset" onClick={handleReset}>
               パスワードをリセット
             </p>

--- a/frontend/src/components/templates/account/reset/confirm.tsx
+++ b/frontend/src/components/templates/account/reset/confirm.tsx
@@ -16,7 +16,7 @@ import VStack from 'components/parts/Stack/Vertical'
 export default function ResetConfirm(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [email, setEmail] = useState<string>('')
   const [isVerified, setIsVerified] = useState<boolean>(false)
@@ -47,7 +47,7 @@ export default function ResetConfirm(): React.JSX.Element {
 
   const handleSubmit = async () => {
     const { newPassword1, newPassword2 } = values
-    if (!isRequiredCheck({ newPassword1, newPassword2 })) return
+    if (!validate({ newPassword1, newPassword2 })) return
     if (newPassword1 !== newPassword2) {
       handleToast('新規パスワードが一致しません', true)
       return
@@ -84,7 +84,7 @@ export default function ResetConfirm(): React.JSX.Element {
                   maxLength={16}
                   placeholder="新規パスワード(英数字8~16文字)"
                   value={values.newPassword1}
-                  required={isRequired}
+                  required error={error}
                   onChange={handleInput}
                 />
                 <Input
@@ -94,7 +94,7 @@ export default function ResetConfirm(): React.JSX.Element {
                   maxLength={16}
                   placeholder="新規パスワード(確認用)"
                   value={values.newPassword2}
-                  required={isRequired}
+                  required error={error}
                   onChange={handleInput}
                 />
               </VStack>

--- a/frontend/src/components/templates/account/reset/confirm.tsx
+++ b/frontend/src/components/templates/account/reset/confirm.tsx
@@ -84,7 +84,8 @@ export default function ResetConfirm(): React.JSX.Element {
                   maxLength={16}
                   placeholder="新規パスワード(英数字8~16文字)"
                   value={values.newPassword1}
-                  required error={error}
+                  required
+                  error={error}
                   onChange={handleInput}
                 />
                 <Input
@@ -94,7 +95,8 @@ export default function ResetConfirm(): React.JSX.Element {
                   maxLength={16}
                   placeholder="新規パスワード(確認用)"
                   value={values.newPassword2}
-                  required error={error}
+                  required
+                  error={error}
                   onChange={handleInput}
                 />
               </VStack>

--- a/frontend/src/components/templates/account/reset/index.tsx
+++ b/frontend/src/components/templates/account/reset/index.tsx
@@ -15,7 +15,7 @@ import VStack from 'components/parts/Stack/Vertical'
 export default function Reset(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [email, setEmail] = useState<string>('')
 
@@ -23,7 +23,7 @@ export default function Reset(): React.JSX.Element {
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)
 
   const handleSubmit = async () => {
-    if (!isRequiredCheck({ email })) return
+    if (!validate({ email })) return
     handleLoading(true)
     const ret = await postPasswordResetEmail(email)
     handleLoading(false)
@@ -40,7 +40,7 @@ export default function Reset(): React.JSX.Element {
         <form method="POST" action="" className="form_account">
           <h1 className="login_h1">パスワードリセット</h1>
           <VStack gap="8">
-            <Input type="email" name="email" placeholder="メールアドレス" maxLength={255} required={isRequired} onChange={handleInput} />
+            <Input type="email" name="email" placeholder="メールアドレス" maxLength={255} required error={error} onChange={handleInput} />
             <Alert type="info">メールアドレス宛にパスワード再設定用リンクを送信します。</Alert>
           </VStack>
 

--- a/frontend/src/components/templates/account/signup/email.tsx
+++ b/frontend/src/components/templates/account/signup/email.tsx
@@ -15,7 +15,7 @@ import VStack from 'components/parts/Stack/Vertical'
 export default function SignupEmail(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [email, setEmail] = useState<string>('')
 
@@ -23,7 +23,7 @@ export default function SignupEmail(): React.JSX.Element {
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)
 
   const handleSubmit = async () => {
-    if (!isRequiredCheck({ email })) return
+    if (!validate({ email })) return
     handleLoading(true)
     const ret = await postSignupEmail(email)
     handleLoading(false)
@@ -41,7 +41,7 @@ export default function SignupEmail(): React.JSX.Element {
           <h1 className="signup_h1">アカウント登録</h1>
 
           <VStack gap="8">
-            <Input type="email" name="email" placeholder="メールアドレス" maxLength={255} required={isRequired} onChange={handleInput} />
+            <Input type="email" name="email" placeholder="メールアドレス" maxLength={255} required error={error} onChange={handleInput} />
             <Alert type="info">
               メールアドレス宛に本登録用リンクを送信します。
               <br />

--- a/frontend/src/components/templates/account/signup/index.tsx
+++ b/frontend/src/components/templates/account/signup/index.tsx
@@ -35,7 +35,7 @@ const initSignup: SignupIn = {
 export default function Signup(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<SignupIn>(initSignup)
   const [isVerified, setIsVerified] = useState<boolean>(false)
@@ -66,7 +66,7 @@ export default function Signup(): React.JSX.Element {
 
   const handleSubmit = async () => {
     const { email, username, nickname, lastName, firstName, password1, password2 } = values
-    if (!isRequiredCheck({ email, username, nickname, lastName, firstName, password1, password2 })) return
+    if (!validate({ email, username, nickname, lastName, firstName, password1, password2 })) return
     handleLoading(true)
     const ret = await postSignup(values)
     handleLoading(false)
@@ -89,16 +89,16 @@ export default function Signup(): React.JSX.Element {
                 <VStack gap="4">
                   <p>名前</p>
                   <div className="name_group">
-                    <Input name="lastName" placeholder="姓" maxLength={30} required={isRequired} onChange={handleInput} />
-                    <Input name="firstName" placeholder="名" maxLength={30} required={isRequired} onChange={handleInput} />
+                    <Input name="lastName" placeholder="姓" maxLength={30} required error={error} onChange={handleInput} />
+                    <Input name="firstName" placeholder="名" maxLength={30} required error={error} onChange={handleInput} />
                   </div>
                 </VStack>
 
-                <Input name="username" placeholder="ユーザー名(英数字)" maxLength={20} required={isRequired} onChange={handleInput} />
-                <Input name="nickname" placeholder="投稿者名" maxLength={80} required={isRequired} onChange={handleInput} />
+                <Input name="username" placeholder="ユーザー名(英数字)" maxLength={20} required error={error} onChange={handleInput} />
+                <Input name="nickname" placeholder="投稿者名" maxLength={80} required error={error} onChange={handleInput} />
                 <Input type="email" name="email" value={values.email} disabled maxLength={255} />
-                <Input type="password" name="password1" placeholder="パスワード(英数字8~16文字)" minLength={8} maxLength={16} required={isRequired} onChange={handleInput} />
-                <Input type="password" name="password2" placeholder="パスワード(確認用)" minLength={8} maxLength={16} required={isRequired} onChange={handleInput} />
+                <Input type="password" name="password1" placeholder="パスワード(英数字8~16文字)" minLength={8} maxLength={16} required error={error} onChange={handleInput} />
+                <Input type="password" name="password2" placeholder="パスワード(確認用)" minLength={8} maxLength={16} required error={error} onChange={handleInput} />
 
                 <VStack gap="4">
                   <p>生年月日</p>

--- a/frontend/src/components/templates/manage/advertise/create.tsx
+++ b/frontend/src/components/templates/manage/advertise/create.tsx
@@ -18,7 +18,7 @@ import VStack from 'components/parts/Stack/Vertical'
 export default function AdvertiseCreate(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<AdvertiseIn>({ title: '', url: '', content: '', publish: true, period: null })
 
@@ -32,7 +32,7 @@ export default function AdvertiseCreate(): React.JSX.Element {
 
   const handleForm = async () => {
     const { title, url, content, image } = values
-    if (!isRequiredCheck({ title, url, content, image })) return
+    if (!validate({ title, url, content, image })) return
     handleLoading(true)
     const ret = await postAdvertiseCreate(values)
     handleLoading(false)
@@ -56,11 +56,11 @@ export default function AdvertiseCreate(): React.JSX.Element {
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Input label="リンク URL" name="url" type="url" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Input label="リンク URL" name="url" type="url" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
           <Input label="表示期限" name="period" type="date" onChange={handlePeriod} />
-          <InputFile label="画像（必須）" accept="image/*" required={isRequired} onChange={handleImage} />
+          <InputFile label="画像（必須）" accept="image/*" required error={error} onChange={handleImage} />
           <InputFile label="動画（任意）" accept="video/*" onChange={handleVideo} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -28,13 +28,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
   const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<AdvertiseUpdateIn>({
-    title: data.title,
-    url: data.url,
-    content: data.content,
-    publish: data.publish,
-    period: data.period,
-  })
+  const [values, setValues] = useState<AdvertiseUpdateIn>({ title: data.title, url: data.url, content: data.content, publish: data.publish, period: data.period })
 
   const handleBack = () => router.push('/manage/advertise')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })

--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -25,7 +25,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<AdvertiseUpdateIn>({
@@ -46,7 +46,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { title, url, content } = values
-    if (!isRequiredCheck({ title, url, content })) return
+    if (!validate({ title, url, content })) return
     handleLoading(true)
     const ret = await putManageAdvertise(data.ulid, values)
     handleLoading(false)
@@ -69,9 +69,9 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
       <form method="POST" action="" encType="multipart/form-data">
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Input label="リンク URL" name="url" type="url" value={values.url} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Input label="リンク URL" name="url" type="url" value={values.url} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <Input label="表示期限" name="period" type="date" value={values.period ?? ''} onChange={handlePeriod} />
           <InputFile label="画像" accept="image/*" onChange={handleImage} />
           <InputFile label="動画" accept="video/*" onChange={handleVideo} />

--- a/frontend/src/components/templates/manage/blog/create.tsx
+++ b/frontend/src/components/templates/manage/blog/create.tsx
@@ -33,7 +33,7 @@ export default function BlogCreate(props: Props): React.JSX.Element {
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<BlogIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', richtext: '' })
 
@@ -50,7 +50,7 @@ export default function BlogCreate(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, richtext, image } = values
-    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, richtext, image })) return
+    if (!validate({ channelUlid, categoryUlid, title, content, richtext, image })) return
     handleLoading(true)
     const ret = await postBlogCreate(values)
     handleLoading(false)
@@ -68,11 +68,11 @@ export default function BlogCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
-          <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />
-          <TextEditor label="本文" value={values.richtext} required={isRequired} onChange={handleRichtext} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
+          <InputFile label="サムネイル" accept="image/*" required error={error} onChange={handleFile} />
+          <TextEditor label="本文" value={values.richtext} required error={error} onChange={handleRichtext} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/blog/edit.tsx
+++ b/frontend/src/components/templates/manage/blog/edit.tsx
@@ -38,7 +38,7 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<BlogUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, richtext: data.richtext, publish: data.publish })
@@ -57,7 +57,7 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { categoryUlid, title, content, richtext } = values
-    if (!isRequiredCheck({ categoryUlid, title, content, richtext })) return
+    if (!validate({ categoryUlid, title, content, richtext })) return
     handleLoading(true)
     const ret = await putManageBlog(data.ulid, values)
     handleLoading(false)
@@ -81,11 +81,11 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
-          <TextEditor label="本文" value={values.richtext} required={isRequired} onChange={handleRichtext} />
+          <TextEditor label="本文" value={values.richtext} required error={error} onChange={handleRichtext} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/chat/create.tsx
+++ b/frontend/src/components/templates/manage/chat/create.tsx
@@ -30,7 +30,7 @@ export default function ChatCreate(props: Props): React.JSX.Element {
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<ChatIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', period: '' })
 
@@ -41,7 +41,7 @@ export default function ChatCreate(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, period } = values
-    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, period })) return
+    if (!validate({ channelUlid, categoryUlid, title, content, period })) return
     handleLoading(true)
     const ret = await postChatCreate(values)
     handleLoading(false)
@@ -59,10 +59,10 @@ export default function ChatCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
-          <Input label="期間" name="period" placeholder={`${nowDate.year}-12-31`} required={isRequired} onChange={handleInput} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
+          <Input label="期間" name="period" placeholder={`${nowDate.year}-12-31`} required error={error} onChange={handleInput} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/chat/edit.tsx
+++ b/frontend/src/components/templates/manage/chat/edit.tsx
@@ -38,7 +38,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
   const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
-  const [values, setValues] = useState<ChatUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, period: formatDate(data.period), publish: data.publish })
+  const [values, setValues] = useState<ChatUpdateIn>({ ...data, period: formatDate(data.period) })
 
   const handleBack = () => router.push('/manage/chat')
   const handlePublish = () => setValues({ ...values, publish: !values.publish })

--- a/frontend/src/components/templates/manage/chat/edit.tsx
+++ b/frontend/src/components/templates/manage/chat/edit.tsx
@@ -35,7 +35,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<ChatUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, period: formatDate(data.period), publish: data.publish })
@@ -48,7 +48,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { categoryUlid, title, content, period } = values
-    if (!isRequiredCheck({ categoryUlid, title, content, period })) return
+    if (!validate({ categoryUlid, title, content, period })) return
     handleLoading(true)
     const ret = await putManageChat(data.ulid, values)
     handleLoading(false)
@@ -72,10 +72,10 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
-          <Input label="期間" name="period" value={values.period} required={isRequired} onChange={handleInput} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
+          <Input label="期間" name="period" value={values.period} required error={error} onChange={handleInput} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/comic/create.tsx
+++ b/frontend/src/components/templates/manage/comic/create.tsx
@@ -30,7 +30,7 @@ export default function ComicCreate(props: Props): React.JSX.Element {
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<ComicIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
 
@@ -43,7 +43,7 @@ export default function ComicCreate(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, image, pages } = values
-    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, image, pages })) return
+    if (!validate({ channelUlid, categoryUlid, title, content, image, pages })) return
     handleLoading(true)
     const ret = await postComicCreate(values)
     handleLoading(false)
@@ -61,11 +61,11 @@ export default function ComicCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
-          <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />
-          <InputFile label="ページ画像" accept="image/*" required={isRequired} multiple onChange={handleMultiFile} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
+          <InputFile label="サムネイル" accept="image/*" required error={error} onChange={handleFile} />
+          <InputFile label="ページ画像" accept="image/*" required error={error} multiple onChange={handleMultiFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/comic/edit.tsx
+++ b/frontend/src/components/templates/manage/comic/edit.tsx
@@ -35,7 +35,7 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<ComicUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, publish: data.publish })
@@ -49,7 +49,7 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { categoryUlid, title, content } = values
-    if (!isRequiredCheck({ categoryUlid, title, content })) return
+    if (!validate({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManageComic(data.ulid, values)
     handleLoading(false)
@@ -73,9 +73,9 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/music/create.tsx
+++ b/frontend/src/components/templates/manage/music/create.tsx
@@ -31,7 +31,7 @@ export default function MusicCreate(props: Props): React.JSX.Element {
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<MusicIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '', lyric: '', download: true })
 
@@ -44,7 +44,7 @@ export default function MusicCreate(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, music } = values
-    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, music })) return
+    if (!validate({ channelUlid, categoryUlid, title, content, music })) return
     handleLoading(true)
     const ret = await postMusicCreate(values)
     handleLoading(false)
@@ -62,12 +62,12 @@ export default function MusicCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
-          <Textarea label="歌詞" name="lyric" required={isRequired} onChange={handleText} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
+          <Textarea label="歌詞" name="lyric" required error={error} onChange={handleText} />
           <VStack gap="2">
-            <InputFile label="音楽" accept="audio/*" required={isRequired} onChange={handleFile} />
+            <InputFile label="音楽" accept="audio/*" required error={error} onChange={handleFile} />
             <CheckBox label="ダウンロード許可" name="download" defaultChecked onChange={handleCheck} />
           </VStack>
         </VStack>

--- a/frontend/src/components/templates/manage/music/create.tsx
+++ b/frontend/src/components/templates/manage/music/create.tsx
@@ -65,7 +65,7 @@ export default function MusicCreate(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" required error={error} onChange={handleText} />
-          <Textarea label="歌詞" name="lyric" required error={error} onChange={handleText} />
+          <Textarea label="歌詞" name="lyric" onChange={handleText} />
           <VStack gap="2">
             <InputFile label="音楽" accept="audio/*" required error={error} onChange={handleFile} />
             <CheckBox label="ダウンロード許可" name="download" defaultChecked onChange={handleCheck} />

--- a/frontend/src/components/templates/manage/music/edit.tsx
+++ b/frontend/src/components/templates/manage/music/edit.tsx
@@ -35,7 +35,7 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<MusicUpdateIn>({ ...data })
@@ -49,7 +49,7 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { categoryUlid, title, content, lyric } = values
-    if (!isRequiredCheck({ categoryUlid, title, content, lyric })) return
+    if (!validate({ categoryUlid, title, content, lyric })) return
     handleLoading(true)
     const ret = await putManageMusic(data.ulid, values)
     handleLoading(false)
@@ -73,10 +73,10 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
-          <Textarea label="歌詞" name="lyric" value={values.lyric} required={isRequired} onChange={handleText} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
+          <Textarea label="歌詞" name="lyric" value={values.lyric} required error={error} onChange={handleText} />
           <CheckBox label="ダウンロード許可" name="download" checked={values.download} onChange={handleCheck} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/music/edit.tsx
+++ b/frontend/src/components/templates/manage/music/edit.tsx
@@ -48,8 +48,8 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.checked })
 
   const handleForm = async () => {
-    const { categoryUlid, title, content, lyric } = values
-    if (!validate({ categoryUlid, title, content, lyric })) return
+    const { categoryUlid, title, content } = values
+    if (!validate({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManageMusic(data.ulid, values)
     handleLoading(false)
@@ -76,7 +76,7 @@ export default function ManageMusicEdit(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <Textarea label="歌詞" name="lyric" value={values.lyric} required error={error} onChange={handleText} />
+          <Textarea label="歌詞" name="lyric" value={values.lyric} onChange={handleText} />
           <CheckBox label="ダウンロード許可" name="download" checked={values.download} onChange={handleCheck} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/picture/create.tsx
+++ b/frontend/src/components/templates/manage/picture/create.tsx
@@ -30,7 +30,7 @@ export default function PictureCreate(props: Props): React.JSX.Element {
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<PictureIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
 
@@ -42,7 +42,7 @@ export default function PictureCreate(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, image } = values
-    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, image })) return
+    if (!validate({ channelUlid, categoryUlid, title, content, image })) return
     handleLoading(true)
     const ret = await postPictureCreate(values)
     handleLoading(false)
@@ -60,10 +60,10 @@ export default function PictureCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
-          <InputFile label="画像" accept="image/*" required={isRequired} onChange={handleFile} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
+          <InputFile label="画像" accept="image/*" required error={error} onChange={handleFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/picture/edit.tsx
+++ b/frontend/src/components/templates/manage/picture/edit.tsx
@@ -35,7 +35,7 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<PictureUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, publish: data.publish })
@@ -49,7 +49,7 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { categoryUlid, title, content } = values
-    if (!isRequiredCheck({ categoryUlid, title, content })) return
+    if (!validate({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManagePicture(data.ulid, values)
     handleLoading(false)
@@ -73,9 +73,9 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <InputFile label="画像" accept="image/*" onChange={handleFile} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/video/create.tsx
+++ b/frontend/src/components/templates/manage/video/create.tsx
@@ -30,7 +30,7 @@ export default function VideoCreate(props: Props): React.JSX.Element {
   const categoryOptions: Option[] = [{ label: '未選択', value: '' }, ...categories.map((c) => ({ label: c.jpName, value: c.ulid }))]
 
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [formKey, setFormKey] = useState(0)
   const [values, setValues] = useState<VideoIn>({ channelUlid, categoryUlid: '', publish: true, title: '', content: '' })
@@ -44,7 +44,7 @@ export default function VideoCreate(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, image, video } = values
-    if (!isRequiredCheck({ channelUlid, categoryUlid, title, content, image, video })) return
+    if (!validate({ channelUlid, categoryUlid, title, content, image, video })) return
     handleLoading(true)
     const ret = await postVideoCreate(values)
     handleLoading(false)
@@ -63,11 +63,11 @@ export default function VideoCreate(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={values.channelUlid} options={channelOptions} onChange={handleSelect} />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" required={isRequired} onChange={handleText} />
-          <InputFile label="サムネイル" accept="image/*" required={isRequired} onChange={handleFile} />
-          <InputFile label="動画" accept="video/*" required={isRequired} onChange={handleMovie} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" required error={error} onChange={handleText} />
+          <InputFile label="サムネイル" accept="image/*" required error={error} onChange={handleFile} />
+          <InputFile label="動画" accept="video/*" required error={error} onChange={handleMovie} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/video/edit.tsx
+++ b/frontend/src/components/templates/manage/video/edit.tsx
@@ -35,7 +35,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
 
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const [values, setValues] = useState<VideoUpdateIn>({ categoryUlid: data.categoryUlid, title: data.title, content: data.content, publish: data.publish })
@@ -49,7 +49,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
 
   const handleForm = async () => {
     const { categoryUlid, title, content } = values
-    if (!isRequiredCheck({ categoryUlid, title, content })) return
+    if (!validate({ categoryUlid, title, content })) return
     handleLoading(true)
     const ret = await putManageVideo(data.ulid, values)
     handleLoading(false)
@@ -73,9 +73,9 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
         <VStack gap="8">
           <ToggleCard label="公開する" isActive={values.publish} onClick={handlePublish} />
           <SelectBox label="チャンネル" name="channelUlid" value={data.channel.ulid} options={channelOptions} disabled />
-          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required={isRequired} onChange={handleSelect} />
-          <Input label="タイトル" name="title" value={values.title} required={isRequired} onChange={handleInput} />
-          <Textarea label="内容" name="content" value={values.content} required={isRequired} onChange={handleText} />
+          <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
+          <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
+          <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/setting/mypage/channel/create.tsx
+++ b/frontend/src/components/templates/setting/mypage/channel/create.tsx
@@ -26,7 +26,7 @@ const initChannel: ChannelIn = {
 export default function ChannelCreate(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { message, handleError } = useApiError({ handleToast })
   const [avatarFile, setAvatarFile] = useState<File>()
@@ -41,7 +41,7 @@ export default function ChannelCreate(): React.JSX.Element {
 
   const handleSubmit = async () => {
     const { name } = values
-    if (!isRequiredCheck({ name })) return
+    if (!validate({ name })) return
     handleLoading(true)
     const ret = await postChannel({ ...values, avatarFile })
     handleLoading(false)
@@ -86,7 +86,7 @@ export default function ChannelCreate(): React.JSX.Element {
               />
             </VStack>
 
-            <Input name="name" placeholder="チャンネル名" maxLength={50} required={isRequired} onChange={handleInput} />
+            <Input name="name" placeholder="チャンネル名" maxLength={50} required error={error} onChange={handleInput} />
             <Textarea name="description" placeholder="説明" onChange={handleText} />
           </VStack>
 

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -58,7 +58,8 @@ export default function PasswordChange(): React.JSX.Element {
               maxLength={16}
               placeholder="現在パスワード"
               value={values.oldPassword}
-              required error={error}
+              required
+              error={error}
               onChange={handleInput}
             />
             <Input
@@ -68,7 +69,8 @@ export default function PasswordChange(): React.JSX.Element {
               maxLength={16}
               placeholder="新規パスワード(英数字8~16文字)"
               value={values.newPassword1}
-              required error={error}
+              required
+              error={error}
               onChange={handleInput}
             />
             <Input
@@ -78,7 +80,8 @@ export default function PasswordChange(): React.JSX.Element {
               maxLength={16}
               placeholder="新規パスワード(確認用)"
               value={values.newPassword2}
-              required error={error}
+              required
+              error={error}
               onChange={handleInput}
             />
           </VStack>

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -17,7 +17,7 @@ import style from '../Setting.module.scss'
 export default function PasswordChange(): React.JSX.Element {
   const router = useRouter()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<PasswordChangeIn>({ oldPassword: '', newPassword1: '', newPassword2: '' })
 
@@ -26,7 +26,7 @@ export default function PasswordChange(): React.JSX.Element {
 
   const handleSubmit = async () => {
     const { oldPassword, newPassword1, newPassword2 } = values
-    if (!isRequiredCheck({ oldPassword, newPassword1, newPassword2 })) return
+    if (!validate({ oldPassword, newPassword1, newPassword2 })) return
     if (newPassword1 !== newPassword2) {
       handleToast('新規パスワードが一致しません', true)
       return
@@ -58,7 +58,7 @@ export default function PasswordChange(): React.JSX.Element {
               maxLength={16}
               placeholder="現在パスワード"
               value={values.oldPassword}
-              required={isRequired}
+              required error={error}
               onChange={handleInput}
             />
             <Input
@@ -68,7 +68,7 @@ export default function PasswordChange(): React.JSX.Element {
               maxLength={16}
               placeholder="新規パスワード(英数字8~16文字)"
               value={values.newPassword1}
-              required={isRequired}
+              required error={error}
               onChange={handleInput}
             />
             <Input
@@ -78,7 +78,7 @@ export default function PasswordChange(): React.JSX.Element {
               maxLength={16}
               placeholder="新規パスワード(確認用)"
               value={values.newPassword2}
-              required={isRequired}
+              required error={error}
               onChange={handleInput}
             />
           </VStack>

--- a/frontend/src/components/templates/setting/profile/edit.tsx
+++ b/frontend/src/components/templates/setting/profile/edit.tsx
@@ -37,7 +37,7 @@ export default function SettingProfileEdit(props: Props): React.JSX.Element {
   const router = useRouter()
   const { updateUser } = useUser()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const { message, setMessage, handleError } = useApiError({ handleToast })
   const [avatarFile, setAvatarFile] = useState<File>()
@@ -67,7 +67,7 @@ export default function SettingProfileEdit(props: Props): React.JSX.Element {
 
   const handlSubmit = async () => {
     const { email, username, nickname, lastName, firstName, phone, postalCode } = values
-    if (!isRequiredCheck({ email, username, nickname, lastName, firstName, phone, postalCode })) return
+    if (!validate({ email, username, nickname, lastName, firstName, phone, postalCode })) return
     handleLoading(true)
     await new Promise((resolve) => setTimeout(resolve, 200))
     const request: ProfileIn = { ...values, avatarFile }
@@ -117,18 +117,18 @@ export default function SettingProfileEdit(props: Props): React.JSX.Element {
           />
         </TableRow>
         <TableRow label="メールアドレス">
-          <Input name="email" value={values.email} maxLength={120} required={isRequired} onChange={handleInput} />
+          <Input name="email" value={values.email} maxLength={120} required error={error} onChange={handleInput} />
         </TableRow>
         <TableRow label="ユーザー名">
-          <Input name="username" value={values.username} maxLength={30} placeholder="英数字" required={isRequired} onChange={handleInput} />
+          <Input name="username" value={values.username} maxLength={30} placeholder="英数字" required error={error} onChange={handleInput} />
         </TableRow>
         <TableRow label="投稿者名">
-          <Input name="nickname" value={values.nickname} maxLength={60} required={isRequired} onChange={handleInput} />
+          <Input name="nickname" value={values.nickname} maxLength={60} required error={error} onChange={handleInput} />
         </TableRow>
         <TableRow label="名前">
           <HStack gap="1" full>
-            <Input name="lastName" value={values.lastName} placeholder="姓" maxLength={30} required={isRequired} onChange={handleInput} />
-            <Input name="firstName" value={values.firstName} placeholder="名" maxLength={30} required={isRequired} onChange={handleInput} />
+            <Input name="lastName" value={values.lastName} placeholder="姓" maxLength={30} required error={error} onChange={handleInput} />
+            <Input name="firstName" value={values.firstName} placeholder="名" maxLength={30} required error={error} onChange={handleInput} />
           </HStack>
         </TableRow>
         <TableRow label="生年月日">
@@ -149,11 +149,11 @@ export default function SettingProfileEdit(props: Props): React.JSX.Element {
           </HStack>
         </TableRow>
         <TableRow label="電話番号">
-          <Input type="tel" name="phone" value={values.phone} maxLength={15} required={isRequired} onChange={handleInput} />
+          <Input type="tel" name="phone" value={values.phone} maxLength={15} required error={error} onChange={handleInput} />
         </TableRow>
         <TableRow label="郵便番号">
           <div className="d_flex">
-            <Input type="tel" name="postalCode" value={values.postalCode} maxLength={8} className="mr_2" required={isRequired} onChange={handleInput} />
+            <Input type="tel" name="postalCode" value={values.postalCode} maxLength={8} className="mr_2" required error={error} onChange={handleInput} />
             <Button name="住所自動入力" onClick={handleAutoAddress} />
           </div>
         </TableRow>

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -19,7 +19,7 @@ export default function WithdrawalConfirm(): React.JSX.Element {
   const router = useRouter()
   const { resetUser } = useUser()
   const { isLoading, handleLoading } = useIsLoading()
-  const { isRequired, isRequiredCheck } = useRequired()
+  const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<WithdrawalIn>({ password: '' })
 
@@ -28,7 +28,7 @@ export default function WithdrawalConfirm(): React.JSX.Element {
 
   const handleSubmit = async () => {
     const { password } = values
-    if (!isRequiredCheck({ password })) return
+    if (!validate({ password })) return
 
     handleLoading(true)
     const request: WithdrawalIn = { password: encrypt(password) }
@@ -55,7 +55,7 @@ export default function WithdrawalConfirm(): React.JSX.Element {
               maxLength={16}
               placeholder="パスワード"
               value={values.password}
-              required={isRequired}
+              required error={error}
               onChange={handleInput}
             />
           </VStack>

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -48,16 +48,7 @@ export default function WithdrawalConfirm(): React.JSX.Element {
         <form method="POST" action="" className={style.form_account}>
           <VStack gap="8">
             <p className="red">本当に退会しますか？</p>
-            <Input
-              type="password"
-              name="password"
-              minLength={8}
-              maxLength={16}
-              placeholder="パスワード"
-              value={values.password}
-              required error={error}
-              onChange={handleInput}
-            />
+            <Input type="password" name="password" minLength={8} maxLength={16} placeholder="パスワード" value={values.password} required error={error} onChange={handleInput} />
           </VStack>
 
           <VStack gap="12" className="mv_40">

--- a/frontend/src/utils/functions/validation.ts
+++ b/frontend/src/utils/functions/validation.ts
@@ -1,0 +1,4 @@
+export const isEmpty = (value: unknown): boolean => {
+  if (typeof value === 'string') return !value.trim()
+  return !value
+}


### PR DESCRIPTION
## Summary
- `useRequired` の戻り値を `{ isRequired, isRequiredCheck }` から `{ error, validate }` に変更
- 失敗時に空文字 `''` を返すことで Input 側の必須エラー表示と接続
- `templates/*` 全体で `validate(...)` と `required error={error}` のスタイルに統一

## 変更内容

### `useRequired` の API 変更
PR #808 で Input 系コンポーネントの error API を `error?: string` に統一したので、本 PR で呼び出し側を追従。

```diff
- interface OutProps {
-   isRequired: boolean
-   isRequiredCheck: (values: Record<string, unknown>) => boolean
- }
+ interface OutProps {
+   error?: string
+   validate: (values: Record<string, unknown>) => boolean
+ }
```

`validate` は値が空のとき `setError('')` を呼び、Input 側の `error === '' && required && !value` 判定に渡す形。エラーメッセージは出さず、見た目だけ赤枠 + `*` マーカーで表現。

### templates/* の追従
`useRequired` を使っている 23 ファイルで以下の置換を実施：

```diff
- const { isRequired, isRequiredCheck } = useRequired()
+ const { error, validate } = useRequired()

- if (!isRequiredCheck({ ... })) return
+ if (!validate({ ... })) return

- <Input required={isRequired} ... />
+ <Input required error={error} ... />
```

これにより、`required` は静的な「必須項目」フラグ（`*` 表示用）となり、`error` が動的な検証状態を表すようになった。

### 対象ファイル
- `frontend/src/components/hooks/useRequired.tsx`
- `frontend/src/components/templates/account/{login,reset/{confirm,index},signup/{email,index}}.tsx`
- `frontend/src/components/templates/manage/{advertise,blog,chat,comic,music,picture,video}/{create,edit}.tsx`
- `frontend/src/components/templates/setting/{mypage/channel/create,password/change,profile/edit,withdrawal/confirm}.tsx`