### PR TITLE
【front】プラン変更ページを実装し現在プラン表示を追加

### DIFF
--- a/frontend/src/components/templates/setting/payment/PlanCard/PlanCard.module.scss
+++ b/frontend/src/components/templates/setting/payment/PlanCard/PlanCard.module.scss
@@ -23,6 +23,15 @@
     color: rgb(0, 70, 175);
   }
 
+  .current_label {
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 500;
+    color: rgb(120, 120, 120);
+    background: rgb(240, 240, 240);
+    border-radius: 10px;
+  }
+
   .price {
     display: flex;
     align-items: baseline;

--- a/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
+++ b/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
@@ -13,15 +13,20 @@ interface Props {
   plan: Plan
   active: boolean
   onClick: () => void
+  current?: boolean
+  showPurchase?: boolean
 }
 
 export default function PlanCard(props: Props): React.JSX.Element {
-  const { plan, active, onClick } = props
+  const { plan, active, onClick, current = false, showPurchase = true } = props
   const { name, price, features, stripeId } = plan
 
   return (
     <div className={cx(style.plan, active && style.active)} onClick={onClick}>
-      <div className={style.name}>{name}</div>
+      <div className={style.name}>
+        {name}
+        {current && <span className={style.current_label}>現在</span>}
+      </div>
       <div className={style.price}>
         <span>¥{price.toLocaleString()}</span>
         <span className={style.price_unit}>/ 月</span>
@@ -33,7 +38,7 @@ export default function PlanCard(props: Props): React.JSX.Element {
           </li>
         ))}
       </ul>
-      <Button color="purple" size="l" name="購入する" value={stripeId} />
+      {showPurchase && <Button color="purple" size="l" name="購入する" value={stripeId} />}
     </div>
   )
 }

