### PR TITLE
【back】Plan モデルを廃止し Enum と静的定義に置き換え

### DIFF
--- a/myus/api/db/models/master.py
+++ b/myus/api/db/models/master.py
@@ -2,24 +2,6 @@ from django.db import models
 from django_ulid.models import ulid
 
 
-class Plan(models.Model):
-    """Plan"""
-    id            = models.BigAutoField(primary_key=True)
-    name          = models.CharField(max_length=30)
-    stripe_api_id = models.CharField(max_length=30)
-    price         = models.IntegerField()
-    max_advertise = models.IntegerField()
-    description   = models.TextField()
-
-    def __str__(self):
-        return self.name
-
-    class Meta:
-        db_table = "plan"
-        verbose_name_plural = "001 Plan"
-        indexes = [models.Index(fields=["stripe_api_id"], name="stripe_api_idx")]
-
-
 class Category(models.Model):
     """Category"""
     id      = models.BigAutoField(primary_key=True)

--- a/myus/api/db/models/user.py
+++ b/myus/api/db/models/user.py
@@ -3,8 +3,7 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.utils import timezone
 from django_ulid.models import ulid
-from api.db.models.master import Plan
-from api.utils.enum.index import GenderType
+from api.utils.enum.index import GenderType, PlanAction, PlanName
 from api.utils.functions.file import avatar_upload
 
 
@@ -128,9 +127,10 @@ class UserNotification(models.Model):
 
 class UserPlan(models.Model):
     """UserPlan"""
+    plans        = [(p, p) for p in PlanName]
     id           = models.BigAutoField(primary_key=True)
     user         = models.OneToOneField(User, on_delete=models.CASCADE, related_name="user_plan")
-    plan         = models.ForeignKey(Plan, on_delete=models.CASCADE, default=1)
+    plan         = models.CharField(max_length=30, choices=plans, default=PlanName.FREE)
     customer_id  = models.CharField(max_length=255)
     subscription = models.CharField(max_length=255)
     is_paid      = models.BooleanField(default=False)
@@ -138,8 +138,29 @@ class UserPlan(models.Model):
     end_date     = models.DateTimeField(blank=True, null=True)
 
     def __str__(self):
-        return self.plan.name
+        return self.plan
 
     class Meta:
         db_table = "user_plan"
         verbose_name_plural = "001 UserPlan"
+
+
+class UserPlanHistory(models.Model):
+    """UserPlanHistory"""
+    plans        = [(p, p) for p in PlanName]
+    actions      = [(a, a) for a in PlanAction]
+    id           = models.BigAutoField(primary_key=True)
+    user         = models.ForeignKey(User, on_delete=models.CASCADE, related_name="user_plan_histories")
+    plan         = models.CharField(max_length=30, choices=plans)
+    price        = models.IntegerField()
+    action       = models.CharField(max_length=20, choices=actions)
+    subscription = models.CharField(max_length=255, blank=True)
+    created      = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user_id}:{self.plan}:{self.action}"
+
+    class Meta:
+        db_table = "user_plan_history"
+        verbose_name_plural = "001 UserPlanHistory"
+        indexes = [models.Index(fields=["user", "-created"], name="user_plan_history_idx")]

--- a/myus/api/src/adapter/setting.py
+++ b/myus/api/src/adapter/setting.py
@@ -101,7 +101,7 @@ class SettingMyPageAPI:
             follower_count=mypage.follower_count,
             following_count=mypage.following_count,
             tag_manager_id=mypage.tag_manager_id,
-            plan=user_plan.plan.name,
+            plan=user_plan.plan,
             plan_start_date=user_plan.start_date,
             plan_end_date=user_plan.end_date,
             is_advertise=mypage.is_advertise,

--- a/myus/api/src/domain/entity/user/_convert.py
+++ b/myus/api/src/domain/entity/user/_convert.py
@@ -2,9 +2,8 @@ from typing import assert_never
 from django.contrib.auth.hashers import make_password
 from django_ulid.models import ulid
 from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat
-from api.db.models.master import Plan
 from api.db.models.user import MyPage, Profile, User, UserNotification, UserPlan
