### PR TITLE
【front】ManageTable の削除モーダル文言を共通化し label プロップを削除

### DIFF
--- a/frontend/src/components/templates/manage/_container/Table/index.tsx
+++ b/frontend/src/components/templates/manage/_container/Table/index.tsx
@@ -19,7 +19,6 @@ interface Props<T> {
     onChange: (page: number) => void
   }
   deletion: {
-    label: string
     open: boolean
     loading: boolean
     onClose: () => void
@@ -45,8 +44,8 @@ export default function ManageTable<T>(props: Props<T>): React.JSX.Element {
       </div>
       <DeleteModal
         open={deletion.open}
-        title={`${deletion.label}の削除`}
-        content={`${selection.keys.size}件の${deletion.label}を削除しますか？`}
+        title="データの削除"
+        content={`${selection.keys.size}件のデータを削除しますか？`}
         loading={deletion.loading}
         onClose={deletion.onClose}
         onAction={deletion.onAction}

--- a/frontend/src/components/templates/manage/advertise/index.tsx
+++ b/frontend/src/components/templates/manage/advertise/index.tsx
@@ -146,7 +146,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (a) => a.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: '広告', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/blog/index.tsx
+++ b/frontend/src/components/templates/manage/blog/index.tsx
@@ -143,7 +143,7 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (b) => b.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: 'ブログ', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/chat/index.tsx
+++ b/frontend/src/components/templates/manage/chat/index.tsx
@@ -154,7 +154,7 @@ export default function ManageChats(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (c) => c.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: 'チャット', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/comic/index.tsx
+++ b/frontend/src/components/templates/manage/comic/index.tsx
@@ -143,7 +143,7 @@ export default function ManageComics(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (c) => c.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: '漫画', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/music/index.tsx
+++ b/frontend/src/components/templates/manage/music/index.tsx
@@ -150,7 +150,7 @@ export default function ManageMusics(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (m) => m.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: '音楽', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/picture/index.tsx
+++ b/frontend/src/components/templates/manage/picture/index.tsx
@@ -143,7 +143,7 @@ export default function ManagePictures(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (p) => p.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: '画像', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -143,7 +143,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (v) => v.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ label: '動画', open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
       />
     </Main>
   )


### PR DESCRIPTION
## Summary
- 削除モーダルのタイトル / 本文をメディア種別ごとの可変文言から「データの削除」「X件のデータを削除しますか？」に固定化
- ManageTable の Props から `label` を削除し、7 ファイルの呼び出しからも除去

## 変更内容

### 背景
これまで `<ManageTable>` は `deletion={{ label: '音楽', ... }}` のようにメディア名を渡し、削除モーダルの文言を `${label}の削除` で組み立てていた。
- メディアごとに値が異なるだけで構造的な意味はない
- 「広告」も含まれており「メディア」と一括りにできない
- 管理画面という文脈ではメディア名を出さなくても用件が伝わる

そのため文言を「データ」固定に変更し、prop 自体を撤廃した。

### 変更ファイル
- `templates/manage/_container/Table/index.tsx`
  - Props から `label` を削除
  - `title` を `"データの削除"`、`content` を `"${count}件のデータを削除しますか？"` に固定
- `templates/manage/{advertise,blog,chat,comic,music,picture,video}/index.tsx`
  - `<ManageTable>` の `label="..."` を除去