--- a/frontend/src/components/templates/setting/payment/change/Change.module.scss
+++ b/frontend/src/components/templates/setting/payment/change/Change.module.scss
@@ -1,4 +1,4 @@
-.payment {
+.change {
   display: flex;
   flex-direction: column;
   gap: 32px;

--- a/frontend/src/components/templates/setting/payment/change/index.tsx
+++ b/frontend/src/components/templates/setting/payment/change/index.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import style from './Change.module.scss'
+import PlanCard from '../PlanCard'
+import { plans } from '../plans'
+
+const currentPlanName = 'Free'
+
+export default function PaymentChange(): React.JSX.Element {
+  const router = useRouter()
+  const [activeId, setActiveId] = useState<string>('')
+  const handleBack = () => router.push('/setting/payment')
+  const handleSubmit = () => router.push('/setting/payment')
+
+  const currentStripeId = plans.find((plan) => plan.name === currentPlanName)?.stripeId ?? ''
+  const isChanged = activeId !== '' && activeId !== currentStripeId
+
+  return (
+    <Main metaTitle="プラン変更">
+      <div className={style.change}>
+        <div className={style.current}>
+          <span className={style.current_label}>現在のプラン</span>
+          <span className={style.current_plan}>{currentPlanName}</span>
+        </div>
+
+        <div className={style.plans}>
+          {plans.map((plan) => (
+            <PlanCard
+              key={plan.name}
+              plan={plan}
+              active={activeId === plan.stripeId}
+              onClick={() => setActiveId(plan.stripeId)}
+              current={plan.name === currentPlanName}
+              showPurchase={false}
+            />
+          ))}
+        </div>
+
+        <div className={style.actions}>
+          <Button color="green" size="l" name="変更する" disabled={!isChanged} onClick={handleSubmit} />
+          <Button color="blue" size="l" name="キャンセル" onClick={handleBack} />
+        </div>
+      </div>
+    </Main>
+  )
+}

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -3,28 +3,10 @@ import { useRouter } from 'next/router'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import style from './Payment.module.scss'
-import PlanCard, { Plan } from './PlanCard'
+import PlanCard from './PlanCard'
+import { plans } from './plans'
 
-const plans: Plan[] = [
-  {
-    name: 'Basic',
-    price: 550,
-    features: ['個別広告表示 1つ', '全体広告 非表示'],
-    stripeId: 'price_1K9VSxCHdDAlRliqOZnYuctl',
-  },
-  {
-    name: 'Standard',
-    price: 880,
-    features: ['個別広告表示 3つ', '全体広告 非表示'],
-    stripeId: 'price_1K9VTbCHdDAlRliq3YNA768b',
-  },
-  {
-    name: 'Premium',
-    price: 1200,
-    features: ['個別広告表示 4つ', '全体広告 非表示', '楽曲ダウンロード'],
-    stripeId: 'price_1K9VU9CHdDAlRliqXsIS6GC4',
-  },
-]
+const currentPlanName = 'Free'
 
 export default function Payment(): React.JSX.Element {
   const router = useRouter()
@@ -35,18 +17,20 @@ export default function Payment(): React.JSX.Element {
   return (
     <Main metaTitle="料金プラン">
       <div className={style.payment}>
+        <div className={style.current}>
+          <span className={style.current_label}>現在のプラン</span>
+          <span className={style.current_plan}>{currentPlanName}</span>
+        </div>
+
         <div className={style.plans}>
           {plans.map((plan) => (
             <PlanCard key={plan.name} plan={plan} active={activeId === plan.stripeId} onClick={() => setActiveId(plan.stripeId)} />
           ))}
         </div>
 
-        <div className={style.current}>
-          <p className={style.current_label}>現在のプランを変更</p>
-          <div className={style.current_actions}>
-            <Button color="green" size="m" name="プランを変更" onClick={handleChange} />
-            <Button color="red" size="m" name="解約する" onClick={handleCancel} />
-          </div>
+        <div className={style.actions}>
+          <Button color="green" size="m" name="プランを変更" onClick={handleChange} />
+          <Button color="red" size="m" name="解約する" onClick={handleCancel} />
         </div>
       </div>
     </Main>

--- a/frontend/src/components/templates/setting/payment/plans.ts
+++ b/frontend/src/components/templates/setting/payment/plans.ts
@@ -1,0 +1,22 @@
+import { Plan } from './PlanCard'
+
+export const plans: Plan[] = [
+  {
+    name: 'Basic',
+    price: 550,
+    features: ['個別広告表示 1つ', '全体広告 非表示'],
+    stripeId: 'price_1K9VSxCHdDAlRliqOZnYuctl',
+  },
+  {
+    name: 'Standard',
+    price: 880,
+    features: ['個別広告表示 3つ', '全体広告 非表示'],
+    stripeId: 'price_1K9VTbCHdDAlRliq3YNA768b',
+  },
+  {
+    name: 'Premium',
+    price: 1200,
+    features: ['個別広告表示 4つ', '全体広告 非表示', '楽曲ダウンロード'],
+    stripeId: 'price_1K9VU9CHdDAlRliqXsIS6GC4',
+  },
+]

--- a/frontend/src/pages/setting/payment/change.tsx
+++ b/frontend/src/pages/setting/payment/change.tsx
@@ -1,0 +1,5 @@
+import PaymentChange from 'components/templates/setting/payment/change'
+
+export default function PaymentChangePage(): React.JSX.Element {
+  return <PaymentChange />
+}


### PR DESCRIPTION
## Summary
- `/setting/payment/change` プラン変更ページを新規実装（`PlanCard` を再利用）
- `payment` / `change` 両ページ上部に「現在のプラン」バナーを追加し、ユーザーの契約状態を分かりやすく表示
- プラン配列を `plans.ts` に切り出して両ページで共有、`PlanCard` に `current` / `showPurchase` prop を追加

## 変更内容

### 新規ファイル
- `pages/setting/payment/change.tsx`: プラン変更ページのルーティング
- `templates/setting/payment/change/index.tsx`: プラン変更ページ本体
- `templates/setting/payment/change/Change.module.scss`: 変更ページ専用スタイル
- `templates/setting/payment/plans.ts`: プラン配列を共有データとして切り出し

### 既存ファイル更新

#### `templates/setting/payment/PlanCard/index.tsx`
- `current?: boolean` prop 追加: true の場合プラン名横に「現在」グレーラベルを表示
- `showPurchase?: boolean` prop 追加（default: true）: false で「購入する」ボタン非表示（変更ページで使用）

#### `templates/setting/payment/PlanCard/PlanCard.module.scss`
- `.current_label` を追加（11px グレー / 角丸ピル形）

#### `templates/setting/payment/index.tsx` / `Payment.module.scss`
- 上部に「現在のプラン」バナーを追加（`currentPlanName = 'Free'` mock）
- `.current` を「現在表示」用に再定義（label 13px グレー + plan 26px 青 bold）
- 下部のアクション群を `.actions` クラスに分離
- プラン配列を `./plans` から import するように変更

#### 変更ページ動作
- 上部: 現在のプラン表示
- プランカード: クリックで `activeId` を更新、現在プラン名に該当するカードに「現在」ラベル
- 「変更する」ボタンは現在と異なるプランが選択されたときのみ enabled
- 「キャンセル」で `/setting/payment` に戻る
- API 連携は未実装（`handleSubmit` は仮で payment に戻るのみ）

### Mock 値
- `currentPlanName = 'Free'`（payment / change 両ページで統一）
- 実装完了後はバックエンド `MypageOut.plan` から取得する想定