### PR TITLE
【back】CheckoutData のフィールド命名・並び順を整理

### DIFF
--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -10,6 +10,12 @@ class Money:
 
 
 @dataclass(frozen=True, slots=True)
+class MarketplaceData:
+    seller_id: str
+    application_fee: Money
+
+
+@dataclass(frozen=True, slots=True)
 class CustomerData:
     email: str
 
@@ -21,18 +27,12 @@ class RedirectUrls:
 
 
 @dataclass(frozen=True, slots=True)
-class MarketplaceData:
-    seller_id: str
-    application_fee: Money
-
-
-@dataclass(frozen=True, slots=True)
 class CheckoutData:
-    payment_type: PaymentType
-    price: Money
-    customer: CustomerData
+    product_code: str
     description: str
-    product_ref: str
+    price: Money
+    payment_type: PaymentType
+    customer: CustomerData
     redirect: RedirectUrls
     marketplace: MarketplaceData
     locale: Locale


### PR DESCRIPTION
## Summary
- `CheckoutData.product_ref` → `product_code` に改名
- `CheckoutData` のフィールド順を「商品情報グループ先頭」に再編
- 依存関係に従い `MarketplaceData` を `Money` の直下に移動

## 背景

PR #829 で定義した `CheckoutData` を実装に進める前に、命名と並び順を見直し。誰も使っていない interface 段階のうちに整える。

## 変更内容

### `product_ref` → `product_code`

- "ref" は技術的すぎて何の参照か曖昧
- `_code` は文字列識別子であることが明確（DB 整数 `id` と混同しない）
- EC 業界標準命名（商品コード）

### `CheckoutData` のフィールド順

**Before:**
```python
class CheckoutData:
    payment_type: PaymentType
    price: Money
    customer: CustomerData          # ← 商品情報を分断
    description: str
    product_ref: str
    redirect: RedirectUrls
    marketplace: MarketplaceData
    locale: Locale
```

**After:**
```python
class CheckoutData:
    product_code: str               # 商品情報グループ ┐
    description: str                #                  │
    price: Money                    #                  ┘
    payment_type: PaymentType       # 取引種別
    customer: CustomerData          # 買い手
    redirect: RedirectUrls          # 取引ルーティング ┐
    marketplace: MarketplaceData    #                  ┘
    locale: Locale                  # 表示
```

商品情報（product_code / description / price）を先頭に集約し、`customer` で分断されていた状態を解消。

### `MarketplaceData` を `Money` の直下に移動

`MarketplaceData.application_fee: Money` という依存関係に従って、定義順を「依存される側 → 依存する側」へ。

## スコープ外

- `docs/roadmap_payment.md` 内の `product_ref` 表記の追従更新（unstaged のため別 PR）
- adapter / Stripe Provider 等の実装（誰もこの interface を使っていないので影響なし）

## 確認

- mypy clean
- 既存テスト無変更（誰もこの interface を使っていない）