### PR TITLE
【front】退会ページを Alert コンポーネント化しレイアウトを統一

### DIFF
--- a/frontend/src/components/parts/Alert/Alert.module.scss
+++ b/frontend/src/components/parts/Alert/Alert.module.scss
@@ -4,7 +4,7 @@
   gap: 8px;
   padding: 10px 12px;
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.4;
   border: 1px solid transparent;
   border-radius: 5px;
 

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -10,10 +10,10 @@ import { useToast } from 'components/hooks/useToast'
 import { useUser } from 'components/hooks/useUser'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
+import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
-import style from '../Setting.module.scss'
 
 export default function WithdrawalConfirm(): React.JSX.Element {
   const router = useRouter()
@@ -43,11 +43,12 @@ export default function WithdrawalConfirm(): React.JSX.Element {
   }
 
   return (
-    <Main title="退会処理" toast={toast}>
-      <article className={style.article_pass}>
-        <form method="POST" action="" className={style.form_account}>
+    <Main metaTitle="退会処理" toast={toast}>
+      <article className="article_registration">
+        <form method="POST" action="" className="form_account">
+          <h1 className="login_h1">退会処理</h1>
           <VStack gap="8">
-            <p className="red">本当に退会しますか？</p>
+            <Alert type="error">本当に退会しますか？</Alert>
             <Password value={values.password} name="password" placeholder="パスワード" error={error} onChange={handleInput} />
           </VStack>
 

--- a/frontend/src/components/templates/setting/withdrawal/index.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/index.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router'
 import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
+import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import VStack from 'components/parts/Stack/Vertical'
-import style from '../Setting.module.scss'
 
 export default function Withdrawal(): React.JSX.Element {
   const router = useRouter()
@@ -11,12 +11,16 @@ export default function Withdrawal(): React.JSX.Element {
   const handleNext = () => router.push('/setting/withdrawal/confirm')
 
   return (
-    <Main title="退会処理">
-      <article className={style.article_pass}>
-        <div className={style.form_account}>
-          <VStack gap="8" className="ws_nowrap">
-            <p>退会するとアカウントが利用できなくなります！</p>
-            <p className="red">この操作は取り消しできません。</p>
+    <Main metaTitle="退会処理">
+      <article className="article_registration">
+        <div className="form_account">
+          <h1 className="login_h1">退会処理</h1>
+          <VStack gap="8">
+            <Alert type="error">
+              退会するとアカウントが利用できなくなります！
+              <br />
+              この操作は取り消しできません。
+            </Alert>
           </VStack>
 
           <VStack gap="12" className="mv_40">


### PR DESCRIPTION
## Summary
- 退会ページの注意文を `<p className="red">` から `Alert` コンポーネントに置き換え
- `Setting.module.scss` 依存をやめ、登録ページと同じ `article_registration` / `form_account` / `login_h1` グローバルクラスに統一
- `Main` の `title` プロパティを `metaTitle` に修正

## 変更内容

### `templates/setting/withdrawal/index.tsx`
- 注意文 2 行を `Alert type="error"` 内に `<br />` で 1 つにまとめて表示
- `Setting.module.scss` の import を削除し、`article_registration` / `form_account` / `login_h1` を使用
- `Main` の `title` → `metaTitle` に変更
- `VStack` の `ws_nowrap` を削除（Alert 側でレイアウトされるため不要）

### `templates/setting/withdrawal/confirm.tsx`
- 「本当に退会しますか？」を `Alert type="error"` で表示
- `Setting.module.scss` の import を削除し、`article_registration` / `form_account` / `login_h1` を使用
- `Main` の `title` → `metaTitle` に変更

### `parts/Alert/Alert.module.scss`
- `line-height` を `1.5` → `1.4` に微調整（複数行 Alert の見た目を整える）