-from api.src.domain.interface.user.data import MyPageData, PlanData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
+from api.src.domain.interface.user.data import MyPageData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
 from api.utils.enum.index import MediaType
 
 
@@ -82,20 +81,9 @@ def user_notification_data(user_notification: UserNotification) -> UserNotificat
     )
 
 
-def plan_data(plan: Plan) -> PlanData:
-    return PlanData(
-        id=plan.id,
-        name=plan.name,
-        stripe_api_id=plan.stripe_api_id,
-        price=plan.price,
-        max_advertise=plan.max_advertise,
-        description=plan.description,
-    )
-
-
 def user_plan_data(user_plan: UserPlan) -> UserPlanData:
     return UserPlanData(
-        plan=plan_data(user_plan.plan),
+        plan=user_plan.plan,
         customer_id=user_plan.customer_id,
         subscription=user_plan.subscription,
         is_paid=user_plan.is_paid,
@@ -189,7 +177,7 @@ def marshal_user_plan(user: User, data: UserAllData) -> UserPlan:
     user_plan = data.user_plan
     return UserPlan(
         user=user,
-        plan_id=user_plan.plan.id if user_plan.plan.id != 0 else 1,
+        plan=user_plan.plan,
         customer_id=user_plan.customer_id,
         subscription=user_plan.subscription,
         is_paid=user_plan.is_paid,

--- a/myus/api/src/domain/entity/user/repository.py
+++ b/myus/api/src/domain/entity/user/repository.py
@@ -25,7 +25,7 @@ USER_PLAN_FIELDS = ["customer_id", "subscription", "is_paid", "start_date", "end
 
 class UserRepository(UserInterface):
     def queryset(self) -> QuerySet[User]:
-        return User.objects.select_related("profile", "mypage", "notification", "user_plan", "user_plan__plan")
+        return User.objects.select_related("profile", "mypage", "notification", "user_plan")
 
     def get_ids(self, filter: FilterOption, sort: SortOption | None = None) -> list[int]:
         q_list: list[Q] = []

--- a/myus/api/src/domain/interface/user/data.py
+++ b/myus/api/src/domain/interface/user/data.py
@@ -66,18 +66,8 @@ class UserNotificationData:
 
 
 @dataclass(frozen=True, slots=True)
-class PlanData:
-    id: int
-    name: str
-    stripe_api_id: str
-    price: int
-    max_advertise: int
-    description: str
-
-
-@dataclass(frozen=True, slots=True)
 class UserPlanData:
-    plan: PlanData
+    plan: str
     customer_id: str
     subscription: str
     is_paid: bool

--- a/myus/api/src/usecase/advertise.py
+++ b/myus/api/src/usecase/advertise.py
@@ -9,6 +9,7 @@ from api.src.domain.interface.media.index import ExcludeOption, FilterOption, Pa
 from api.src.injectors.container import injector
 from api.src.usecase.user import get_user_data
 from api.utils.functions.index import create_url
+from api.utils.plan import get_plan
 
 
 def get_user_advertises(user_ulid: str) -> list[AdvertiseData]:
@@ -17,7 +18,8 @@ def get_user_advertises(user_ulid: str) -> list[AdvertiseData]:
         log.info("User not found", user_ulid=user_ulid)
         return []
 
-    max_count = user.user_plan.plan.max_advertise
+    plan = get_plan(user.user_plan.plan)
+    max_count = plan.max_advertise if plan is not None else 0
     if max_count <= 0:
         return []
 

--- a/myus/api/src/usecase/auth.py
+++ b/myus/api/src/usecase/auth.py
@@ -8,7 +8,8 @@ from django.core.mail import send_mail
 from django.http import HttpRequest
 from django.template.loader import render_to_string
 from api.modules.logger import log
-from api.src.domain.interface.user.data import MyPageData, PlanData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
+from api.src.domain.interface.user.data import MyPageData, ProfileData, UserAllData, UserData, UserNotificationData, UserPlanData
+from api.utils.enum.index import PlanName
 from api.src.domain.interface.user.interface import FilterOption, UserInterface
 from api.src.injectors.container import injector
 from api.src.types.schema.auth import PasswordChangeIn, PasswordResetIn, SignupIn, WithdrawalIn
@@ -169,14 +170,7 @@ def signup_user(input: SignupIn) -> bool:
             is_views=True,
         ),
         user_plan=UserPlanData(
-            plan=PlanData(
-                id=0,
-                name="",
-                stripe_api_id="",
-                price=0,
-                max_advertise=0,
-                description="",
-            ),
+            plan=PlanName.FREE,
             customer_id="",
             subscription="",
             is_paid=False,

--- a/myus/api/tests/test_login.py
+++ b/myus/api/tests/test_login.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import authenticate, get_user_model
 from django.test import Client, TestCase
-from api.db.models.master import Plan
 
 
 # Create your tests here.
@@ -9,13 +8,6 @@ User = get_user_model()
 
 class LoginTest(TestCase):
     def setUp(self):
-        Plan.objects.create(
-            name="Free",
-            stripe_api_id="free_plan",
-            price=0,
-            max_advertise=0
-        )
-
         self.user = User.objects.create_user(
             email="emailtest@gmail.com",
             username="usernametest",

--- a/myus/api/utils/enum/index.py
+++ b/myus/api/utils/enum/index.py
@@ -7,6 +7,21 @@ class GenderType(str, Enum):
     SECRET = "Secret"
 
 
+class PlanName(str, Enum):
+    FREE = "Free"
+    BASIC = "Basic"
+    STANDARD = "Standard"
+    PREMIUM = "Premium"
+    ULTIMATE = "Ultimate"
+
+
+class PlanAction(str, Enum):
+    SUBSCRIBE = "Subscribe"
+    CHANGE = "Change"
+    CANCEL = "Cancel"
+    EXPIRE = "Expire"
+
+
 class MediaType(str, Enum):
     VIDEO = "Video"
     MUSIC = "Music"

--- a/myus/api/utils/plan.py
+++ b/myus/api/utils/plan.py
@@ -35,6 +35,12 @@ PLANS: list[PlanDef] = [
         max_advertise=3,
         description="・個別広告表示3つ\n・全体広告OFF\n・楽曲ダウンロード",
     ),
+    PlanDef(
+        name=PlanName.ULTIMATE,
+        price=2000,
+        max_advertise=4,
+        description="・個別広告表示4つ\n・全体広告OFF\n・楽曲ダウンロード",
+    ),
 ]
 
 

--- a/myus/api/utils/plan.py
+++ b/myus/api/utils/plan.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from api.utils.enum.index import PlanName
+
+
+@dataclass(frozen=True, slots=True)
+class PlanDef:
+    name: str
+    price: int
+    max_advertise: int
+    description: str
+
+
+PLANS: list[PlanDef] = [
+    PlanDef(
+        name=PlanName.FREE,
+        price=0,
+        max_advertise=0,
+        description="・有料プランを解約します\n・アップロード機能\n・コメント機能\n・フォロー機能など",
+    ),
+    PlanDef(
+        name=PlanName.BASIC,
+        price=550,
+        max_advertise=1,
+        description="・個別広告表示1つ\n・全体広告OFF",
+    ),
+    PlanDef(
+        name=PlanName.STANDARD,
+        price=880,
+        max_advertise=2,
+        description="・個別広告表示2つ\n・全体広告OFF",
+    ),
+    PlanDef(
+        name=PlanName.PREMIUM,
+        price=1200,
+        max_advertise=3,
+        description="・個別広告表示3つ\n・全体広告OFF\n・楽曲ダウンロード",
+    ),
+]
+
+
+PLAN_MAP: dict[str, PlanDef] = {p.name: p for p in PLANS}
+
+
+def get_plan(name: str) -> PlanDef | None:
+    return PLAN_MAP.get(name)

--- a/myus/app/modules/context_data.py
+++ b/myus/app/modules/context_data.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime, timedelta
 from django.contrib.auth import get_user_model
 from django.db.models import F, Count, Exists, OuterRef
-from api.db.models import Plan, MyPage, SearchTag, UserNotification, Follow, Comment
+from api.db.models import MyPage, SearchTag, UserNotification, Follow, Comment
+from api.utils.plan import PLANS
 from api.db.models import Video, Music, Blog, Comic, Picture, Chat, Advertise
 from api.utils.constant import model_dict, model_media_comment_no_dict
 from app.modules.notification import notification_data
@@ -35,7 +36,7 @@ class ContextData:
             context["mypage_list"] = MyPage.objects.filter(user=user.id)
 
         if class_name == "Payment":
-            context["payment_list"] = Plan.objects.all().order_by("-id")
+            context["payment_list"] = list(reversed(PLANS))
 
         if class_name == "FollowList":
             context["follow_list"] = Follow.objects.filter(follower=user.id).select_related("following__mypage").order_by("created")[:100]
@@ -92,7 +93,7 @@ class ContextData:
 
         context["advertise_auto_list"] = Advertise.objects.filter(publish=True, type=0).order_by("?")[:1]
         advertise = Advertise.objects.filter(publish=True, type=1, author=author).order_by("?")
-        author_plan = author.user_plan.plan.name
+        author_plan = author.user_plan.plan
         if author_plan == "Basic":
             context["advertise_list"] = advertise[:1]
         if author_plan == "Standard":

--- a/myus/app/modules/pjax.py
+++ b/myus/app/modules/pjax.py
@@ -2,7 +2,8 @@ from datetime import datetime, timedelta
 from django.contrib.auth import get_user_model
 from django.db.models import Count, F
 from django.template.loader import render_to_string
-from api.db.models import Advertise, Follow, MyPage, Plan, UserNotification
+from api.db.models import Advertise, Follow, MyPage, UserNotification
+from api.utils.plan import PLANS
 from api.utils.constant import model_create_pjax, model_dict, model_pjax
 from app.modules.search import SearchData
 
@@ -94,7 +95,7 @@ def pjax_context(request, href):
         template = "menu/knowledge_content.html"
     if href == "setting/payment":
         template = "setting/payment/payment_content.html"
-        context = {"payment_list": Plan.objects.all().order_by("-id")}
+        context = {"payment_list": list(reversed(PLANS))}
     if href == "setting/profile":
         template = "setting/profile_content.html"
     if href == "setting/mypage":


### PR DESCRIPTION
## Summary
- `Plan` DB モデルを削除し、`PlanName` / `PlanAction` Enum と `PlanDef` dataclass による静的定義へ移行
- `UserPlan.plan` を ForeignKey から `CharField(choices=PlanName)` に変更
- プラン変更履歴を保持する `UserPlanHistory` モデルを追加

## 変更内容

### モデル変更
- `myus/api/db/models/master.py`: `Plan` モデルを削除
- `myus/api/db/models/user.py`:
  - `UserPlan.plan` を `CharField(choices)` 化、`__str__` も合わせて変更
  - `UserPlanHistory` モデルを新設（`user`, `plan`, `price`, `action`, `subscription`, `created`、`(user, -created)` インデックス）

### Enum / 静的定義の追加
- `myus/api/utils/enum/index.py`: `PlanName`（FREE / BASIC / STANDARD / PREMIUM / ULTIMATE）と `PlanAction`（SUBSCRIBE / CHANGE / CANCEL / EXPIRE）を追加
- `myus/api/utils/plan.py` を新設: `PlanDef` dataclass、`PLANS` リスト、`PLAN_MAP`、`get_plan(name)` を提供

### ドメイン層の追従
- `src/domain/interface/user/data.py`: `PlanData` を削除、`UserPlanData.plan` を `str` に変更
- `src/domain/entity/user/_convert.py`: `plan_data` 削除、`user_plan_data` / `marshal_user_plan` を新方式に追従
- `src/domain/entity/user/repository.py`: `select_related` から `user_plan__plan` を除去

### ユースケース / アダプタ
- `src/usecase/auth.py`: signup 時のデフォルトを `PlanName.FREE` に変更
- `src/usecase/advertise.py`: `get_plan()` 経由で `max_advertise` を取得（未定義時は 0）
- `src/adapter/setting.py`: `user_plan.plan.name` → `user_plan.plan` に変更

### app 側
- `app/modules/context_data.py`, `app/modules/pjax.py`: `Plan.objects.all()` の代わりに `list(reversed(PLANS))` を使用
- 広告枠の判定を `user_plan.plan.name` から `user_plan.plan` に変更

### テスト
- `tests/test_login.py`: `Plan.objects.create(...)` の前処理を削除