### PR TITLE
【back】Stripe checkout API を新設

### DIFF
--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -1,0 +1,47 @@
+import stripe
+from django.conf import settings
+from django.http import HttpRequest
+from ninja import Router
+from api.modules.logger import log
+from api.src.types.schema.common import ErrorOut
+from api.src.types.schema.payment import PaymentCheckoutIn, PaymentCheckoutOut
+from api.src.usecase.auth import auth_check
+from api.src.usecase.user import get_user_data
+
+
+class PaymentAPI:
+    """料金プランAPI"""
+
+    router = Router()
+
+    @staticmethod
+    @router.post("/checkout", response={200: PaymentCheckoutOut, 401: ErrorOut, 404: ErrorOut, 500: ErrorOut})
+    def checkout(request: HttpRequest, input: PaymentCheckoutIn):
+        log.info("PaymentAPI checkout", stripe_id=input.stripe_id)
+
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        user_data = get_user_data(user_id=user_id)
+        if user_data is None:
+            return 404, ErrorOut(message="Not Found")
+
+        stripe.api_key = settings.STRIPE_SECRET_KEY
+        try:
+            session = stripe.checkout.Session.create(
+                mode="subscription",
+                line_items=[{"price": input.stripe_id, "quantity": 1}],
+                success_url=f"{settings.FRONTEND_URL}/setting/payment/success",
+                cancel_url=f"{settings.FRONTEND_URL}/setting/payment",
+                customer_email=user_data.user.email,
+            )
+        except stripe.StripeError as e:
+            log.error("Stripe checkout error", exc=e)
+            return 500, ErrorOut(message="決済セッションの作成に失敗しました!")
+
+        if session.url is None:
+            log.error("Stripe checkout url is None")
+            return 500, ErrorOut(message="決済セッションの作成に失敗しました!")
+
+        return 200, PaymentCheckoutOut(url=session.url)

--- a/myus/api/src/routers.py
+++ b/myus/api/src/routers.py
@@ -8,6 +8,7 @@ from api.src.adapter.manage import ManageVideoAPI, ManageMusicAPI, ManageBlogAPI
 from api.src.adapter.media import HomeAPI, RecommendAPI, VideoAPI, MusicAPI, BlogAPI, ComicAPI, PictureAPI, ChatAPI
 from api.src.adapter.message import MessageAPI
 from api.src.adapter.channel import ChannelAPI
+from api.src.adapter.payment import PaymentAPI
 from api.src.adapter.setting import SettingMyPageAPI, SettingNotificationAPI, SettingProfileAPI
 from api.src.adapter.user import UserAPI
 
@@ -20,6 +21,7 @@ api.add_router("/user", UserAPI().router, tags=["user"])
 api.add_router("/setting/profile", SettingProfileAPI().router, tags=["Setting"])
 api.add_router("/setting/mypage", SettingMyPageAPI().router, tags=["Setting"])
 api.add_router("/setting/notification", SettingNotificationAPI().router, tags=["Setting"])
+api.add_router("/payment", PaymentAPI().router, tags=["Payment"])
 
 api.add_router("/manage/media/video", ManageVideoAPI().router, tags=["Manage Video"])
 api.add_router("/manage/media/music", ManageMusicAPI().router, tags=["Manage Music"])

--- a/myus/api/src/types/schema/payment.py
+++ b/myus/api/src/types/schema/payment.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class PaymentCheckoutIn(BaseModel):
+    stripe_id: str
+
+
+class PaymentCheckoutOut(BaseModel):
+    url: str


### PR DESCRIPTION
## Summary
- `POST /api/payment/checkout` を新設し、Stripe Checkout Session を生成して URL を返す
- フロントの `postPaymentCheckout` と疎通する最小実装
- フロント側 PR (#826) とセットでデプロイすることでプラン購入フローが動作する

## 変更内容

### 新規ファイル

#### `myus/api/src/types/schema/payment.py`
- `PaymentCheckoutIn`: 入力スキーマ（`stripe_id: str`）
- `PaymentCheckoutOut`: 出力スキーマ（`url: str` — Stripe Checkout Session の URL）

#### `myus/api/src/adapter/payment.py`
- `PaymentAPI.checkout` エンドポイント実装
- 認証チェック（`auth_check`）→ ユーザー存在確認（`get_user_data`）→ `stripe.checkout.Session.create` の流れ
- `mode="subscription"` でサブスク決済として作成
- `success_url=/setting/payment/success`、`cancel_url=/setting/payment` を設定
- `customer_email` にログインユーザーの email を渡す
- `stripe.StripeError` を捕捉して 500 を返す（`log.error` でスタックトレース保持）
- `session.url` が None の場合の防御的チェック

### 既存ファイル更新

#### `myus/api/src/routers.py`
- `PaymentAPI` を import
- `api.add_router("/payment", PaymentAPI().router, tags=["Payment"])` を登録

### 動作フロー
1. フロント: ユーザーが「購入する」クリック → `POST /api/payment/checkout` に `stripe_id` を送信
2. バックエンド: 認証 → Stripe Session 生成 → URL 返却
3. フロント: 受け取った URL に `window.location.href` でリダイレクト
4. ユーザーが Stripe で決済完了
5. Stripe が `success_url` (`/setting/payment/success`) にリダイレクト

### 残タスク（別 PR）
- `POST /api/payment/webhook` で Stripe からの決済完了通知を受け取り `UserPlan` を更新
- 解約フロー（Free 復帰）API