### PR TITLE
【back】決済ドメイン層を新設（interfaces + data + enums）

### DIFF
--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from api.utils.enum.i18n import Currency, Locale
+from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType
+
+
+@dataclass(frozen=True, slots=True)
+class Money:
+    amount: int
+    currency: Currency
+
+
+@dataclass(frozen=True, slots=True)
+class CustomerData:
+    email: str
+
+
+@dataclass(frozen=True, slots=True)
+class RedirectUrls:
+    success_url: str
+    cancel_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class MarketplaceData:
+    seller_id: str
+    application_fee: Money
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutData:
+    payment_type: PaymentType
+    price: Money
+    customer: CustomerData
+    description: str
+    product_ref: str
+    redirect: RedirectUrls
+    marketplace: MarketplaceData
+    locale: Locale
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutSessionData:
+    provider: PaymentProvider
+    external_id: str
+    redirect_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutCreated:
+    session: CheckoutSessionData
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutFailed:
+    error: CheckoutError
+    message: str
+
+
+type CheckoutResult = CheckoutCreated | CheckoutFailed

--- a/myus/api/src/domain/interface/payment/provider.py
+++ b/myus/api/src/domain/interface/payment/provider.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from api.src.domain.interface.payment.data import CheckoutData, CheckoutResult
+from api.utils.enum.payment import PaymentProvider
+
+
+class PaymentProviderInterface(ABC):
+    @abstractmethod
+    def kind(self) -> PaymentProvider:
+        ...
+
+    @abstractmethod
+    def create_checkout(self, input: CheckoutData) -> CheckoutResult:
+        ...

--- a/myus/api/utils/enum/i18n.py
+++ b/myus/api/utils/enum/i18n.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+class Currency(str, Enum):
+    JPY = "Jpy"
+    USD = "Usd"
+    EUR = "Eur"
+    GBP = "Gbp"
+    CNY = "Cny"
+    KRW = "Krw"
+
+
+class Locale(str, Enum):
+    JA = "Ja"
+    EN = "En"
+    ZH = "Zh"
+    KO = "Ko"
+
+
+class Country(str, Enum):
+    JP = "Jp"
+    US = "Us"
+    GB = "Gb"
+    CN = "Cn"
+    KR = "Kr"

--- a/myus/api/utils/enum/payment.py
+++ b/myus/api/utils/enum/payment.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class PaymentProvider(str, Enum):
+    STRIPE = "Stripe"
+
+
+class PaymentType(str, Enum):
+    SUBSCRIPTION = "Subscription"
+    ONE_TIME = "OneTime"
+
+
+class CheckoutError(str, Enum):
+    UNKNOWN_PRODUCT = "UnknownProduct"
+    INVALID_AMOUNT = "InvalidAmount"
+    PROVIDER_REJECTED = "ProviderRejected"
+    NETWORK_ERROR = "NetworkError"


### PR DESCRIPTION
## Summary
- プロバイダ非依存な決済ドメインモデル（interface / value object / sum type）を定義（実装無し）
- Sum type による `None` 排除と、多通貨・多言語・複数国に拡張可能な i18n enum を utility に追加
- 既存機能には一切影響しない（誰もこの interface を使っていないため）

## 背景

`docs/roadmap_payment.md`（次 PR で追加予定）に基づくロードマップの **PR #1**。決済基盤を Stripe 密結合から疎結合に再構築するための土台として、まずドメイン層だけを先に定義する。Stripe Provider の実装、injector 登録、adapter / frontend 切替は後続 PR で順次行う。

## 変更内容

### 新規 enum（`myus/api/utils/enum/`）

#### `payment.py`
- `PaymentProvider`: 決済プロバイダ種別（現状 `STRIPE` のみ、将来 GMO / Amazon Pay 等を追加）
- `PaymentType`: `SUBSCRIPTION` / `ONE_TIME`
- `CheckoutError`: 失敗カテゴリ enum
  - `UNKNOWN_PRODUCT`（input 検証）
  - `INVALID_AMOUNT`（input 検証）
  - `PROVIDER_REJECTED`（プロバイダが API エラー）
  - `NETWORK_ERROR`（到達できない）
  - 順序は「責務シフト順（caller → provider → infrastructure）」

#### `i18n.py`
- `Currency`: `JPY` / `USD` / `EUR` / `GBP` / `CNY` / `KRW`
- `Locale`: `JA` / `EN` / `ZH` / `KO`
- `Country`: `JP` / `US` / `GB` / `CN` / `KR`

### 決済ドメイン interface（`myus/api/src/domain/interface/payment/`）

#### `data.py`
Value Object 群:
- `Money(amount, currency)` — 通貨と金額のセット
- `CustomerData(email)` — 顧客情報
- `RedirectUrls(success_url, cancel_url)` — リダイレクト先 URL
- `MarketplaceData(seller_id, application_fee)` — マーケットプレイス情報。`seller_id=\"\"` で PLATFORM 課金を表現

入力:
- `CheckoutData` — `payment_type` / `price` / `customer` / `description` / `product_ref` / `redirect` / `marketplace` / `locale` を持つ

出力（Sum Type で `None` 排除）:
- `CheckoutSessionData(provider, external_id, redirect_url)` — 成功時の決済セッション
- `CheckoutCreated(session)` — 成功バリアント
- `CheckoutFailed(error: CheckoutError, message)` — 失敗バリアント
- `type CheckoutResult = CheckoutCreated | CheckoutFailed`

#### `provider.py`
- `PaymentProviderInterface` ABC
  - `kind() -> PaymentProvider` — どのプロバイダかを宣言
  - `create_checkout(input: CheckoutData) -> CheckoutResult` — 決済セッション作成

## 設計上の決定

- **`None` 排除**: `| None` の代わりに sum type で失敗を表現。呼び出し側は `match-case` で網羅
- **Value Object 強制**: `amount: int` 単独を渡さず `Money` で包む（多通貨対応の素地）
- **`product_ref: str`**: 内部商品参照は opaque 文字列。プロバイダ実装側で必要なら lookup
- **`MarketplaceData` 必須**: `seller_id=\"\"` センチネルで PLATFORM 課金を表現、`None` 不使用
- **CRUD パターン非準拠**: payment は DB-backed Repository ではなく外部サービス adapter なので、`get_ids` / `bulk_get` 等は持たない

## スコープ外

- StripeProvider 実装（次 PR）
- injector 登録・env 追加（次 PR）
- adapter / frontend 切替（その次の PR）
- Subscription / PaymentTransaction テーブル設計（Phase 2 以降）

## 確認

- `uv run mypy api/utils/enum/ api/src/domain/interface/payment/` → clean
- match-case による smoke test pass（`CheckoutCreated` / `CheckoutFailed` 両分岐）
- 既存 import パスは触らない（`api.utils.enum.index` は既存のまま、payment 系のみ別ファイルに分離）