### PR TITLE
【front】DatePicker parts を追加し管理画面の日付入力に適用

### DIFF
--- a/frontend/src/components/parts/Icon/Calendar.tsx
+++ b/frontend/src/components/parts/Icon/Calendar.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  size: string
+  className?: string
+}
+
+export default function IconCalendar(props: Props): React.JSX.Element {
+  const { size, className } = props
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 16 16" width={size} height={size} className={className}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 1v2M11 1v2M2 6h12M3 3h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" />
+    </svg>
+  )
+}

--- a/frontend/src/components/parts/Input/DatePicker/DatePicker.module.scss
+++ b/frontend/src/components/parts/Input/DatePicker/DatePicker.module.scss
@@ -1,0 +1,189 @@
+.box {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .label {
+    display: block;
+    font-size: 14px;
+    color: rgb(50, 50, 50);
+
+    .required {
+      margin-left: 4px;
+      font-family: sans-serif;
+      color: rgb(220, 0, 0);
+    }
+  }
+
+  .field {
+    position: relative;
+    width: 100%;
+
+    .input {
+      width: 100%;
+      height: 36px;
+      padding: 6px 36px 6px 12px;
+      font-size: 14px;
+      border: 1px solid rgb(200, 200, 200);
+      border-radius: 5px;
+      background: rgb(255, 255, 255);
+      text-align: left;
+      color: rgb(0, 0, 0);
+      cursor: pointer;
+
+      &.placeholder {
+        color: rgb(150, 150, 150);
+      }
+
+      &.error {
+        color: rgb(0, 0, 0);
+        background: rgb(255, 240, 240);
+      }
+
+      &.active,
+      &:focus-visible {
+        outline: none;
+        border-color: rgb(40, 130, 250);
+      }
+    }
+
+    .icon {
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: rgb(120, 120, 120);
+      pointer-events: none;
+    }
+
+    .calendar {
+      position: absolute;
+      bottom: calc(100% + 4px);
+      left: 0;
+      z-index: 10;
+      width: 280px;
+      background: rgb(255, 255, 255);
+      border: 1px solid rgb(220, 220, 220);
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      padding: 12px;
+
+      .nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 8px;
+
+        .title {
+          font-size: 14px;
+          font-weight: 600;
+          color: rgb(30, 30, 30);
+        }
+
+        .nav_button {
+          width: 28px;
+          height: 28px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 18px;
+          background: transparent;
+          border: 1px solid transparent;
+          border-radius: 6px;
+          color: rgb(50, 50, 50);
+          cursor: pointer;
+
+          &:hover {
+            background: rgb(245, 245, 245);
+          }
+        }
+      }
+
+      .weekdays {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: 2px;
+        margin-bottom: 4px;
+
+        .weekday {
+          text-align: center;
+          font-size: 12px;
+          font-weight: 600;
+          color: rgb(120, 120, 120);
+          padding: 4px 0;
+
+          &.sunday {
+            color: rgb(220, 38, 38);
+          }
+
+          &.saturday {
+            color: rgb(37, 99, 235);
+          }
+        }
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: 2px;
+
+        .empty {
+          height: 32px;
+        }
+
+        .day {
+          height: 32px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 14px;
+          background: transparent;
+          border: 1px solid transparent;
+          border-radius: 6px;
+          color: rgb(30, 30, 30);
+          cursor: pointer;
+
+          &:hover:not(:disabled) {
+            background: rgb(240, 245, 255);
+          }
+
+          &.sunday {
+            color: rgb(220, 38, 38);
+          }
+
+          &.saturday {
+            color: rgb(37, 99, 235);
+          }
+
+          &.today {
+            font-weight: 700;
+            text-decoration: underline;
+          }
+
+          &.selected {
+            background: rgb(44, 110, 203);
+            color: rgb(255, 255, 255);
+          }
+
+          &.selected:hover {
+            background: rgb(34, 90, 173);
+          }
+
+          &.disabled,
+          &:disabled {
+            color: rgb(200, 200, 200);
+            cursor: not-allowed;
+            background: transparent;
+          }
+        }
+      }
+    }
+  }
+
+  .error_text {
+    padding-top: 2px;
+    text-indent: 4px;
+    font-size: 12px;
+    color: rgb(255, 0, 0);
+  }
+}

