### PR TITLE
【front】Stripe checkout API クライアントと success ページを追加

### DIFF
--- a/frontend/src/api/internal/payment.ts
+++ b/frontend/src/api/internal/payment.ts
@@ -1,0 +1,9 @@
+import { apiClient } from 'lib/axios/internal'
+import { ApiOut, apiOut } from 'lib/error'
+import { PaymentCheckoutIn, PaymentCheckoutOut } from 'types/internal/payment'
+import { apiPaymentCheckout } from 'api/uri'
+import { camelSnake } from 'utils/functions/convertCase'
+
+export const postPaymentCheckout = async (request: PaymentCheckoutIn): Promise<ApiOut<PaymentCheckoutOut>> => {
+  return await apiOut(apiClient('json').post(apiPaymentCheckout, camelSnake(request)))
+}

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -33,6 +33,9 @@ export const apiSettingProfile = base + '/setting/profile'
 export const apiSettingMypage = base + '/setting/mypage'
 export const apiSettingNotification = base + '/setting/notification'
 
+// Payment
+export const apiPaymentCheckout = base + '/payment/checkout'
+
 // Channel
 export const apiChannelCreate = base + '/channel'
 export const apiChannelUser = base + '/channel/user'

--- a/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
+++ b/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
@@ -16,14 +16,17 @@ interface Props {
   showPurchase?: boolean
   disabled?: boolean
   purchaseDisabled?: boolean
+  loading?: boolean
   onClick?: () => void
+  onPurchase?: (stripeId: string) => void
 }
 
 export default function PlanCard(props: Props): React.JSX.Element {
-  const { plan, active, onClick, current = false, showPurchase = true, disabled = false, purchaseDisabled = false } = props
+  const { plan, active, onClick, onPurchase, current = false, showPurchase = true, disabled = false, purchaseDisabled = false, loading = false } = props
   const { name, price, features, stripeId } = plan
 
   const handleClick = disabled ? undefined : onClick
+  const handlePurchase = () => onPurchase?.(stripeId)
 
   return (
     <div className={cx(style.plan, active && style.active, handleClick && style.clickable, disabled && style.disabled)} onClick={handleClick}>
@@ -42,7 +45,7 @@ export default function PlanCard(props: Props): React.JSX.Element {
           </li>
         ))}
       </ul>
-      {showPurchase && stripeId && <Button color="purple" size="l" name="購入する" value={stripeId} disabled={purchaseDisabled} />}
+      {showPurchase && stripeId && <Button color="purple" size="l" name="購入する" disabled={purchaseDisabled} loading={loading} onClick={handlePurchase} />}
     </div>
   )
 }

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { MypageOut } from 'types/internal/user'
+import { postPaymentCheckout } from 'api/internal/payment'
+import { FetchError } from 'utils/constants/enum'
+import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
 import CurrentBanner from './CurrentBanner'
