### PR TITLE
【front】account 系の form スタイルを Account.module.scss に切り出し

### DIFF
--- a/frontend/src/components/templates/account/Account.module.scss
+++ b/frontend/src/components/templates/account/Account.module.scss
@@ -1,0 +1,28 @@
+.account {
+  display: flex;
+  justify-content: center;
+
+  a {
+    text-decoration: none;
+  }
+
+  .form {
+    width: 100%;
+    max-width: 380px;
+    padding: 15px;
+  }
+
+  .title {
+    margin: 40px 0;
+    font-family: 'Libre Caslon Display', serif;
+    font-size: 28px;
+    color: rgb(50, 50, 50);
+  }
+
+  .signup_title {
+    margin-bottom: 20px;
+    font-family: 'Libre Caslon Display', serif;
+    font-size: 28px;
+    color: rgb(50, 50, 50);
+  }
+}

--- a/frontend/src/components/templates/account/login.tsx
+++ b/frontend/src/components/templates/account/login.tsx
@@ -16,6 +16,7 @@ import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
 import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
+import style from './Account.module.scss'
 
 export default function Login(): React.JSX.Element {
   const { t } = useTranslation('common')
@@ -50,10 +51,9 @@ export default function Login(): React.JSX.Element {
 
   return (
     <Main title="ログイン" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="login_h1">{t('welcome')}</h1>
-
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.title}>{t('welcome')}</h1>
           {message && (
             <ul className="messages_login">
               <li>{message}</li>

--- a/frontend/src/components/templates/account/reset/confirm.tsx
+++ b/frontend/src/components/templates/account/reset/confirm.tsx
@@ -13,6 +13,7 @@ import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
 import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../Account.module.scss'
 
 export default function ResetConfirm(): React.JSX.Element {
   const router = useRouter()
@@ -70,10 +71,9 @@ export default function ResetConfirm(): React.JSX.Element {
 
   return (
     <Main metaTitle="パスワード再設定" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="login_h1">パスワード再設定</h1>
-
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.title}>パスワード再設定</h1>
           {isVerified && (
             <>
               <VStack gap="8">

--- a/frontend/src/components/templates/account/reset/done.tsx
+++ b/frontend/src/components/templates/account/reset/done.tsx
@@ -3,6 +3,7 @@ import Footer from 'components/layout/Footer'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../Account.module.scss'
 
 export default function ResetDone(): React.JSX.Element {
   const router = useRouter()
@@ -10,9 +11,9 @@ export default function ResetDone(): React.JSX.Element {
 
   return (
     <Main metaTitle="パスワード再設定">
-      <article className="article_registration">
-        <div className="form_account">
-          <h1 className="login_h1">パスワード再設定</h1>
+      <article className={style.account}>
+        <div className={style.form}>
+          <h1 className={style.title}>パスワード再設定</h1>
           <p className="fs_14">パスワードの再設定が完了しました!</p>
           <VStack gap="12" className="mv_40">
             <Button color="blue" size="l" name="ログイン" onClick={handleBack} />

--- a/frontend/src/components/templates/account/reset/index.tsx
+++ b/frontend/src/components/templates/account/reset/index.tsx
@@ -11,6 +11,7 @@ import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../Account.module.scss'
 
 export default function Reset(): React.JSX.Element {
   const router = useRouter()
@@ -36,9 +37,9 @@ export default function Reset(): React.JSX.Element {
 
   return (
     <Main metaTitle="パスワードリセット" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="login_h1">パスワードリセット</h1>
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.title}>パスワードリセット</h1>
           <VStack gap="8">
             <Input type="email" name="email" placeholder="メールアドレス" maxLength={255} required error={error} onChange={handleInput} />
             <Alert type="info">メールアドレス宛にパスワード再設定用リンクを送信します。</Alert>

--- a/frontend/src/components/templates/account/signup/email.tsx
+++ b/frontend/src/components/templates/account/signup/email.tsx
@@ -11,6 +11,7 @@ import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import Input from 'components/parts/Input'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../Account.module.scss'
 
 export default function SignupEmail(): React.JSX.Element {
   const router = useRouter()
@@ -36,10 +37,9 @@ export default function SignupEmail(): React.JSX.Element {
 
   return (
     <Main metaTitle="アカウント登録" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="signup_h1">アカウント登録</h1>
-
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.signup_title}>アカウント登録</h1>
           <VStack gap="8">
             <Input type="email" name="email" placeholder="メールアドレス" maxLength={255} required error={error} onChange={handleInput} />
             <Alert type="info">

--- a/frontend/src/components/templates/account/signup/index.tsx
+++ b/frontend/src/components/templates/account/signup/index.tsx
@@ -17,6 +17,7 @@ import Radio from 'components/parts/Input/Radio'
 import SelectBox from 'components/parts/Input/SelectBox'
 import HStack from 'components/parts/Stack/Horizontal'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../Account.module.scss'
 
 const initSignup: SignupIn = {
   token: '',
@@ -80,10 +81,9 @@ export default function Signup(): React.JSX.Element {
 
   return (
     <Main metaTitle="アカウント登録" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="signup_h1">アカウント登録</h1>
-
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.signup_title}>アカウント登録</h1>
           {isVerified && (
             <>
               <VStack gap="8">

--- a/frontend/src/components/templates/setting/Setting.module.scss
+++ b/frontend/src/components/templates/setting/Setting.module.scss
@@ -89,3 +89,32 @@
   margin: 10px 0;
   flex-shrink: 0;
 }
+
+.account {
+  display: flex;
+  justify-content: center;
+
+  a {
+    text-decoration: none;
+  }
+
+  .form {
+    width: 100%;
+    max-width: 380px;
+    padding: 15px;
+  }
+
+  .title {
+    margin: 40px 0;
+    font-family: 'Libre Caslon Display', serif;
+    font-size: 28px;
+    color: rgb(50, 50, 50);
+  }
+
+  .signup_title {
+    margin-bottom: 20px;
+    font-family: 'Libre Caslon Display', serif;
+    font-size: 28px;
+    color: rgb(50, 50, 50);
+  }
+}

--- a/frontend/src/components/templates/setting/mypage/channel/create.tsx
+++ b/frontend/src/components/templates/setting/mypage/channel/create.tsx
@@ -55,10 +55,9 @@ export default function ChannelCreate(): React.JSX.Element {
 
   return (
     <Main metaTitle="チャンネル作成" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="signup_h1">チャンネル作成</h1>
-
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.signup_title}>チャンネル作成</h1>
           {message && (
             <ul className="messages_signup">
               <li>{message}</li>

--- a/frontend/src/components/templates/setting/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/confirm.tsx
@@ -14,6 +14,7 @@ import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../../account/Account.module.scss'
 
 export default function WithdrawalConfirm(): React.JSX.Element {
   const router = useRouter()
@@ -44,9 +45,9 @@ export default function WithdrawalConfirm(): React.JSX.Element {
 
   return (
     <Main metaTitle="退会処理" toast={toast}>
-      <article className="article_registration">
-        <form method="POST" action="" className="form_account">
-          <h1 className="login_h1">退会処理</h1>
+      <article className={style.account}>
+        <form method="POST" action="" className={style.form}>
+          <h1 className={style.title}>退会処理</h1>
           <VStack gap="8">
             <Alert type="error">本当に退会しますか？</Alert>
             <Password value={values.password} name="password" placeholder="パスワード" error={error} onChange={handleInput} />

--- a/frontend/src/components/templates/setting/withdrawal/index.tsx
+++ b/frontend/src/components/templates/setting/withdrawal/index.tsx
@@ -4,6 +4,7 @@ import Main from 'components/layout/Main'
 import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import VStack from 'components/parts/Stack/Vertical'
+import style from '../../account/Account.module.scss'
 
 export default function Withdrawal(): React.JSX.Element {
   const router = useRouter()
@@ -12,9 +13,9 @@ export default function Withdrawal(): React.JSX.Element {
 
   return (
     <Main metaTitle="退会処理">
-      <article className="article_registration">
-        <div className="form_account">
-          <h1 className="login_h1">退会処理</h1>
+      <article className={style.account}>
+        <div className={style.form}>
+          <h1 className={style.title}>退会処理</h1>
           <VStack gap="8">
             <Alert type="error">
               退会するとアカウントが利用できなくなります！

--- a/frontend/src/styles/internal/registration.scss
+++ b/frontend/src/styles/internal/registration.scss
@@ -74,32 +74,3 @@
   display: flex;
   gap: 4px;
 }
-
-.account {
-  display: flex;
-  justify-content: center;
-
-  a {
-    text-decoration: none;
-  }
-
-  .form {
-    width: 100%;
-    max-width: 380px;
-    padding: 15px;
-  }
-
-  .title {
-    margin: 40px 0;
-    font-family: 'Libre Caslon Display', serif;
-    font-size: 28px;
-    color: rgb(50, 50, 50);
-  }
-
-  .signup_title {
-    margin-bottom: 20px;
-    font-family: 'Libre Caslon Display', serif;
-    font-size: 28px;
-    color: rgb(50, 50, 50);
-  }
-}

--- a/frontend/src/styles/internal/registration.scss
+++ b/frontend/src/styles/internal/registration.scss
@@ -1,37 +1,7 @@
-/* registration */
-.article_registration {
-  display: flex;
-  justify-content: center;
-}
-
-.form_account {
-  width: 100%;
-  max-width: 380px;
-  padding: 15px;
-}
-
-.form_account .login_h1 {
-  font-family: 'Libre Caslon Display', serif;
-  font-size: 28px;
-  color: rgb(50, 50, 50);
-  margin: 40px 0;
-}
-
 .myus_h1 {
   font-family: 'Libre Caslon Display', serif;
   font-size: 26px;
   margin: 0 0 24px 0;
-}
-
-.form_account .signup_h1 {
-  font-family: 'Libre Caslon Display', serif;
-  font-size: 28px;
-  color: rgb(50, 50, 50);
-  margin-bottom: 20px;
-}
-
-.form_account .checkbox {
-  font-weight: 400;
 }
 
 .password_reset {
@@ -100,11 +70,36 @@
   margin: 0 0 16px 0;
 }
 
-.article_registration a {
-  text-decoration: none;
-}
-
 .name_group {
   display: flex;
   gap: 4px;
+}
+
+.account {
+  display: flex;
+  justify-content: center;
+
+  a {
+    text-decoration: none;
+  }
+
+  .form {
+    width: 100%;
+    max-width: 380px;
+    padding: 15px;
+  }
+
+  .title {
+    margin: 40px 0;
+    font-family: 'Libre Caslon Display', serif;
+    font-size: 28px;
+    color: rgb(50, 50, 50);
+  }
+
+  .signup_title {
+    margin-bottom: 20px;
+    font-family: 'Libre Caslon Display', serif;
+    font-size: 28px;
+    color: rgb(50, 50, 50);
+  }
 }


### PR DESCRIPTION
## Summary
- `styles/internal/registration.scss` のグローバル class（`article_registration` / `form_account` / `login_h1` / `signup_h1`）を `templates/account/Account.module.scss` に切り出し、CSS Modules 化
- account / 退会 / channel/create の各 template を新しい `style.account` / `style.form` / `style.title` / `style.signup_title` に置き換え
- 切り出し済みのグローバル class とその関連 `article_registration a` を `registration.scss` から削除

## 変更内容

### 新規追加
- `templates/account/Account.module.scss`
  - `.account`（旧 `.article_registration`）配下に `.form` / `.title` / `.signup_title` をネストして定義
  - `.account a { text-decoration: none }` は元のグローバル `article_registration a` をネスト形式で移行

### 置き換え（9 ファイル）
- `templates/account/login.tsx`
- `templates/account/signup/index.tsx` / `signup/email.tsx`
- `templates/account/reset/index.tsx` / `reset/confirm.tsx` / `reset/done.tsx`
- `templates/setting/withdrawal/index.tsx` / `withdrawal/confirm.tsx`
- `templates/setting/mypage/channel/create.tsx`

各ファイルで `<article className="article_registration">` / `<form className="form_account">` / `<h1 className="login_h1 / signup_h1">` を `style.account` / `style.form` / `style.title` / `style.signup_title` に変更。

### 削除
- `styles/internal/registration.scss` から `.article_registration` / `.form_account` / `.form_account .login_h1` / `.form_account .signup_h1` / `.form_account .checkbox` / `.article_registration a` を削除
- `.messages_*` / `.password_reset` / `.name_group` 等は他ページが direct global class として参照しているため据え置き