### PR TITLE
【front】管理画面 edit ページの InputFile に required マーカーを追加

### DIFF
--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -67,7 +67,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
           <Input label="リンク URL" name="url" type="url" value={values.url} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <Input label="表示期限" name="period" type="date" value={values.period ?? ''} onChange={handlePeriod} />
-          <InputFile label="画像" accept="image/*" onChange={handleImage} />
+          <InputFile label="画像" accept="image/*" required error={error} onChange={handleImage} />
           <InputFile label="動画" accept="video/*" onChange={handleVideo} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/blog/edit.tsx
+++ b/frontend/src/components/templates/manage/blog/edit.tsx
@@ -84,7 +84,7 @@ export default function ManageBlogEdit(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
+          <InputFile label="サムネイル" accept="image/*" required error={error} onChange={handleFile} />
           <TextEditor label="本文" value={values.richtext} required error={error} onChange={handleRichtext} />
         </VStack>
       </form>

--- a/frontend/src/components/templates/manage/comic/edit.tsx
+++ b/frontend/src/components/templates/manage/comic/edit.tsx
@@ -76,7 +76,7 @@ export default function ManageComicEdit(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
+          <InputFile label="サムネイル" accept="image/*" required error={error} onChange={handleFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/picture/edit.tsx
+++ b/frontend/src/components/templates/manage/picture/edit.tsx
@@ -76,7 +76,7 @@ export default function ManagePictureEdit(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <InputFile label="画像" accept="image/*" onChange={handleFile} />
+          <InputFile label="画像" accept="image/*" required error={error} onChange={handleFile} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/video/edit.tsx
+++ b/frontend/src/components/templates/manage/video/edit.tsx
@@ -76,7 +76,7 @@ export default function ManageVideoEdit(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <InputFile label="サムネイル" accept="image/*" onChange={handleFile} />
+          <InputFile label="サムネイル" accept="image/*" required error={error} onChange={handleFile} />
         </VStack>
       </form>
     </Main>


### PR DESCRIPTION
## Summary
- 管理画面の edit ページで画像系 `<InputFile>` に `required error={error}` を追加
- 対象: video / picture / blog / comic / advertise の edit
- 視覚マーカー目的で `validate(...)` には image を含めない

## 変更内容

### 背景
これまで edit ページの画像系 `<InputFile>` には `required` マーカーが付いておらず、create ページとの一貫性に欠けていた。`*` マーカーが付いていないと「任意の項目」と誤認される可能性があった。

### 設計判断
- `required error={error}` を追加し、ラベルに `*` を表示
- ただし `validate({ ... })` には image を含めない
  - 編集画面では既にデータが保存済みのため、再アップロードを強制すると UX が悪化
  - 他フィールド（タイトル / 内容 / カテゴリー）の検証失敗時にこの InputFile も赤枠表示される副次効果のみ

### 変更ファイル
- `templates/manage/video/edit.tsx`: サムネイル
- `templates/manage/picture/edit.tsx`: 画像
- `templates/manage/blog/edit.tsx`: サムネイル
- `templates/manage/comic/edit.tsx`: サムネイル
- `templates/manage/advertise/edit.tsx`: 画像（動画は create でも非必須なので除外）