@@ -14,20 +18,34 @@ interface Props {
 export default function Payment(props: Props): React.JSX.Element {
   const { mypage } = props
   const router = useRouter()
+  const { toast, handleToast } = useToast()
+  const [loadingId, setLoadingId] = useState<string>('')
+
+  const currentPlan = mypage.plan
+  const purchasable = plans.filter((plan) => plan.stripeId !== '')
+  const isPaid = currentPlan !== 'Free'
+
   const handleChange = () => router.push('/setting/payment/change')
 
-  const currentPlanName = mypage.plan
-  const purchasable = plans.filter((plan) => plan.stripeId !== '')
-  const isPaid = currentPlanName !== 'Free'
+  const handlePurchase = async (stripeId: string) => {
+    setLoadingId(stripeId)
+    const ret = await postPaymentCheckout({ stripeId })
+    if (ret.isErr()) {
+      setLoadingId('')
+      handleToast(ret.error.message ?? FetchError.Post, true)
+      return
+    }
+    window.location.href = ret.value.url
+  }
 
   return (
-    <Main metaTitle="料金プラン">
+    <Main metaTitle="料金プラン" toast={toast}>
       <div className={style.payment}>
-        <CurrentBanner planName={currentPlanName} />
+        <CurrentBanner planName={currentPlan} />
 
         <div className={style.plans}>
           {purchasable.map((plan) => (
-            <PlanCard key={plan.name} plan={plan} active={currentPlanName === plan.name} purchaseDisabled={isPaid} />
+            <PlanCard key={plan.name} plan={plan} active={currentPlan === plan.name} purchaseDisabled={isPaid} loading={loadingId === plan.stripeId} onPurchase={handlePurchase} />
           ))}
         </div>
 

--- a/frontend/src/components/templates/setting/payment/success/Success.module.scss
+++ b/frontend/src/components/templates/setting/payment/success/Success.module.scss
@@ -1,0 +1,21 @@
+.success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  max-width: 480px;
+  padding: 40px 16px;
+  margin: 24px auto;
+  text-align: center;
+
+  .title {
+    font-size: 24px;
+    font-weight: 700;
+    color: rgb(50, 50, 50);
+  }
+
+  .message {
+    font-size: 14px;
+    color: rgb(80, 80, 80);
+  }
+}

--- a/frontend/src/components/templates/setting/payment/success/index.tsx
+++ b/frontend/src/components/templates/setting/payment/success/index.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router'
+import Main from 'components/layout/Main'
+import Button from 'components/parts/Button'
+import style from './Success.module.scss'
+
+export default function PaymentSuccess(): React.JSX.Element {
+  const router = useRouter()
+  const handleBack = () => router.push('/setting/payment')
+
+  return (
+    <Main metaTitle="決済完了">
+      <div className={style.success}>
+        <h1 className={style.title}>決済が完了しました</h1>
+        <p className={style.message}>
+          ご購入ありがとうございます。
+          <br />
+          反映には数分かかる場合があります。
+        </p>
+        <Button color="blue" name="料金プランに戻る" onClick={handleBack} />
+      </div>
+    </Main>
+  )
+}

--- a/frontend/src/pages/setting/payment/success.tsx
+++ b/frontend/src/pages/setting/payment/success.tsx
@@ -1,0 +1,5 @@
+import PaymentSuccess from 'components/templates/setting/payment/success'
+
+export default function PaymentSuccessPage(): React.JSX.Element {
+  return <PaymentSuccess />
+}

--- a/frontend/src/types/internal/payment.d.ts
+++ b/frontend/src/types/internal/payment.d.ts
@@ -1,0 +1,7 @@
+export interface PaymentCheckoutIn {
+  stripeId: string
+}
+
+export interface PaymentCheckoutOut {
+  url: string
+}


### PR DESCRIPTION
## Summary
- フロントから Stripe Checkout を呼び出すための API クライアント（`postPaymentCheckout`）を追加
- 「購入する」ボタン押下で checkout API → Stripe URL へリダイレクトする実装
- 決済完了後に表示される `/setting/payment/success` ページを新設

## 変更内容

### 新規ファイル
- **`api/internal/payment.ts`**: `postPaymentCheckout(request)` — Stripe Session URL を取得
- **`types/internal/payment.d.ts`**: `PaymentCheckoutIn` (`stripeId`) / `PaymentCheckoutOut` (`url`)
- **`pages/setting/payment/success.tsx`**: success ページのルーティング
- **`templates/setting/payment/success/index.tsx`**: 決済完了画面（タイトル + メッセージ + 戻るボタン）
- **`templates/setting/payment/success/Success.module.scss`**: success ページ専用スタイル

### 既存ファイル更新

#### `api/uri.ts`
- `apiPaymentCheckout = /api/payment/checkout` を追加

#### `templates/setting/payment/PlanCard/index.tsx`
- `onPurchase?: (stripeId) => void` prop を追加（購入ボタン押下時のハンドラ）
- `loading?: boolean` prop を追加（ボタンに spinner 表示）
- 購入ボタンを `value` 属性から `onClick` ハンドラに切替

#### `templates/setting/payment/index.tsx`
- `useToast` / `useState` で loading & error 状態管理
- `handlePurchase` で `postPaymentCheckout({ stripeId })` を呼び、成功時 `window.location.href = ret.value.url` で Stripe にリダイレクト
- 失敗時はトーストでエラー表示
- `loadingId` で押されたカードのボタンだけ loading 表示
- 変数名を `currentPlanName` → `currentPlan` に整理

### 動作フロー
1. ユーザーがプランカードの「購入する」をクリック
2. ボタンが loading 状態に
3. `POST /api/payment/checkout` → Stripe Session URL を受け取る
4. `window.location.href` で Stripe ホスト型決済画面へ遷移
5. 決済完了 → Stripe が `/setting/payment/success` にリダイレクト
6. 決済キャンセル → Stripe が `/setting/payment` に戻す

### バックエンドの依存
本 PR はフロントの実装のみ。`POST /api/payment/checkout` のバックエンド実装は別 PR で対応する想定。