### PR TITLE
【front】管理画面のモーダル state を isModal / handleModal に統一

### DIFF
--- a/frontend/src/components/templates/manage/_container/Header/index.tsx
+++ b/frontend/src/components/templates/manage/_container/Header/index.tsx
@@ -9,12 +9,12 @@ interface Props {
   count: number
   ulid: string
   options: Option[]
-  onDelete: () => void
+  onModal: () => void
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void
 }
 
 export default function ManageHeader(props: Props): React.JSX.Element {
-  const { count, ulid, options, onDelete, onChange } = props
+  const { count, ulid, options, onModal, onChange } = props
 
   const router = useRouter()
 
@@ -23,7 +23,7 @@ export default function ManageHeader(props: Props): React.JSX.Element {
       {count > 0 && (
         <>
           <span className={style.count}>{count}件選択</span>
-          <Button color="red" size="s" name="一括削除" onClick={onDelete} />
+          <Button color="red" size="s" name="一括削除" onClick={onModal} />
         </>
       )}
       <Button color="blue" size="s" name="投稿管理" onClick={() => router.push('/manage')} />

--- a/frontend/src/components/templates/manage/advertise/index.tsx
+++ b/frontend/src/components/templates/manage/advertise/index.tsx
@@ -32,10 +32,10 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (advertise: Advertise) => router.push(`/manage/advertise/${advertise.ulid}`)
   const handleCreate = () => router.push('/manage/advertise/create')
 
@@ -51,7 +51,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -134,7 +134,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
           {selectedKeys.size > 0 && (
             <>
               <span className={style.selected_count}>{selectedKeys.size}件選択</span>
-              <Button color="red" size="s" name="一括削除" onClick={handleDelete} />
+              <Button color="red" size="s" name="一括削除" onClick={handleModal} />
             </>
           )}
           <Button color="blue" size="s" name="投稿管理" onClick={() => router.push('/manage')} />
@@ -146,7 +146,7 @@ export default function ManageAdvertises(props: Props): React.JSX.Element {
         table={{ datas, columns, rowKey: (a) => a.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/blog/index.tsx
+++ b/frontend/src/components/templates/manage/blog/index.tsx
@@ -137,7 +137,7 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onModal={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (b) => b.ulid }}

--- a/frontend/src/components/templates/manage/blog/index.tsx
+++ b/frontend/src/components/templates/manage/blog/index.tsx
@@ -33,10 +33,10 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (blog: Blog) => router.push(`/manage/blog/${blog.ulid}`)
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -55,7 +55,7 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -137,13 +137,13 @@ export default function ManageBlogs(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (b) => b.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/chat/index.tsx
+++ b/frontend/src/components/templates/manage/chat/index.tsx
@@ -32,10 +32,10 @@ export default function ManageChats(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (chat: Chat) => router.push(`/manage/chat/${chat.ulid}`)
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -54,7 +54,7 @@ export default function ManageChats(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -148,13 +148,13 @@ export default function ManageChats(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (c) => c.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/chat/index.tsx
+++ b/frontend/src/components/templates/manage/chat/index.tsx
@@ -148,7 +148,7 @@ export default function ManageChats(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onModal={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (c) => c.ulid }}

--- a/frontend/src/components/templates/manage/comic/index.tsx
+++ b/frontend/src/components/templates/manage/comic/index.tsx
@@ -137,7 +137,7 @@ export default function ManageComics(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onModal={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (c) => c.ulid }}

--- a/frontend/src/components/templates/manage/comic/index.tsx
+++ b/frontend/src/components/templates/manage/comic/index.tsx
@@ -33,10 +33,10 @@ export default function ManageComics(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (comic: Comic) => router.push(`/manage/comic/${comic.ulid}`)
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -55,7 +55,7 @@ export default function ManageComics(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -137,13 +137,13 @@ export default function ManageComics(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (c) => c.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/music/index.tsx
+++ b/frontend/src/components/templates/manage/music/index.tsx
@@ -32,10 +32,10 @@ export default function ManageMusics(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (music: Music) => router.push(`/manage/music/${music.ulid}`)
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -54,7 +54,7 @@ export default function ManageMusics(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -144,13 +144,13 @@ export default function ManageMusics(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (m) => m.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/music/index.tsx
+++ b/frontend/src/components/templates/manage/music/index.tsx
@@ -144,7 +144,7 @@ export default function ManageMusics(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onModal={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (m) => m.ulid }}

--- a/frontend/src/components/templates/manage/picture/index.tsx
+++ b/frontend/src/components/templates/manage/picture/index.tsx
@@ -33,10 +33,10 @@ export default function ManagePictures(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (picture: Picture) => router.push(`/manage/picture/${picture.ulid}`)
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -55,7 +55,7 @@ export default function ManagePictures(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -137,13 +137,13 @@ export default function ManagePictures(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (p) => p.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )

--- a/frontend/src/components/templates/manage/picture/index.tsx
+++ b/frontend/src/components/templates/manage/picture/index.tsx
@@ -137,7 +137,7 @@ export default function ManagePictures(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onModal={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (p) => p.ulid }}

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -137,7 +137,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onModal={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (v) => v.ulid }}

--- a/frontend/src/components/templates/manage/video/index.tsx
+++ b/frontend/src/components/templates/manage/video/index.tsx
@@ -33,10 +33,10 @@ export default function ManageVideos(props: Props): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const { handleError } = useApiError({ handleToast })
   const { currentPage, totalPages, handlePage } = usePagination(total, page)
-  const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
 
-  const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+  const handleModal = () => setIsModal(!isModal)
   const handleEdit = (video: Video) => router.push(`/manage/video/${video.ulid}`)
 
   const handleChannel = (e: ChangeEvent<HTMLSelectElement>) => {
@@ -55,7 +55,7 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       return
     }
     setSelectedKeys(new Set())
-    handleDelete()
+    handleModal()
     router.replace(router.asPath)
   }
 
@@ -137,13 +137,13 @@ export default function ManageVideos(props: Props): React.JSX.Element {
       type="table"
       toast={toast}
       isFooter={false}
-      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleDelete} onChange={handleChannel} />}
+      button={<ManageHeader count={selectedKeys.size} ulid={channelUlid} options={channelOptions} onDelete={handleModal} onChange={handleChannel} />}
     >
       <ManageTable
         table={{ datas, columns, rowKey: (v) => v.ulid }}
         selection={{ keys: selectedKeys, onChange: setSelectedKeys }}
         pagination={{ current: currentPage, total: totalPages, onChange: handlePage }}
-        deletion={{ open: isDeleteModal, loading, onClose: handleDelete, onAction: handleDeleteSubmit }}
+        deletion={{ open: isModal, loading, onClose: handleModal, onAction: handleDeleteSubmit }}
       />
     </Main>
   )


### PR DESCRIPTION
## Summary
- 管理画面の 7 ファイルでモーダル state を `isDeleteModal` → `isModal`、ハンドラを `handleDelete` → `handleModal` にリネーム
- 1 画面に 1 種類のモーダルしかない場合は汎用名で扱う方針

## 変更内容

### 背景
従来は削除モーダルしか存在しないにも関わらず `isDeleteModal` / `handleDelete` のように削除専用の命名になっていた。1 種類しかないモーダルなら命名で用途を限定する必要はなく、`isModal` / `handleModal` のシンプルな名前で良い。

実際の削除処理は `handleDeleteSubmit`（モーダル内のアクションボタン押下時に呼ばれる）が担っており、こちらは命名を維持。

### 機械的な置換
```diff
- const [isDeleteModal, setIsDeleteModal] = useState<boolean>(false)
+ const [isModal, setIsModal] = useState<boolean>(false)

- const handleDelete = () => setIsDeleteModal(!isDeleteModal)
+ const handleModal = () => setIsModal(!isModal)

- onDelete={handleDelete}
+ onDelete={handleModal}

- deletion={{ open: isDeleteModal, ..., onClose: handleDelete, ... }}
+ deletion={{ open: isModal, ..., onClose: handleModal, ... }}
```

### 対象ファイル
- `templates/manage/{advertise,blog,chat,comic,music,picture,video}/index.tsx`

### 注意
将来モーダルの種類が複数になった場合は、用途別の命名 (`isXxxModal`) に戻す必要あり。本 PR は「1 種類のとき限定」のリファクタ。