### PR TITLE
【front】プラン変更画面で Free を末尾配置に変更しボタンサイズを統一

### DIFF
--- a/frontend/src/components/templates/setting/payment/change/index.tsx
+++ b/frontend/src/components/templates/setting/payment/change/index.tsx
@@ -42,8 +42,8 @@ export default function PaymentChange(props: Props): React.JSX.Element {
         </div>
 
         <div className={style.actions}>
-          <Button color="green" size="l" name="変更する" disabled={!isChanged} onClick={handleSubmit} />
-          <Button color="blue" size="l" name="キャンセル" onClick={handleBack} />
+          <Button color="green" name="変更する" disabled={!isChanged} onClick={handleSubmit} />
+          <Button color="blue" name="キャンセル" onClick={handleBack} />
         </div>
       </div>
     </Main>

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -33,7 +33,7 @@ export default function Payment(props: Props): React.JSX.Element {
 
         {isPaid && (
           <div className={style.actions}>
-            <Button color="green" size="m" name="プランを変更" onClick={handleChange} />
+            <Button color="green" name="プランを変更" onClick={handleChange} />
           </div>
         )}
       </div>

--- a/frontend/src/components/templates/setting/payment/plans.ts
+++ b/frontend/src/components/templates/setting/payment/plans.ts
@@ -2,12 +2,6 @@ import { Plan } from './PlanCard'
 
 export const plans: Plan[] = [
   {
-    name: 'Free',
-    price: 0,
-    features: ['基本機能', '広告あり'],
-    stripeId: '',
-  },
-  {
     name: 'Basic',
     price: 550,
     features: ['個別広告表示 1つ', '全体広告 非表示'],
@@ -24,5 +18,11 @@ export const plans: Plan[] = [
     price: 1200,
     features: ['個別広告表示 4つ', '全体広告 非表示', '楽曲ダウンロード'],
     stripeId: 'price_1K9VU9CHdDAlRliqXsIS6GC4',
+  },
+  {
+    name: 'Free',
+    price: 0,
+    features: ['基本機能', '広告あり'],
+    stripeId: '',
   },
 ]


### PR DESCRIPTION
## Summary
- `plans.ts` の配列順を変更し、変更画面で Free カードを Premium の右隣（末尾）に配置
- payment / change ページのアクションボタンから `size` 指定を外し、デフォルト (m) に統一

## 変更内容

### `plans.ts`
- 配列順を `Free → Basic → Standard → Premium` から `Basic → Standard → Premium → Free` に変更
- 変更画面では全プラン表示なので Free が右端に表示される
- payment トップは `purchasable = plans.filter(stripeId !== '')` で Free を除外しているため表示順は影響なし

### `payment/index.tsx`
- `<Button color="green" size="m" name="プランを変更" />` から `size="m"` を削除（Button のデフォルトと同じため冗長）

### `payment/change/index.tsx`
- 「変更する」「キャンセル」両ボタンから `size="l"` を削除し、デフォルトサイズに統一