### PR TITLE
【front】useLoading をページ遷移用途に明示するため usePageLoading にリネーム

### DIFF
--- a/frontend/src/components/hooks/usePageLoading.tsx
+++ b/frontend/src/components/hooks/usePageLoading.tsx
@@ -6,7 +6,7 @@ interface OutProps {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-export function useLoading(): OutProps {
+export function usePageLoading(): OutProps {
   const router = useRouter()
   const [loading, setLoading] = useState<boolean>(false)
 

--- a/frontend/src/components/layout/index.tsx
+++ b/frontend/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import { useLoading } from 'components/hooks/useLoading'
+import { usePageLoading } from 'components/hooks/usePageLoading'
 import Header from 'components/layout/Header'
 import SearchTagBar from 'components/layout/SearchTagBar'
 import SideBar from 'components/layout/SideBar'
@@ -11,7 +11,7 @@ interface Props {
 export default function Layout(props: Props): React.JSX.Element {
   const { children } = props
 
-  const { loading } = useLoading()
+  const { loading } = usePageLoading()
 
   return (
     <div className={style.layout}>


### PR DESCRIPTION
## Summary
- ページ遷移ローディング用の `useLoading` を `usePageLoading` にリネーム
- 後続の `useIsLoading` → `useLoading` リネームに向けた名前空け

## 変更内容

### 背景
`useLoading` は Next.js の `router.events` を購読してページ遷移中のローディング状態を返す Layout 専用フック。一方 `useIsLoading` は API 呼び出しなどに使う汎用ローディングフックで、用途が混同しやすい。

汎用フックの名前を `useLoading` に整えるための前段として、まずページ遷移用フックを `usePageLoading` にリネームし、責務を name で明示する。

### 変更ファイル
- `frontend/src/components/hooks/useLoading.tsx` → `usePageLoading.tsx`（`git mv`、関数名も `useLoading` → `usePageLoading`）
- `frontend/src/components/layout/index.tsx`: import / 呼び出しを差し替え

呼び出し元は Layout の 1 箇所のみのため影響範囲は小さい。

### 後続予定
別 PR で `useIsLoading` → `useLoading` リネーム（36 箇所の置換）を行う。