### PR TITLE
【front】payment ページを SSR 化し現在プランをバックエンドから取得

### DIFF
--- a/frontend/src/components/templates/setting/payment/CurrentBanner/CurrentBanner.module.scss
+++ b/frontend/src/components/templates/setting/payment/CurrentBanner/CurrentBanner.module.scss
@@ -1,0 +1,21 @@
+.current {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 20px;
+  border: 1px solid rgb(220, 220, 220);
+  border-radius: 6px;
+  background: rgb(255, 255, 255);
+
+  .label {
+    font-size: 13px;
+    color: rgb(120, 120, 120);
+  }
+
+  .plan {
+    font-size: 26px;
+    font-weight: 700;
+    color: rgb(0, 70, 175);
+  }
+}

--- a/frontend/src/components/templates/setting/payment/CurrentBanner/index.tsx
+++ b/frontend/src/components/templates/setting/payment/CurrentBanner/index.tsx
@@ -1,0 +1,16 @@
+import style from './CurrentBanner.module.scss'
+
+interface Props {
+  planName: string
+}
+
+export default function CurrentBanner(props: Props): React.JSX.Element {
+  const { planName } = props
+
+  return (
+    <div className={style.current}>
+      <span className={style.label}>現在のプラン</span>
+      <span className={style.plan}>{planName}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/templates/setting/payment/Payment.module.scss
+++ b/frontend/src/components/templates/setting/payment/Payment.module.scss
@@ -6,28 +6,6 @@
   padding: 0 16px;
   margin: 24px auto;
 
-  .current {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    padding: 20px;
-    border: 1px solid rgb(220, 220, 220);
-    border-radius: 6px;
-    background: rgb(255, 255, 255);
-  }
-
-  .current_label {
-    font-size: 13px;
-    color: rgb(120, 120, 120);
-  }
-
-  .current_plan {
-    font-size: 26px;
-    font-weight: 700;
-    color: rgb(0, 70, 175);
-  }
-
   .plans {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/frontend/src/components/templates/setting/payment/PlanCard/PlanCard.module.scss
+++ b/frontend/src/components/templates/setting/payment/PlanCard/PlanCard.module.scss
@@ -7,11 +7,19 @@
   border-radius: 6px;
   background: rgb(255, 255, 255);
   transition: border-color 0.2s, background 0.2s;
-  cursor: pointer;
+
+  &.clickable {
+    cursor: pointer;
+  }
 
   &.active {
     border-color: rgb(0, 70, 175);
     background: rgb(245, 250, 255);
+  }
+
+  &.disabled {
+    opacity: 0.6;
+    cursor: default;
   }
 
   .name {
@@ -57,6 +65,10 @@
     list-style: none;
     border-top: 1px solid rgb(230, 230, 230);
     border-bottom: 1px solid rgb(230, 230, 230);
+
+    &:last-child {
+      border-bottom: none;
+    }
 
     .feature {
       display: flex;

--- a/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
+++ b/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
@@ -12,17 +12,21 @@ export interface Plan {
 interface Props {
   plan: Plan
   active: boolean
-  onClick: () => void
   current?: boolean
   showPurchase?: boolean
+  disabled?: boolean
+  purchaseDisabled?: boolean
+  onClick?: () => void
 }
 
 export default function PlanCard(props: Props): React.JSX.Element {
-  const { plan, active, onClick, current = false, showPurchase = true } = props
+  const { plan, active, onClick, current = false, showPurchase = true, disabled = false, purchaseDisabled = false } = props
   const { name, price, features, stripeId } = plan
 
+  const handleClick = disabled ? undefined : onClick
+
   return (
-    <div className={cx(style.plan, active && style.active)} onClick={onClick}>
+    <div className={cx(style.plan, active && style.active, handleClick && style.clickable, disabled && style.disabled)} onClick={handleClick}>
       <div className={style.name}>
         {name}
         {current && <span className={style.current_label}>現在</span>}
@@ -38,7 +42,7 @@ export default function PlanCard(props: Props): React.JSX.Element {
           </li>
         ))}
       </ul>
-      {showPurchase && <Button color="purple" size="l" name="購入する" value={stripeId} />}
+      {showPurchase && stripeId && <Button color="purple" size="l" name="購入する" value={stripeId} disabled={purchaseDisabled} />}
     </div>
   )
 }

--- a/frontend/src/components/templates/setting/payment/change/Change.module.scss
+++ b/frontend/src/components/templates/setting/payment/change/Change.module.scss
@@ -6,28 +6,6 @@
   padding: 0 16px;
   margin: 24px auto;
 
-  .current {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    padding: 20px;
-    border: 1px solid rgb(220, 220, 220);
-    border-radius: 6px;
-    background: rgb(255, 255, 255);
-  }
-
-  .current_label {
-    font-size: 13px;
-    color: rgb(120, 120, 120);
-  }
-
-  .current_plan {
-    font-size: 26px;
-    font-weight: 700;
-    color: rgb(0, 70, 175);
-  }
-
   .plans {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/frontend/src/components/templates/setting/payment/change/index.tsx
+++ b/frontend/src/components/templates/setting/payment/change/index.tsx
@@ -1,38 +1,41 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
+import { MypageOut } from 'types/internal/user'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import style from './Change.module.scss'
+import CurrentBanner from '../CurrentBanner'
 import PlanCard from '../PlanCard'
 import { plans } from '../plans'
 
-const currentPlanName = 'Free'
+interface Props {
+  mypage: MypageOut
+}
 
-export default function PaymentChange(): React.JSX.Element {
+export default function PaymentChange(props: Props): React.JSX.Element {
+  const { mypage } = props
   const router = useRouter()
-  const [activeId, setActiveId] = useState<string>('')
+  const [activeName, setActiveName] = useState<string>('')
   const handleBack = () => router.push('/setting/payment')
   const handleSubmit = () => router.push('/setting/payment')
 
-  const currentStripeId = plans.find((plan) => plan.name === currentPlanName)?.stripeId ?? ''
-  const isChanged = activeId !== '' && activeId !== currentStripeId
+  const currentPlanName = mypage.plan
+  const isChanged = activeName !== '' && activeName !== currentPlanName
 
   return (
     <Main metaTitle="プラン変更">
       <div className={style.change}>
-        <div className={style.current}>
-          <span className={style.current_label}>現在のプラン</span>
-          <span className={style.current_plan}>{currentPlanName}</span>
-        </div>
+        <CurrentBanner planName={currentPlanName} />
 
         <div className={style.plans}>
           {plans.map((plan) => (
             <PlanCard
               key={plan.name}
               plan={plan}
-              active={activeId === plan.stripeId}
-              onClick={() => setActiveId(plan.stripeId)}
+              active={activeName === plan.name}
+              onClick={() => setActiveName(plan.name)}
               current={plan.name === currentPlanName}
+              disabled={plan.name === currentPlanName}
               showPurchase={false}
             />
           ))}

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -1,37 +1,41 @@
-import { useState } from 'react'
 import { useRouter } from 'next/router'
+import { MypageOut } from 'types/internal/user'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
+import CurrentBanner from './CurrentBanner'
 import style from './Payment.module.scss'
 import PlanCard from './PlanCard'
 import { plans } from './plans'
 
-const currentPlanName = 'Free'
+interface Props {
+  mypage: MypageOut
+}
 
-export default function Payment(): React.JSX.Element {
+export default function Payment(props: Props): React.JSX.Element {
+  const { mypage } = props
   const router = useRouter()
-  const [activeId, setActiveId] = useState<string>('')
   const handleChange = () => router.push('/setting/payment/change')
-  const handleCancel = () => router.push('/setting/payment/cancel')
+
+  const currentPlanName = mypage.plan
+  const purchasable = plans.filter((plan) => plan.stripeId !== '')
+  const isPaid = currentPlanName !== 'Free'
 
   return (
     <Main metaTitle="料金プラン">
       <div className={style.payment}>
-        <div className={style.current}>
-          <span className={style.current_label}>現在のプラン</span>
-          <span className={style.current_plan}>{currentPlanName}</span>
-        </div>
+        <CurrentBanner planName={currentPlanName} />
 
         <div className={style.plans}>
-          {plans.map((plan) => (
-            <PlanCard key={plan.name} plan={plan} active={activeId === plan.stripeId} onClick={() => setActiveId(plan.stripeId)} />
+          {purchasable.map((plan) => (
+            <PlanCard key={plan.name} plan={plan} active={currentPlanName === plan.name} purchaseDisabled={isPaid} />
           ))}
         </div>
 
-        <div className={style.actions}>
-          <Button color="green" size="m" name="プランを変更" onClick={handleChange} />
-          <Button color="red" size="m" name="解約する" onClick={handleCancel} />
-        </div>
+        {isPaid && (
+          <div className={style.actions}>
+            <Button color="green" size="m" name="プランを変更" onClick={handleChange} />
+          </div>
+        )}
       </div>
     </Main>
   )

--- a/frontend/src/components/templates/setting/payment/plans.ts
+++ b/frontend/src/components/templates/setting/payment/plans.ts
@@ -2,6 +2,12 @@ import { Plan } from './PlanCard'
 
 export const plans: Plan[] = [
   {
+    name: 'Free',
+    price: 0,
+    features: ['基本機能', '広告あり'],
+    stripeId: '',
+  },
+  {
     name: 'Basic',
     price: 550,
     features: ['個別広告表示 1つ', '全体広告 非表示'],

--- a/frontend/src/pages/setting/payment/change.tsx
+++ b/frontend/src/pages/setting/payment/change.tsx
@@ -1,5 +1,26 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { MypageOut } from 'types/internal/user'
+import { getSettingMypage } from 'api/internal/setting'
+import ErrorCheck from 'components/widgets/Error/Check'
 import PaymentChange from 'components/templates/setting/payment/change'
 
-export default function PaymentChangePage(): React.JSX.Element {
-  return <PaymentChange />
+export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ret = await getSettingMypage(req)
+  if (ret.isErr()) return { props: { status: ret.error.status } }
+  return { props: { ...translations, mypage: ret.value } }
+}
+
+interface Props {
+  status: number
+  mypage: MypageOut
+}
+
+export default function PaymentChangePage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <PaymentChange {...props} />
+    </ErrorCheck>
+  )
 }

--- a/frontend/src/pages/setting/payment/index.tsx
+++ b/frontend/src/pages/setting/payment/index.tsx
@@ -1,5 +1,26 @@
+import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { MypageOut } from 'types/internal/user'
+import { getSettingMypage } from 'api/internal/setting'
+import ErrorCheck from 'components/widgets/Error/Check'
 import Payment from 'components/templates/setting/payment'
 
-export default function PaymentPage(): React.JSX.Element {
-  return <Payment />
+export const getServerSideProps: GetServerSideProps = async ({ locale, req }) => {
+  const translations = await serverSideTranslations(String(locale), ['common'])
+  const ret = await getSettingMypage(req)
+  if (ret.isErr()) return { props: { status: ret.error.status } }
+  return { props: { ...translations, mypage: ret.value } }
+}
+
+interface Props {
+  status: number
+  mypage: MypageOut
+}
+
+export default function PaymentPage(props: Props): React.JSX.Element {
+  return (
+    <ErrorCheck status={props.status}>
+      <Payment {...props} />
+    </ErrorCheck>
+  )
 }

--- a/frontend/src/types/internal/user.d.ts
+++ b/frontend/src/types/internal/user.d.ts
@@ -78,7 +78,8 @@ export interface MypageOut {
   followingCount: number
   tagManagerId: string
   plan: string
-  planDate: string
+  planStartDate: string | null
+  planEndDate: string | null
   isAdvertise: boolean
   content: string
 }


### PR DESCRIPTION
## Summary
- `/setting/payment` / `/setting/payment/change` を SSR 化し、`getSettingMypage` 経由でバックエンドから現在プランを取得
- `MypageOut` の型を実 API レスポンスに合わせて修正（`planDate` → `planStartDate` / `planEndDate`）
- Free 以外の契約時に「購入する」ボタンを全カードで disable、現在プランカードに `disabled` / 「現在」表示の挙動を整理
- `CurrentBanner` 共通コンポーネントを切り出し、payment / change 両ページで重複していた SCSS を排除

## 変更内容

### 型修正
#### `types/internal/user.d.ts`
- `MypageOut.planDate: string` を削除
- `planStartDate: string \| null` / `planEndDate: string \| null` を追加（バックエンド `plan_start_date` / `plan_end_date` に整合）

### pages（SSR 化）
#### `pages/setting/payment/index.tsx`
- `getServerSideProps` で `getSettingMypage(req)` を呼び、`mypage` を Payment テンプレートに渡す
- `ErrorCheck` で 401 / 404 / 500 等をハンドル

#### `pages/setting/payment/change.tsx`
- 同パターンで PaymentChange に渡す

### templates
#### `templates/setting/payment/index.tsx`
- Props に `mypage: MypageOut` を追加し、`mypage.plan` を `currentPlanName` として使用
- 全カードに `purchaseDisabled={isPaid}` を渡す（Free 以外は購入ボタン disable）

#### `templates/setting/payment/change/index.tsx`
- 同様に Props で `mypage` を受け取り、`mypage.plan` を使用
- 現在プランカードに `disabled` を追加（クリック不可・半透明）

### コンポーネント

#### `templates/setting/payment/CurrentBanner/`（新規）
- `index.tsx` + `CurrentBanner.module.scss` を新設
- payment / change 両ページから `<CurrentBanner planName={...} />` で再利用
- 重複していた `.current` / `.current_label` / `.current_plan` スタイルを排除

#### `templates/setting/payment/PlanCard/index.tsx`
- `disabled?: boolean` prop 追加: 現在プランカードのクリック無効化（change ページで使用）
- `purchaseDisabled?: boolean` prop 追加: 「購入する」ボタンだけを無効化（payment ページで使用）
- カード全体の disable / ボタンのみの disable を別概念として分離

#### `templates/setting/payment/PlanCard/PlanCard.module.scss`
- `.disabled` クラス追加（opacity 0.6 / cursor default）
- `.features:last-child { border-bottom: none }` で購入ボタンが無いときのカード下線を自動で消す

### mock 削除
- `plans.ts` から `export const currentPlanName = 'Free'` を削除（バックエンド取得に置き換わったため）