### PR TITLE
【back】Subscription / PaymentTransaction モデル新設

### DIFF
--- a/myus/api/db/models/__init__.py
+++ b/myus/api/db/models/__init__.py
@@ -5,6 +5,7 @@ from api.db.models.media import *
 from api.db.models.hashtag import *
 from api.db.models.message import *
 from api.db.models.notification import *
+from api.db.models.payment import *
 from api.db.models.stripe import *
 from api.db.models.subscribe import *
 from api.db.models.user import *

--- a/myus/api/db/models/payment.py
+++ b/myus/api/db/models/payment.py
@@ -1,0 +1,59 @@
+import datetime
+from django.db import models
+from api.db.models.user import User
+from api.utils.constant import CURRENCY_CHOICES, PROVIDER_CHOICES, SUBSCRIPTION_STATUS_CHOICES, PAYMENT_STATUS_CHOICES
+from api.utils.enum.i18n import Currency
+from api.utils.enum.payment import SubscriptionStatus, PaymentStatus
+
+DATETIME_MIN = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+
+
+class Subscription(models.Model):
+    """Subscription"""
+    id                 = models.BigAutoField(primary_key=True)
+    customer           = models.ForeignKey(User, on_delete=models.CASCADE, related_name="subscriptions")
+    seller_id          = models.CharField(max_length=26, blank=True)
+    provider           = models.CharField(max_length=20, choices=PROVIDER_CHOICES)
+    external_id        = models.CharField(max_length=255)
+    product_code       = models.CharField(max_length=30)
+    price_amount       = models.IntegerField(default=0)
+    price_currency     = models.CharField(max_length=3, choices=CURRENCY_CHOICES, default=Currency.JPY)
+    status             = models.CharField(max_length=20, choices=SUBSCRIPTION_STATUS_CHOICES, default=SubscriptionStatus.INCOMPLETE)
+    started_at         = models.DateTimeField(default=DATETIME_MIN)
+    current_period_end = models.DateTimeField(default=DATETIME_MIN)
+    canceled_at        = models.DateTimeField(default=DATETIME_MIN)
+
+    def __str__(self):
+        return f"{self.customer_id}:{self.product_code}:{self.status}"
+
+    class Meta:
+        db_table = "subscription"
+        verbose_name_plural = "001 Subscription"
+        indexes = [
+            models.Index(fields=["customer", "status"], name="subscription_customer_status_idx"),
+            models.Index(fields=["provider", "external_id"], name="subscription_external_idx"),
+        ]
+
+
+class PaymentTransaction(models.Model):
+    """PaymentTransaction"""
+    id              = models.BigAutoField(primary_key=True)
+    subscription_id = models.BigIntegerField(default=0)
+    customer        = models.ForeignKey(User, on_delete=models.CASCADE, related_name="payment_transactions")
+    provider        = models.CharField(max_length=20, choices=PROVIDER_CHOICES)
+    external_id     = models.CharField(max_length=255)
+    price_amount    = models.IntegerField(default=0)
+    price_currency  = models.CharField(max_length=3, choices=CURRENCY_CHOICES, default=Currency.JPY)
+    status          = models.CharField(max_length=20, choices=PAYMENT_STATUS_CHOICES, default=PaymentStatus.PENDING)
+    paid_at         = models.DateTimeField(default=DATETIME_MIN)
+
+    def __str__(self):
+        return f"{self.customer_id}:{self.external_id}:{self.status}"
+
+    class Meta:
+        db_table = "payment_transaction"
+        verbose_name_plural = "001 PaymentTransaction"
+        indexes = [
+            models.Index(fields=["customer", "-paid_at"], name="payment_tx_customer_paid_idx"),
+            models.Index(fields=["provider", "external_id"], name="payment_tx_external_idx"),
+        ]

--- a/myus/api/src/adapter/external/payment/stripe/_convert.py
+++ b/myus/api/src/adapter/external/payment/stripe/_convert.py
@@ -79,6 +79,7 @@ def convert_line_items(input: CheckoutData) -> list[SessionCreateParamsLineItem]
 def convert_marketplace_params(input: CheckoutData) -> SessionCreateParams:
     if len(input.marketplace.seller_id) == 0:
         return SessionCreateParams()
+
     match input.payment_type:
         case PaymentType.SUBSCRIPTION:
             sub_transfer = SessionCreateParamsSubscriptionDataTransferData(destination=input.marketplace.seller_id)

--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
+from datetime import datetime
 from api.utils.enum.i18n import Currency, Locale
-from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType
+from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentStatus, PaymentType, SubscriptionStatus
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,3 +58,30 @@ class CheckoutFailed:
 
 
 type CheckoutResult = CheckoutCreated | CheckoutFailed
