### PR TITLE
【front】Password widget を導入し全パスワード入力を統合

### DIFF
--- a/frontend/src/components/parts/Input/Password/index.tsx
+++ b/frontend/src/components/parts/Input/Password/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent } from 'react'
-import Input from 'components/parts/Input'
+import Input from '..'
 
 interface Props {
   value?: string

--- a/frontend/src/components/templates/account/login.tsx
+++ b/frontend/src/components/templates/account/login.tsx
@@ -14,8 +14,8 @@ import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
-import Password from 'components/widgets/Password'
 
 export default function Login(): React.JSX.Element {
   const { t } = useTranslation('common')

--- a/frontend/src/components/templates/account/login.tsx
+++ b/frontend/src/components/templates/account/login.tsx
@@ -15,6 +15,7 @@ import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
+import Password from 'components/widgets/Password'
 
 export default function Login(): React.JSX.Element {
   const { t } = useTranslation('common')
@@ -61,7 +62,7 @@ export default function Login(): React.JSX.Element {
 
           <VStack gap="8">
             <Input type="text" name="username" placeholder="ユーザー名 or メールアドレス" required error={error} onChange={handleInput} />
-            <Input type="password" name="password" placeholder="パスワード" minLength={8} maxLength={16} required error={error} onChange={handleInput} />
+            <Password name="password" placeholder="パスワード" error={error} onChange={handleInput} />
             <p className="password_reset" onClick={handleReset}>
               パスワードをリセット
             </p>

--- a/frontend/src/components/templates/account/reset/confirm.tsx
+++ b/frontend/src/components/templates/account/reset/confirm.tsx
@@ -11,8 +11,8 @@ import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
-import Password from 'components/widgets/Password'
 
 export default function ResetConfirm(): React.JSX.Element {
   const router = useRouter()

--- a/frontend/src/components/templates/account/reset/confirm.tsx
+++ b/frontend/src/components/templates/account/reset/confirm.tsx
@@ -12,6 +12,7 @@ import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
+import Password from 'components/widgets/Password'
 
 export default function ResetConfirm(): React.JSX.Element {
   const router = useRouter()
@@ -20,7 +21,7 @@ export default function ResetConfirm(): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const [email, setEmail] = useState<string>('')
   const [isVerified, setIsVerified] = useState<boolean>(false)
-  const [values, setValues] = useState<PasswordResetIn>({ token: '', newPassword1: '', newPassword2: '' })
+  const [values, setValues] = useState<PasswordResetIn>({ token: '', password1: '', password2: '' })
 
   const handleBack = () => router.push('/account/login')
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
@@ -46,17 +47,17 @@ export default function ResetConfirm(): React.JSX.Element {
   }, [router])
 
   const handleSubmit = async () => {
-    const { newPassword1, newPassword2 } = values
-    if (!validate({ newPassword1, newPassword2 })) return
-    if (newPassword1 !== newPassword2) {
+    const { password1, password2 } = values
+    if (!validate({ password1, password2 })) return
+    if (password1 !== password2) {
       handleToast('新規パスワードが一致しません', true)
       return
     }
     handleLoading(true)
     const request: PasswordResetIn = {
       token: values.token,
-      newPassword1: encrypt(newPassword1),
-      newPassword2: encrypt(newPassword2),
+      password1: encrypt(password1),
+      password2: encrypt(password2),
     }
     const ret = await postPasswordReset(request)
     handleLoading(false)
@@ -77,28 +78,8 @@ export default function ResetConfirm(): React.JSX.Element {
             <>
               <VStack gap="8">
                 <Input type="email" name="email" value={email} disabled maxLength={255} />
-                <Input
-                  type="password"
-                  name="newPassword1"
-                  minLength={8}
-                  maxLength={16}
-                  placeholder="新規パスワード(英数字8~16文字)"
-                  value={values.newPassword1}
-                  required
-                  error={error}
-                  onChange={handleInput}
-                />
-                <Input
-                  type="password"
-                  name="newPassword2"
-                  minLength={8}
-                  maxLength={16}
-                  placeholder="新規パスワード(確認用)"
-                  value={values.newPassword2}
-                  required
-                  error={error}
-                  onChange={handleInput}
-                />
+                <Password value={values.password1} name="password1" placeholder="パスワード(英数字8~16文字)" error={error} onChange={handleInput} />
+                <Password value={values.password2} name="password2" placeholder="パスワード(確認用)" error={error} onChange={handleInput} />
               </VStack>
 
               <VStack gap="12" className="mv_40">

--- a/frontend/src/components/templates/account/signup/index.tsx
+++ b/frontend/src/components/templates/account/signup/index.tsx
@@ -12,11 +12,11 @@ import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import Password from 'components/parts/Input/Password'
 import Radio from 'components/parts/Input/Radio'
 import SelectBox from 'components/parts/Input/SelectBox'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
-import Password from 'components/widgets/Password'
 
 const initSignup: SignupIn = {
   token: '',

--- a/frontend/src/components/templates/account/signup/index.tsx
+++ b/frontend/src/components/templates/account/signup/index.tsx
@@ -16,6 +16,7 @@ import Radio from 'components/parts/Input/Radio'
 import SelectBox from 'components/parts/Input/SelectBox'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
+import Password from 'components/widgets/Password'
 
 const initSignup: SignupIn = {
   token: '',
@@ -97,8 +98,8 @@ export default function Signup(): React.JSX.Element {
                 <Input name="username" placeholder="ユーザー名(英数字)" maxLength={20} required error={error} onChange={handleInput} />
                 <Input name="nickname" placeholder="投稿者名" maxLength={80} required error={error} onChange={handleInput} />
                 <Input type="email" name="email" value={values.email} disabled maxLength={255} />
-                <Input type="password" name="password1" placeholder="パスワード(英数字8~16文字)" minLength={8} maxLength={16} required error={error} onChange={handleInput} />
-                <Input type="password" name="password2" placeholder="パスワード(確認用)" minLength={8} maxLength={16} required error={error} onChange={handleInput} />
+                <Password name="password1" placeholder="パスワード(英数字8~16文字)" error={error} onChange={handleInput} />
+                <Password name="password2" placeholder="パスワード(確認用)" error={error} onChange={handleInput} />
 
                 <VStack gap="4">
                   <p>生年月日</p>

--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -66,9 +66,9 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Input label="リンク URL" name="url" type="url" value={values.url} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <Input label="表示期限" name="period" type="date" value={values.period ?? ''} onChange={handlePeriod} />
           <InputFile label="画像" accept="image/*" required error={error} onChange={handleImage} />
           <InputFile label="動画" accept="video/*" onChange={handleVideo} />
+          <Input label="表示期限" name="period" type="date" value={values.period ?? ''} onChange={handlePeriod} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -10,8 +10,8 @@ import { useToast } from 'components/hooks/useToast'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
-import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
+import Password from 'components/widgets/Password'
 import style from '../Setting.module.scss'
 
 export default function PasswordChange(): React.JSX.Element {
@@ -19,23 +19,23 @@ export default function PasswordChange(): React.JSX.Element {
   const { loading, handleLoading } = useLoading()
   const { error, validate } = useRequired()
   const { toast, handleToast } = useToast()
-  const [values, setValues] = useState<PasswordChangeIn>({ oldPassword: '', newPassword1: '', newPassword2: '' })
+  const [values, setValues] = useState<PasswordChangeIn>({ oldPassword: '', password1: '', password2: '' })
 
   const handleBack = () => router.push('/setting/profile')
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
 
   const handleSubmit = async () => {
-    const { oldPassword, newPassword1, newPassword2 } = values
-    if (!validate({ oldPassword, newPassword1, newPassword2 })) return
-    if (newPassword1 !== newPassword2) {
+    const { oldPassword, password1, password2 } = values
+    if (!validate({ oldPassword, password1, password2 })) return
+    if (password1 !== password2) {
       handleToast('新規パスワードが一致しません', true)
       return
     }
     handleLoading(true)
     const request: PasswordChangeIn = {
       oldPassword: encrypt(oldPassword),
-      newPassword1: encrypt(newPassword1),
-      newPassword2: encrypt(newPassword2),
+      password1: encrypt(password1),
+      password2: encrypt(password2),
     }
     const ret = await postPasswordChange(request)
     handleLoading(false)
@@ -51,39 +51,9 @@ export default function PasswordChange(): React.JSX.Element {
       <article className={style.article_pass}>
         <form method="POST" action="" className={style.form_account}>
           <VStack gap="8">
-            <Input
-              type="password"
-              name="oldPassword"
-              minLength={8}
-              maxLength={16}
-              placeholder="現在パスワード"
-              value={values.oldPassword}
-              required
-              error={error}
-              onChange={handleInput}
-            />
-            <Input
-              type="password"
-              name="newPassword1"
-              minLength={8}
-              maxLength={16}
-              placeholder="新規パスワード(英数字8~16文字)"
-              value={values.newPassword1}
-              required
-              error={error}
-              onChange={handleInput}
-            />
-            <Input
-              type="password"
-              name="newPassword2"
-              minLength={8}
-              maxLength={16}
-              placeholder="新規パスワード(確認用)"
-              value={values.newPassword2}
-              required
-              error={error}
-              onChange={handleInput}
-            />
+            <Password value={values.oldPassword} name="oldPassword" placeholder="現在パスワード" error={error} onChange={handleInput} />
+            <Password value={values.password1} name="password1" placeholder="パスワード(英数字8~16文字)" error={error} onChange={handleInput} />
+            <Password value={values.password2} name="password2" placeholder="パスワード(確認用)" error={error} onChange={handleInput} />
           </VStack>
 
           <VStack gap="12" className="mv_40">

--- a/frontend/src/components/templates/setting/password/change.tsx
+++ b/frontend/src/components/templates/setting/password/change.tsx
@@ -10,8 +10,8 @@ import { useToast } from 'components/hooks/useToast'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
+import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
-import Password from 'components/widgets/Password'
 import style from '../Setting.module.scss'
 
 export default function PasswordChange(): React.JSX.Element {

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -11,8 +11,8 @@ import { useUser } from 'components/hooks/useUser'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
+import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
-import Password from 'components/widgets/Password'
 import style from '../Setting.module.scss'
 
 export default function WithdrawalConfirm(): React.JSX.Element {

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -11,8 +11,8 @@ import { useUser } from 'components/hooks/useUser'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
-import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
+import Password from 'components/widgets/Password'
 import style from '../Setting.module.scss'
 
 export default function WithdrawalConfirm(): React.JSX.Element {
@@ -48,7 +48,7 @@ export default function WithdrawalConfirm(): React.JSX.Element {
         <form method="POST" action="" className={style.form_account}>
           <VStack gap="8">
             <p className="red">本当に退会しますか？</p>
-            <Input type="password" name="password" minLength={8} maxLength={16} placeholder="パスワード" value={values.password} required error={error} onChange={handleInput} />
+            <Password value={values.password} name="password" placeholder="パスワード" error={error} onChange={handleInput} />
           </VStack>
 
           <VStack gap="12" className="mv_40">

--- a/frontend/src/components/widgets/Password/index.tsx
+++ b/frontend/src/components/widgets/Password/index.tsx
@@ -1,0 +1,14 @@
+import { ChangeEvent } from 'react'
+import Input from 'components/parts/Input'
+
+interface Props {
+  value?: string
+  name: string
+  placeholder: string
+  error?: string
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+}
+
+export default function Password(props: Props): React.JSX.Element {
+  return <Input type="password" minLength={8} maxLength={16} required {...props} />
+}

--- a/frontend/src/types/internal/auth.d.ts
+++ b/frontend/src/types/internal/auth.d.ts
@@ -26,14 +26,14 @@ export interface SignupVerifyOut {
 
 export interface PasswordChangeIn {
   oldPassword: string
-  newPassword1: string
-  newPassword2: string
+  password1: string
+  password2: string
 }
 
 export interface PasswordResetIn {
   token: string
-  newPassword1: string
-  newPassword2: string
+  password1: string
+  password2: string
 }
 
 export interface PasswordResetVerifyOut {


### PR DESCRIPTION
## Summary
- `widgets/Password/index.tsx` を新規追加。`type="password"` / `minLength=8` / `maxLength=16` / `required` を内包し、`placeholder` だけ呼び出し側から受け取る薄いラッパー
- 既存のパスワード入力 6 箇所を `<Input type="password">` から `<Password>` に置換
- `PasswordChangeIn` / `PasswordResetIn` の型フィールド `newPassword1/2` を `password1/2` にリネーム

## 変更内容

### 新規 widget
- `widgets/Password/index.tsx`: `Input` を内包し、Props は `value / name / placeholder / error / onChange` の base 順。共通の制約（最小 8 / 最大 16 文字 / required）を内側で固定

### 置換対象
- `account/login.tsx` — ログインのパスワード
- `account/signup/index.tsx` — 新規登録の `password1` / `password2`
- `account/reset/confirm.tsx` — パスワード再設定の `password1` / `password2`
- `setting/password/change.tsx` — パスワード変更の `oldPassword` / `password1` / `password2`
- `setting/withdrawal/confirm.tsx` — 退会確認のパスワード

### 型リネーム
- `types/internal/auth.d.ts`
  - `PasswordChangeIn`: `newPassword1` → `password1`, `newPassword2` → `password2`
  - `PasswordResetIn`: 同上

### その他
- `manage/advertise/edit.tsx` の InputFile required マーカー（前 PR #813 の積み残し）

## 注意
本 PR は **FE のみ**。BE 側 (`myus/api/src/types/schema/auth.py`, `usecase/auth.py`) で `new_password1/2` → `password1/2` のリネームが必要で、別 PR で対応する。両者をセットで本番反映しないとパスワード変更 / 再設定 API が壊れる。