### PR TITLE
【front】withdrawal 配下を setting から account に移動

### DIFF
--- a/frontend/src/components/layout/Header/DropMenu/Profile.tsx
+++ b/frontend/src/components/layout/Header/DropMenu/Profile.tsx
@@ -39,7 +39,7 @@ export default function DropMenuProfile(props: Props): React.JSX.Element {
         <NavItem label="アカウント" icon={<IconPerson size="1.5em" type="circle" />} className={style.item} onClick={() => handleRouter('/setting/profile')} />
         <NavItem label="マイページ" icon={<IconPerson size="1.5em" type="square" />} className={style.item} onClick={() => handleRouter('/setting/mypage')} />
         <NavItem label="料金プラン" icon={<IconCredit size="1.5em" />} className={style.item} onClick={() => handleRouter('/setting/payment')} />
-        <NavItem label="退会処理" icon={<IconPerson size="1.5em" type="cross" />} className={style.item} onClick={() => handleRouter('/setting/withdrawal')} />
+        <NavItem label="退会処理" icon={<IconPerson size="1.5em" type="cross" />} className={style.item} onClick={() => handleRouter('/account/withdrawal')} />
         <NavItem label="ログイン" icon={<IconArrow size="1.5em" type="in" />} className={style.item} onClick={handleLogin} />
         <NavItem label="ログアウト" icon={<IconArrow size="1.5em" type="out" />} className={style.item} onClick={handleLogout} />
       </ul>

--- a/frontend/src/components/templates/account/withdrawal/confirm.tsx
+++ b/frontend/src/components/templates/account/withdrawal/confirm.tsx
@@ -14,7 +14,7 @@ import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import Password from 'components/parts/Input/Password'
 import VStack from 'components/parts/Stack/Vertical'
-import style from '../../account/Account.module.scss'
+import style from '../Account.module.scss'
 
 export default function WithdrawalConfirm(): React.JSX.Element {
   const router = useRouter()
@@ -24,7 +24,7 @@ export default function WithdrawalConfirm(): React.JSX.Element {
   const { toast, handleToast } = useToast()
   const [values, setValues] = useState<WithdrawalIn>({ password: '' })
 
-  const handleBack = () => router.push('/setting/withdrawal')
+  const handleBack = () => router.push('/account/withdrawal')
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => setValues({ ...values, [e.target.name]: e.target.value })
 
   const handleSubmit = async () => {

--- a/frontend/src/components/templates/account/withdrawal/index.tsx
+++ b/frontend/src/components/templates/account/withdrawal/index.tsx
@@ -4,12 +4,12 @@ import Main from 'components/layout/Main'
 import Alert from 'components/parts/Alert'
 import Button from 'components/parts/Button'
 import VStack from 'components/parts/Stack/Vertical'
-import style from '../../account/Account.module.scss'
+import style from '../Account.module.scss'
 
 export default function Withdrawal(): React.JSX.Element {
   const router = useRouter()
   const handleBack = () => router.push('/')
-  const handleNext = () => router.push('/setting/withdrawal/confirm')
+  const handleNext = () => router.push('/account/withdrawal/confirm')
 
   return (
     <Main metaTitle="退会処理">

--- a/frontend/src/pages/account/withdrawal/confirm.tsx
+++ b/frontend/src/pages/account/withdrawal/confirm.tsx
@@ -1,4 +1,4 @@
-import WithdrawalConfirm from 'components/templates/setting/withdrawal/confirm'
+import WithdrawalConfirm from 'components/templates/account/withdrawal/confirm'
 
 export default function WithdrawalConfirmPage(): React.JSX.Element {
   return <WithdrawalConfirm />

--- a/frontend/src/pages/account/withdrawal/index.tsx
+++ b/frontend/src/pages/account/withdrawal/index.tsx
@@ -1,4 +1,4 @@
-import Withdrawal from 'components/templates/setting/withdrawal'
+import Withdrawal from 'components/templates/account/withdrawal'
 
 export default function WithdrawalPage(): React.JSX.Element {
   return <Withdrawal />


### PR DESCRIPTION
## Summary
- `templates/setting/withdrawal/` と `pages/setting/withdrawal/` を `templates/account/withdrawal/` / `pages/account/withdrawal/` に移動（履歴は `git mv` で保持）
- 移動に伴うルーティングパス（`/setting/withdrawal` → `/account/withdrawal`）と import パスを全て更新
- ヘッダードロップメニューの「退会処理」リンク先も新パスに修正

## 変更内容

### ディレクトリ移動
- `components/templates/setting/withdrawal/index.tsx` → `components/templates/account/withdrawal/index.tsx`
- `components/templates/setting/withdrawal/confirm.tsx` → `components/templates/account/withdrawal/confirm.tsx`
- `pages/setting/withdrawal/index.tsx` → `pages/account/withdrawal/index.tsx`
- `pages/setting/withdrawal/confirm.tsx` → `pages/account/withdrawal/confirm.tsx`

### import パス更新
- `templates/account/withdrawal/index.tsx` / `confirm.tsx`
  - `import style from '../../account/Account.module.scss'` → `'../Account.module.scss'`（移動先に合わせて相対パス短縮）
- `pages/account/withdrawal/index.tsx`
  - `import Withdrawal from 'components/templates/setting/withdrawal'` → `'components/templates/account/withdrawal'`
- `pages/account/withdrawal/confirm.tsx`
  - 同様に `setting/withdrawal/confirm` → `account/withdrawal/confirm`

### ルーティングパス更新
- `templates/account/withdrawal/index.tsx`
  - `router.push('/setting/withdrawal/confirm')` → `'/account/withdrawal/confirm'`
- `templates/account/withdrawal/confirm.tsx`
  - `router.push('/setting/withdrawal')` → `'/account/withdrawal'`
- `layout/Header/DropMenu/Profile.tsx`
  - 「退会処理」NavItem の `handleRouter('/setting/withdrawal')` → `'/account/withdrawal'`