### PR TITLE
【front】料金プランの送信値を stripeId から plan に変更

### DIFF
--- a/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
+++ b/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
@@ -6,7 +6,6 @@ export interface Plan {
   name: string
   price: number
   features: string[]
-  stripeId: string
 }
 
 interface Props {
@@ -18,15 +17,15 @@ interface Props {
   purchaseDisabled?: boolean
   loading?: boolean
   onClick?: () => void
-  onPurchase?: (stripeId: string) => void
+  onPurchase?: (plan: string) => void
 }
 
 export default function PlanCard(props: Props): React.JSX.Element {
   const { plan, active, onClick, onPurchase, current = false, showPurchase = true, disabled = false, purchaseDisabled = false, loading = false } = props
-  const { name, price, features, stripeId } = plan
+  const { name, price, features } = plan
 
   const handleClick = disabled ? undefined : onClick
-  const handlePurchase = () => onPurchase?.(stripeId)
+  const handlePurchase = () => onPurchase?.(name)
 
   return (
     <div className={cx(style.plan, active && style.active, handleClick && style.clickable, disabled && style.disabled)} onClick={handleClick}>
@@ -45,7 +44,7 @@ export default function PlanCard(props: Props): React.JSX.Element {
           </li>
         ))}
       </ul>
-      {showPurchase && stripeId && <Button color="purple" size="l" name="購入する" disabled={purchaseDisabled} loading={loading} onClick={handlePurchase} />}
+      {showPurchase && name !== 'Free' && <Button color="purple" size="l" name="購入する" disabled={purchaseDisabled} loading={loading} onClick={handlePurchase} />}
     </div>
   )
 }

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -19,19 +19,19 @@ export default function Payment(props: Props): React.JSX.Element {
   const { mypage } = props
   const router = useRouter()
   const { toast, handleToast } = useToast()
-  const [loadingId, setLoadingId] = useState<string>('')
+  const [loadingPlan, setLoadingPlan] = useState<string>('')
 
   const currentPlan = mypage.plan
-  const purchasable = plans.filter((plan) => plan.stripeId !== '')
+  const purchasable = plans.filter((plan) => plan.name !== 'Free')
   const isPaid = currentPlan !== 'Free'
 
   const handleChange = () => router.push('/setting/payment/change')
 
-  const handlePurchase = async (stripeId: string) => {
-    setLoadingId(stripeId)
-    const ret = await postPaymentCheckout({ stripeId })
+  const handlePurchase = async (plan: string) => {
+    setLoadingPlan(plan)
+    const ret = await postPaymentCheckout({ plan })
     if (ret.isErr()) {
-      setLoadingId('')
+      setLoadingPlan('')
       handleToast(ret.error.message ?? FetchError.Post, true)
       return
     }
@@ -45,7 +45,7 @@ export default function Payment(props: Props): React.JSX.Element {
 
         <div className={style.plans}>
           {purchasable.map((plan) => (
-            <PlanCard key={plan.name} plan={plan} active={currentPlan === plan.name} purchaseDisabled={isPaid} loading={loadingId === plan.stripeId} onPurchase={handlePurchase} />
+            <PlanCard key={plan.name} plan={plan} active={currentPlan === plan.name} purchaseDisabled={isPaid} loading={loadingPlan === plan.name} onPurchase={handlePurchase} />
           ))}
         </div>
 

--- a/frontend/src/components/templates/setting/payment/plans.ts
+++ b/frontend/src/components/templates/setting/payment/plans.ts
@@ -5,24 +5,20 @@ export const plans: Plan[] = [
     name: 'Basic',
     price: 550,
     features: ['個別広告表示 1つ', '全体広告 非表示'],
-    stripeId: 'price_1K9VSxCHdDAlRliqOZnYuctl',
   },
   {
     name: 'Standard',
     price: 880,
     features: ['個別広告表示 3つ', '全体広告 非表示'],
-    stripeId: 'price_1K9VTbCHdDAlRliq3YNA768b',
   },
   {
     name: 'Premium',
     price: 1200,
     features: ['個別広告表示 4つ', '全体広告 非表示', '楽曲ダウンロード'],
-    stripeId: 'price_1K9VU9CHdDAlRliqXsIS6GC4',
   },
   {
     name: 'Free',
     price: 0,
     features: ['基本機能', '広告あり'],
-    stripeId: '',
   },
 ]

--- a/frontend/src/types/internal/payment.d.ts
+++ b/frontend/src/types/internal/payment.d.ts
@@ -1,5 +1,5 @@
 export interface PaymentCheckoutIn {
-  stripeId: string
+  plan: string
 }
 
 export interface PaymentCheckoutOut {


### PR DESCRIPTION
## Summary
- バックエンド PR #836 の `PaymentCheckoutIn` 変更（`stripe_id` → `plan`）に追従
- フロントから Stripe price ID のハードコードを撤去し、プラン名（`Basic` / `Standard` / `Premium` / `Free`）を送信値として扱う
- Free プランの購入ボタン非表示判定を `stripeId === ''` から `name === 'Free'` に変更

## 変更内容

### `frontend/src/types/internal/payment.d.ts`
- `PaymentCheckoutIn.stripeId: string` → `plan: string`

### `frontend/src/components/templates/setting/payment/plans.ts`
- `Plan[]` から `stripeId` フィールドを削除し、Stripe price ID のハードコードを撤去

### `frontend/src/components/templates/setting/payment/PlanCard/index.tsx`
- `Plan` インターフェースから `stripeId` を削除
- 購入ボタン表示条件を `showPurchase && stripeId` → `showPurchase && name !== 'Free'`
- `onPurchase` コールバックの引数を `stripeId` → `plan` 名

### `frontend/src/components/templates/setting/payment/index.tsx`
- ローディング状態の state を `loadingId` → `loadingPlan` にリネーム（実体がプラン名になったため）
- `purchasable` の filter を `plan.stripeId !== ''` → `plan.name !== 'Free'`
- `postPaymentCheckout` への送信値を `{ stripeId }` → `{ plan }`
- ローディング判定を `loadingId === plan.stripeId` → `loadingPlan === plan.name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)