### PR TITLE
【docs】バックエンドの import 順序ルールを明文化

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -21,7 +21,12 @@
 ## インポート
 
 - ファイルの先頭で行う（ローカルインポート禁止、`TYPE_CHECKING`禁止）
-- 順序: 標準ライブラリ → サードパーティ → Django → プロジェクト内
+- **`import X` 文は全て先頭にまとめる**（section に関係なく `from` より上）
+  - 例: `import jwt` は `from dataclasses import replace` より上
+- **`from X import Y` 文は section 順**: 標準ライブラリ → サードパーティ → Django → プロジェクト内
+- **`from x import a, b, c` の中身は domain 順序を維持する**（alphabetical にしない）
+  - 例: `from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat` は `MediaType` enum の定義順を保つ
+- **`ruff check --fix` を勝手に実行しない**: ruff の isort 挙動は上記ルールと衝突するため、import 整理が必要なときは手動で対応する
 
 ## 命名規則
 


### PR DESCRIPTION
## Summary
- バックエンドの import 順序の慣習を `docs/backend.md` に明文化
- `import X` 文を `from` より上にまとめる方針、`from x import a, b, c` の domain 順序維持、`ruff check --fix` 勝手禁止の 3 点

## 背景

これまで暗黙の慣習として運用されていた以下のルールを明文化。先日 `ruff check --fix` を実行して `import jwt` の位置や `MediaType` 順の import が alphabetical 化されてしまった事象を機に、ドキュメント化する。

## 変更内容

### `docs/backend.md` のインポート節

**変更前:**

```md
## インポート

- ファイルの先頭で行う（ローカルインポート禁止、`TYPE_CHECKING`禁止）
- 順序: 標準ライブラリ → サードパーティ → Django → プロジェクト内
```

**変更後:**

```md
## インポート

- ファイルの先頭で行う（ローカルインポート禁止、`TYPE_CHECKING`禁止）
- **`import X` 文は全て先頭にまとめる**（section に関係なく `from` より上）
  - 例: `import jwt` は `from dataclasses import replace` より上
- **`from X import Y` 文は section 順**: 標準ライブラリ → サードパーティ → Django → プロジェクト内
- **`from x import a, b, c` の中身は domain 順序を維持する**（alphabetical にしない）
  - 例: `from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat` は `MediaType` enum の定義順を保つ
- **`ruff check --fix` を勝手に実行しない**: ruff の isort 挙動は上記ルールと衝突するため、import 整理が必要なときは手動で対応する
```

### 規約の根拠

1. **`import X` を先頭にまとめる**: 既存コードの慣習。例: `myus/api/src/usecase/auth.py` の `import jwt` は `from dataclasses` より上
2. **domain 順序の維持**: `MediaType` enum や同様の domain enum は UI / 概念順で並んでおり、それと整合する import 並び順を保つ
3. **`ruff check --fix` 禁止**: 現在の `pyproject.toml` で `select = ["I"]` (isort) が有効だが、ruff のデフォルト挙動が上記 1〜2 と衝突する。設定変更で吸収するのは困難なので、運用ルールとして手動対応とする

## スコープ外

- ruff 設定の調整（`pyproject.toml` の修正）
- 既存ファイルで規約に違反している箇所の網羅修正