+
+
+@dataclass(frozen=True, slots=True)
+class SubscriptionData:
+    id: int
+    customer_user_id: int
+    seller_id: str
+    provider: PaymentProvider
+    external_id: str
+    product_code: str
+    price: Money
+    status: SubscriptionStatus
+    started_at: datetime
+    current_period_end: datetime
+    canceled_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class PaymentTransactionData:
+    id: int
+    subscription_id: int
+    customer_user_id: int
+    provider: PaymentProvider
+    external_id: str
+    price: Money
+    status: PaymentStatus
+    paid_at: datetime

--- a/myus/api/utils/constant.py
+++ b/myus/api/utils/constant.py
@@ -2,6 +2,14 @@ from api.db.models.comment import Comment
 from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat
 from api.db.models.message import Message
 from api.db.models.users import Follow
+from api.utils.enum.i18n import Currency
+from api.utils.enum.payment import PaymentProvider, SubscriptionStatus, PaymentStatus
+
+
+CURRENCY_CHOICES = [(c, c) for c in Currency]
+PROVIDER_CHOICES = [(p, p) for p in PaymentProvider]
+SUBSCRIPTION_STATUS_CHOICES = [(s, s) for s in SubscriptionStatus]
+PAYMENT_STATUS_CHOICES = [(s, s) for s in PaymentStatus]
 
 
 type MediaModel = Video | Music | Blog | Comic | Picture | Chat

--- a/myus/api/utils/enum/payment.py
+++ b/myus/api/utils/enum/payment.py
@@ -15,3 +15,20 @@ class CheckoutError(str, Enum):
     INVALID_AMOUNT = "InvalidAmount"
     PROVIDER_REJECTED = "ProviderRejected"
     NETWORK_ERROR = "NetworkError"
+
+
+class SubscriptionStatus(str, Enum):
+    ACTIVE = "Active"
+    PAST_DUE = "PastDue"
+    CANCELED = "Canceled"
+    EXPIRED = "Expired"
+    INCOMPLETE = "Incomplete"
+
+
+class PaymentStatus(str, Enum):
+    PENDING = "Pending"
+    AUTHORIZED = "Authorized"
+    CAPTURED = "Captured"
+    FAILED = "Failed"
+    REFUNDED = "Refunded"
+    CANCELED = "Canceled"


### PR DESCRIPTION
## Summary
- ロードマップ PR #4 の Step1 として、`Subscription` / `PaymentTransaction` モデルを新設
- `SubscriptionStatus` / `PaymentStatus` enum を追加し、`SubscriptionData` / `PaymentTransactionData` dataclass を domain interface に追加
- Django Admin 用の `CHOICES` 定数を `api/utils/constant.py` に集約
- 既存 `UserPlan` / `UserPlanHistory` は無傷で並行運用可能（データ移行は別 PR）

## 変更内容

### 新規モデル `myus/api/db/models/payment.py`
- `Subscription`: 継続課金の状態を持つ。買い手は `customer` FK、売り手は `seller_id`（"" なら PLATFORM）、`price_amount` + `price_currency` で Money 相当を保持
- `PaymentTransaction`: 個別取引。`subscription_id=0` で one-time を表現
- `None` 排除方針に沿い、`canceled_at` / `paid_at` 等は `datetime.min`（UTC）を sentinel default
- インデックス: `(customer, status)` / `(provider, external_id)` / `(customer, -paid_at)` を付与

### Enum 追加 `myus/api/utils/enum/payment.py`
- `SubscriptionStatus`: `ACTIVE` / `PAST_DUE` / `CANCELED` / `EXPIRED` / `INCOMPLETE`
- `PaymentStatus`: `PENDING` / `AUTHORIZED` / `CAPTURED` / `FAILED` / `REFUNDED` / `CANCELED`

### Choices 集約 `myus/api/utils/constant.py`
- `CURRENCY_CHOICES` / `PROVIDER_CHOICES` / `SUBSCRIPTION_STATUS_CHOICES` / `PAYMENT_STATUS_CHOICES` を集約
- enum はドメイン純粋型として保ち、Django 用の choices 形式は constant 側で組み立てる分離

### Interface 追加 `myus/api/src/domain/interface/payment/data.py`
- `SubscriptionData` / `PaymentTransactionData` dataclass を追加（frozen + slots）
- `price` は `Money` value object で保持

### モデル登録 `myus/api/db/models/__init__.py`
- 新規 `payment` モジュールを export 一覧に追加

### `myus/api/src/adapter/external/payment/stripe/_convert.py`
- `convert_marketplace_params` の `seller_id` 早期 return とその下のロジックの間に空行を 1 行追加（可読性向上）

## 動作確認
- `python manage.py makemigrations db --dry-run` で `Subscription` / `PaymentTransaction` 追加分が捕捉済み（migration はリポジトリで gitignore 対象のため別途生成）
- `python manage.py sqlmigrate` で SQL が想定通り（FK / index / default sentinel）であることを確認
- `mypy` で新規ファイルにエラーなし

## 次の PR（Step2〜4）
- Step2: `UserPlan` → `Subscription` データ移行
- Step3: adapter / usecase の `user.user_plan` 参照を `user.subscription` に置換
- Step4: `UserPlan` / `UserPlanHistory` 削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)