### PR TITLE
【back】auth スキーマの password フィールドをリネームし定義順を整理

### DIFF
--- a/myus/api/src/types/schema/auth.py
+++ b/myus/api/src/types/schema/auth.py
@@ -2,6 +2,20 @@ from pydantic import BaseModel
 from api.utils.enum.index import GenderType
 
 
+class LoginIn(BaseModel):
+    username: str
+    password: str
+
+
+class LoginOut(BaseModel):
+    access: str
+    refresh: str
+
+
+class RefreshOut(BaseModel):
+    access: str
+
+
 class SignupEmailIn(BaseModel):
     email: str
 
@@ -21,19 +35,14 @@ class SignupIn(BaseModel):
     gender: GenderType
 
 
-class LoginIn(BaseModel):
-    username: str
-    password: str
+class SignupVerifyOut(BaseModel):
+    email: str
 
 
 class PasswordChangeIn(BaseModel):
     old_password: str
-    new_password1: str
-    new_password2: str
-
-
-class WithdrawalIn(BaseModel):
-    password: str
+    password1: str
+    password2: str
 
 
 class PasswordResetEmailIn(BaseModel):
@@ -42,22 +51,13 @@ class PasswordResetEmailIn(BaseModel):
 
 class PasswordResetIn(BaseModel):
     token: str
-    new_password1: str
-    new_password2: str
-
-
-class SignupVerifyOut(BaseModel):
-    email: str
+    password1: str
+    password2: str
 
 
 class PasswordResetVerifyOut(BaseModel):
     email: str
 
 
-class LoginOut(BaseModel):
-    access: str
-    refresh: str
-
-
-class RefreshOut(BaseModel):
-    access: str
+class WithdrawalIn(BaseModel):
+    password: str

--- a/myus/api/src/usecase/auth.py
+++ b/myus/api/src/usecase/auth.py
@@ -201,16 +201,16 @@ PASSWORD_MAX_LENGTH = 16
 def change_password(user_id: int, input: PasswordChangeIn) -> str:
     try:
         old_password = decrypt(input.old_password)
-        new_password1 = decrypt(input.new_password1)
-        new_password2 = decrypt(input.new_password2)
+        password1 = decrypt(input.password1)
+        password2 = decrypt(input.password2)
     except Exception:
         log.error("Decrypt error")
         return "復号に失敗しました!"
 
-    if new_password1 != new_password2:
+    if password1 != password2:
         return "新規パスワードが一致しません!"
 
-    if len(new_password1) < PASSWORD_MIN_LENGTH or len(new_password1) > PASSWORD_MAX_LENGTH:
+    if len(password1) < PASSWORD_MIN_LENGTH or len(password1) > PASSWORD_MAX_LENGTH:
         return "新規パスワードは英数字8~16文字で入力してください!"
 
     repository = injector.get(UserInterface)
@@ -223,7 +223,7 @@ def change_password(user_id: int, input: PasswordChangeIn) -> str:
     if not check_password(old_password, user_data.user.password):
         return "現在のパスワードが違います!"
 
-    new_user = replace(user_data.user, password=make_password(new_password1))
+    new_user = replace(user_data.user, password=make_password(password1))
     new_data = replace(user_data, user=new_user)
 
     try:
@@ -302,16 +302,16 @@ def reset_password(input: PasswordResetIn) -> str:
     user_id, _ = result
 
     try:
-        new_password1 = decrypt(input.new_password1)
-        new_password2 = decrypt(input.new_password2)
+        password1 = decrypt(input.password1)
+        password2 = decrypt(input.password2)
     except Exception:
         log.error("Decrypt error")
         return "復号に失敗しました!"
 
-    if new_password1 != new_password2:
+    if password1 != password2:
         return "新規パスワードが一致しません!"
 
-    if len(new_password1) < PASSWORD_MIN_LENGTH or len(new_password1) > PASSWORD_MAX_LENGTH:
+    if len(password1) < PASSWORD_MIN_LENGTH or len(password1) > PASSWORD_MAX_LENGTH:
         return "新規パスワードは英数字8~16文字で入力してください!"
 
     repository = injector.get(UserInterface)
@@ -321,7 +321,7 @@ def reset_password(input: PasswordResetIn) -> str:
         return "ユーザーが見つかりません!"
 
     user_data = users[0]
-    new_user = replace(user_data.user, password=make_password(new_password1))
+    new_user = replace(user_data.user, password=make_password(password1))
     new_data = replace(user_data, user=new_user)
 
     try:


### PR DESCRIPTION
## Summary
- `PasswordChangeIn` / `PasswordResetIn` の `new_password1` / `new_password2` を `password1` / `password2` にリネーム（FE 側 PR #814 と対応）
- `types/schema/auth.py` の定義順を機能ごとにグループ化し、各グループ内で In → Out の順に整理

## 変更内容

### フィールドリネーム
FE 側 (`types/internal/auth.d.ts`) ですでに `password1/2` に統一済み。BE 側もこれに合わせる。

```diff
class PasswordChangeIn(BaseModel):
    old_password: str
-   new_password1: str
-   new_password2: str
+   password1: str
+   password2: str

class PasswordResetIn(BaseModel):
    token: str
-   new_password1: str
-   new_password2: str
+   password1: str
+   password2: str
```

`usecase/auth.py` 内の参照 (8 箇所: `decrypt(input.new_password1)` など) も追従。

### 定義順の整理
従来は In / Out が機能をまたいで散らばっていた。以下の順に整理：

1. **Login**: `LoginIn` → `LoginOut`
2. **Refresh**: `RefreshOut`
3. **Signup**: `SignupEmailIn` → `SignupIn` → `SignupVerifyOut`
4. **PasswordChange**: `PasswordChangeIn`
5. **PasswordReset**: `PasswordResetEmailIn` → `PasswordResetIn` → `PasswordResetVerifyOut`
6. **Withdrawal**: `WithdrawalIn`

## 注意
本 PR は FE 側 PR #814 とセット。**両方マージしないとパスワード変更 / 再設定 API が壊れる**ため、運用時はマージ順に注意。