--- a/frontend/src/components/parts/Input/DatePicker/index.tsx
+++ b/frontend/src/components/parts/Input/DatePicker/index.tsx
@@ -6,7 +6,6 @@ import style from './DatePicker.module.scss'
 
 interface DayCell {
   date: Date
-  isCurrentMonth: boolean
   isDisabled: boolean
 }
 
@@ -31,7 +30,7 @@ const fromIsoDate = (iso?: string): Date | undefined => {
 
 const isSameDate = (a: Date, b: Date): boolean => a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
 
-const buildMonthGrid = (year: number, month: number, min?: Date, max?: Date): DayCell[] => {
+const buildMonthGrid = (year: number, month: number, min?: Date, max?: Date): (DayCell | null)[] => {
   const startDay = new Date(year, month, 1).getDay()
   const lastDay = new Date(year, month + 1, 0).getDate()
   const isDisabled = (d: Date): boolean => {
@@ -39,21 +38,13 @@ const buildMonthGrid = (year: number, month: number, min?: Date, max?: Date): Da
     if (max && d > max) return true
     return false
   }
-  const cells: DayCell[] = []
-  for (let i = startDay; i > 0; i--) {
-    const d = new Date(year, month, 1 - i)
-    cells.push({ date: d, isCurrentMonth: false, isDisabled: isDisabled(d) })
-  }
+  const cells: (DayCell | null)[] = []
+  for (let i = 0; i < startDay; i++) cells.push(null)
   for (let i = 1; i <= lastDay; i++) {
     const d = new Date(year, month, i)
-    cells.push({ date: d, isCurrentMonth: true, isDisabled: isDisabled(d) })
+    cells.push({ date: d, isDisabled: isDisabled(d) })
   }
-  let nextDay = 1
-  while (cells.length < 42) {
-    const d = new Date(year, month + 1, nextDay)
-    cells.push({ date: d, isCurrentMonth: false, isDisabled: isDisabled(d) })
-    nextDay++
-  }
+  while (cells.length < 42) cells.push(null)
   return cells
 }
 
@@ -115,25 +106,19 @@ export default function DatePicker(props: Props): React.JSX.Element {
   const handleToggle = () => setIsOpen((prev) => !prev)
 
   const handlePrev = () => {
-    if (viewMonth === 0) {
-      setViewMonth(11)
-      setViewYear(viewYear - 1)
-    } else {
-      setViewMonth(viewMonth - 1)
-    }
+    const d = new Date(viewYear, viewMonth - 1, 1)
+    setViewYear(d.getFullYear())
+    setViewMonth(d.getMonth())
   }
 
   const handleNext = () => {
-    if (viewMonth === 11) {
-      setViewMonth(0)
-      setViewYear(viewYear + 1)
-    } else {
-      setViewMonth(viewMonth + 1)
-    }
+    const d = new Date(viewYear, viewMonth + 1, 1)
+    setViewYear(d.getFullYear())
+    setViewMonth(d.getMonth())
   }
 
   const handleSelect = (cell: DayCell) => {
-    if (cell.isDisabled || !cell.isCurrentMonth) return
+    if (cell.isDisabled) return
     onChange?.(toIsoDate(cell.date))
     setIsOpen(false)
   }
@@ -171,7 +156,7 @@ export default function DatePicker(props: Props): React.JSX.Element {
             </div>
             <div className={style.grid}>
               {cells.map((cell, i) => {
-                if (!cell.isCurrentMonth) return <span key={i} className={style.empty} />
+                if (!cell) return <span key={i} className={style.empty} />
                 const day = cell.date.getDay()
                 const isToday = isSameDate(cell.date, today)
                 const isSelected = !!selected && isSameDate(cell.date, selected)

--- a/frontend/src/components/parts/Input/DatePicker/index.tsx
+++ b/frontend/src/components/parts/Input/DatePicker/index.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/router'
+import cx from 'utils/functions/cx'
+import IconCalendar from 'components/parts/Icon/Calendar'
+import style from './DatePicker.module.scss'
+
+interface DayCell {
+  date: Date
+  isCurrentMonth: boolean
+  isDisabled: boolean
+}
+
+const PLACEHOLDER_MAP: Record<string, string> = {
+  ja: '日付を選択',
+  en: 'Select a date',
+}
+
+const toIsoDate = (date: Date): string => {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+const fromIsoDate = (iso?: string): Date | undefined => {
+  if (!iso) return undefined
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return undefined
+  return new Date(y, m - 1, d)
+}
+
+const isSameDate = (a: Date, b: Date): boolean => a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+
+const buildMonthGrid = (year: number, month: number, min?: Date, max?: Date): DayCell[] => {
+  const startDay = new Date(year, month, 1).getDay()
+  const lastDay = new Date(year, month + 1, 0).getDate()
+  const isDisabled = (d: Date): boolean => {
+    if (min && d < min) return true
+    if (max && d > max) return true
+    return false
+  }
+  const cells: DayCell[] = []
+  for (let i = startDay; i > 0; i--) {
+    const d = new Date(year, month, 1 - i)
+    cells.push({ date: d, isCurrentMonth: false, isDisabled: isDisabled(d) })
+  }
+  for (let i = 1; i <= lastDay; i++) {
+    const d = new Date(year, month, i)
+    cells.push({ date: d, isCurrentMonth: true, isDisabled: isDisabled(d) })
+  }
+  let nextDay = 1
+  while (cells.length < 42) {
+    const d = new Date(year, month + 1, nextDay)
+    cells.push({ date: d, isCurrentMonth: false, isDisabled: isDisabled(d) })
+    nextDay++
+  }
+  return cells
+}
+
+interface Props {
+  label?: string
+  value?: string
+  name?: string
+  placeholder?: string
+  error?: string
+  className?: string
+  required?: boolean
+  minDate?: string
+  maxDate?: string
+  onChange?: (date: string) => void
+}
+
+export default function DatePicker(props: Props): React.JSX.Element {
+  const { label, value, placeholder, error, className, required = false, minDate, maxDate, onChange } = props
+
+  const router = useRouter()
+  const locale = router.locale ?? 'ja'
+
+  const boxRef = useRef<HTMLDivElement>(null)
+  const today = useMemo(() => new Date(), [])
+  const min = useMemo(() => fromIsoDate(minDate), [minDate])
+  const max = useMemo(() => fromIsoDate(maxDate), [maxDate])
+  const selected = useMemo(() => fromIsoDate(value), [value])
+
+  const displayFormat = useMemo(() => new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric' }), [locale])
+  const titleFormat = useMemo(() => new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long' }), [locale])
+  const weekdays = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short' })
+    return Array.from({ length: 7 }, (_, i) => fmt.format(new Date(2024, 0, 7 + i)))
+  }, [locale])
+  const placeholderText = placeholder ?? PLACEHOLDER_MAP[locale] ?? PLACEHOLDER_MAP.ja
+
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [viewYear, setViewYear] = useState<number>((selected ?? today).getFullYear())
+  const [viewMonth, setViewMonth] = useState<number>((selected ?? today).getMonth())
+
+  const isError = !!error || (error === '' && required && !selected)
+  const cells = useMemo(() => buildMonthGrid(viewYear, viewMonth, min, max), [viewYear, viewMonth, min, max])
+
+  useEffect(() => {
+    if (!selected) return
+    setViewYear(selected.getFullYear())
+    setViewMonth(selected.getMonth())
+  }, [selected])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  const handleToggle = () => setIsOpen((prev) => !prev)
+
+  const handlePrev = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11)
+      setViewYear(viewYear - 1)
+    } else {
+      setViewMonth(viewMonth - 1)
+    }
+  }
+
+  const handleNext = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0)
+      setViewYear(viewYear + 1)
+    } else {
+      setViewMonth(viewMonth + 1)
+    }
+  }
+
+  const handleSelect = (cell: DayCell) => {
+    if (cell.isDisabled || !cell.isCurrentMonth) return
+    onChange?.(toIsoDate(cell.date))
+    setIsOpen(false)
+  }
+
+  return (
+    <div ref={boxRef} className={cx(style.box, className)}>
+      {label && (
+        <label htmlFor={label} className={style.label}>
+          {label}
+          {required && <span className={style.required}>*</span>}
+        </label>
+      )}
+      <div className={style.field}>
+        <button id={label} type="button" onClick={handleToggle} className={cx(style.input, !selected && style.placeholder, isOpen && style.active, isError && style.error)}>
+          {selected ? (locale === 'ja' ? toIsoDate(selected) : displayFormat.format(selected)) : placeholderText}
+        </button>
+        <IconCalendar size="16" className={style.icon} />
+        {isOpen && (
+          <div className={style.calendar}>
+            <div className={style.nav}>
+              <button type="button" onClick={handlePrev} className={style.nav_button}>
+                ‹
+              </button>
+              <span className={style.title}>{titleFormat.format(new Date(viewYear, viewMonth, 1))}</span>
+              <button type="button" onClick={handleNext} className={style.nav_button}>
+                ›
+              </button>
+            </div>
+            <div className={style.weekdays}>
+              {weekdays.map((w, i) => (
+                <span key={w} className={cx(style.weekday, i === 0 && style.sunday, i === 6 && style.saturday)}>
+                  {w}
+                </span>
+              ))}
+            </div>
+            <div className={style.grid}>
+              {cells.map((cell, i) => {
+                if (!cell.isCurrentMonth) return <span key={i} className={style.empty} />
+                const day = cell.date.getDay()
+                const isToday = isSameDate(cell.date, today)
+                const isSelected = !!selected && isSameDate(cell.date, selected)
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    disabled={cell.isDisabled}
+                    onClick={() => handleSelect(cell)}
+                    className={cx(
+                      style.day,
+                      isToday && style.today,
+                      isSelected && style.selected,
+                      cell.isDisabled && style.disabled,
+                      !cell.isDisabled && !isSelected && day === 0 && style.sunday,
+                      !cell.isDisabled && !isSelected && day === 6 && style.saturday,
+                    )}
+                  >
+                    {cell.date.getDate()}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+      {error && <p className={style.error_text}>{error}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/templates/manage/advertise/create.tsx
+++ b/frontend/src/components/templates/manage/advertise/create.tsx
@@ -9,6 +9,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import DatePicker from 'components/parts/Input/DatePicker'
 import InputFile from 'components/parts/Input/File'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -26,7 +27,7 @@ export default function AdvertiseCreate(): React.JSX.Element {
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
-  const handlePeriod = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, period: e.target.value || null })
+  const handlePeriod = (period: string) => setValues({ ...values, period: period || null })
   const handleImage = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
   const handleVideo = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, video: files })
 
@@ -59,9 +60,9 @@ export default function AdvertiseCreate(): React.JSX.Element {
           <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
           <Input label="リンク URL" name="url" type="url" required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" required error={error} onChange={handleText} />
-          <Input label="表示期限" name="period" type="date" onChange={handlePeriod} />
           <InputFile label="画像" accept="image/*" required error={error} onChange={handleImage} />
           <InputFile label="動画" accept="video/*" onChange={handleVideo} />
+          <DatePicker label="期間" name="period" value={values.period ?? ''} onChange={handlePeriod} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/advertise/edit.tsx
+++ b/frontend/src/components/templates/manage/advertise/edit.tsx
@@ -10,6 +10,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import DatePicker from 'components/parts/Input/DatePicker'
 import InputFile from 'components/parts/Input/File'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -34,7 +35,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
   const handlePublish = () => setValues({ ...values, publish: !values.publish })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
-  const handlePeriod = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, period: e.target.value || null })
+  const handlePeriod = (period: string) => setValues({ ...values, period: period || null })
   const handleImage = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, image: files })
   const handleVideo = (files: File | File[]) => Array.isArray(files) || setValues({ ...values, video: files })
 
@@ -68,7 +69,7 @@ export default function ManageAdvertiseEdit(props: Props): React.JSX.Element {
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
           <InputFile label="画像" accept="image/*" required error={error} onChange={handleImage} />
           <InputFile label="動画" accept="video/*" onChange={handleVideo} />
-          <Input label="表示期限" name="period" type="date" value={values.period ?? ''} onChange={handlePeriod} />
+          <DatePicker label="表示期限" name="period" value={values.period ?? ''} onChange={handlePeriod} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/chat/create.tsx
+++ b/frontend/src/components/templates/manage/chat/create.tsx
@@ -5,13 +5,13 @@ import { ChatIn } from 'types/internal/media/input'
 import { Option } from 'types/internal/other'
 import { postChatCreate } from 'api/internal/manage/create'
 import { FetchError } from 'utils/constants/enum'
-import { nowDate } from 'utils/functions/datetime'
 import { useLoading } from 'components/hooks/useLoading'
 import { useRequired } from 'components/hooks/useRequired'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import DatePicker from 'components/parts/Input/DatePicker'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -38,6 +38,7 @@ export default function ChatCreate(props: Props): React.JSX.Element {
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handlePeriod = (period: string) => setValues({ ...values, period })
 
   const handleForm = async () => {
     const { channelUlid, categoryUlid, title, content, period } = values
@@ -62,7 +63,7 @@ export default function ChatCreate(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" required error={error} onChange={handleText} />
-          <Input label="期間" name="period" placeholder={`${nowDate.year}-12-31`} required error={error} onChange={handleInput} />
+          <DatePicker label="期間" name="period" value={values.period} required error={error} onChange={handlePeriod} />
         </VStack>
       </form>
     </Main>

--- a/frontend/src/components/templates/manage/chat/edit.tsx
+++ b/frontend/src/components/templates/manage/chat/edit.tsx
@@ -15,6 +15,7 @@ import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
+import DatePicker from 'components/parts/Input/DatePicker'
 import SelectBox from 'components/parts/Input/SelectBox'
 import Textarea from 'components/parts/Input/Textarea'
 import ToggleCard from 'components/parts/Input/ToggleCard'
@@ -45,6 +46,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
   const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
   const handleText = (e: ChangeEvent<HTMLTextAreaElement>) => setValues({ ...values, [e.target.name]: e.target.value })
+  const handlePeriod = (period: string) => setValues({ ...values, period })
 
   const handleForm = async () => {
     const { categoryUlid, title, content, period } = values
@@ -75,7 +77,7 @@ export default function ManageChatEdit(props: Props): React.JSX.Element {
           <SelectBox label="カテゴリー" name="categoryUlid" value={values.categoryUlid} options={categoryOptions} required error={error} onChange={handleSelect} />
           <Input label="タイトル" name="title" value={values.title} required error={error} onChange={handleInput} />
           <Textarea label="内容" name="content" value={values.content} required error={error} onChange={handleText} />
-          <Input label="期間" name="period" value={values.period} required error={error} onChange={handleInput} />
+          <DatePicker label="期間" name="period" value={values.period} required error={error} onChange={handlePeriod} />
         </VStack>
       </form>
     </Main>


### PR DESCRIPTION
## Summary
- 自前実装の `DatePicker` を `parts/Input/` に追加（ドロップダウンカレンダー / locale 対応 / 自前 SCSS）
- `parts/Icon/Calendar.tsx` を追加
- 管理画面 advertise / chat の create/edit で `<Input type="date">` を `<DatePicker>` に置き換え

## 変更内容

### 新規 widget: `parts/Input/DatePicker/`
- 自前実装でライブラリ依存なし
- 入力欄クリックでカレンダードロップダウン展開（入力欄の上に表示、ラベルに重なる）
- `Intl.DateTimeFormat(locale, ...)` で以下を生成：
  - 表示フォーマット: `{ year, month, day }`
  - ヘッダータイトル: `{ year, month: 'long' }`
  - 曜日ヘッダ: `{ weekday: 'short' }` を 7 日分
- ただし locale が `ja` のときは表示を `YYYY-MM-DD` に固定（プロジェクトの慣例）
- placeholder は ja/en の小さい map から fallback
- 内部 value / onChange は ISO 文字列 `YYYY-MM-DD` (locale 非依存)
- `minDate` / `maxDate` で範囲外を disabled に
- 前後月の日付セルは空欄表示でクリック不可
- 視覚: 土曜青 / 日曜赤、today 強調、selected 青背景、開いている間 active 青枠
- 外側クリックでドロップダウン close

### 新規 icon
- `parts/Icon/Calendar.tsx` (Bootstrap Icons calendar3 ベース)

### 適用先
- `templates/manage/advertise/create.tsx`
- `templates/manage/advertise/edit.tsx`
- `templates/manage/chat/create.tsx`
- `templates/manage/chat/edit.tsx`

各ファイルで `<Input type="date">` を `<DatePicker>` に差し替え、`handlePeriod` のシグネチャを `(period: string) => void` に変更。

## 拡張余地
- `Intl` ベースなので将来 locale 追加時に自動対応（ja special-case を外せば全 locale で Intl が走る）
- 将来的にレンジ選択 / disabled callback / 月年プルダウンなどが必要になれば追加可能