### PR TITLE
【back】constant.py を constants/ ディレクトリに分割 + Choices を choice.py に集約

### DIFF
--- a/myus/api/admin.py
+++ b/myus/api/admin.py
@@ -9,7 +9,7 @@ from api.db.models import Notification, AccessLog, Comment, Message, Follow, Adv
 from api.db.models import User, Profile, MyPage, SearchTag, HashTag, NgWord, UserNotification
 from api.db.models import Video, Music, Blog, Comic, Picture, Chat
 from api.db.models.channel import Channel
-from api.utils.constant import model_media_comment_dict
+from api.utils.constants.media import model_media_comment_dict
 
 
 # Admin用の管理画面

--- a/myus/api/db/models/common.py
+++ b/myus/api/db/models/common.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django_ulid.models import ulid
 from api.db.models.user import User
+from api.utils.constants.choice import ADVERTISE_TYPE_CHOICES
 from api.utils.functions.file import advertise_image_upload, advertise_video_upload
 
 
@@ -24,7 +25,6 @@ class AccessLog(models.Model):
 
 class Advertise(models.Model):
     """Advertise"""
-    choice  = (("all", "全体"), ("one", "個別"))
     id      = models.BigAutoField(primary_key=True)
     ulid    = models.CharField(max_length=26, unique=True, editable=False, default=ulid.new)
     author  = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -34,7 +34,7 @@ class Advertise(models.Model):
     image   = models.ImageField(upload_to=advertise_image_upload, max_length=255, blank=True)
     video   = models.FileField(upload_to=advertise_video_upload, max_length=255, blank=True)
     read    = models.IntegerField(default=0)
-    type    = models.CharField(choices=choice, max_length=3, default="one")
+    type    = models.CharField(choices=ADVERTISE_TYPE_CHOICES, max_length=3, default="one")
     period  = models.DateField(blank=True, null=True)
     publish = models.BooleanField(default=True)
     created = models.DateTimeField(auto_now_add=True)

--- a/myus/api/db/models/notification.py
+++ b/myus/api/db/models/notification.py
@@ -1,9 +1,7 @@
-from django.contrib.contenttypes.fields import GenericForeignKey
-from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django_ulid.models import ulid
 from api.db.models.user import User
-from api.utils.constant import notification_type_model
+from api.utils.constants.notification import notification_type_model
 
 
 class Notification(models.Model):

--- a/myus/api/db/models/payment.py
+++ b/myus/api/db/models/payment.py
@@ -1,7 +1,7 @@
 import datetime
 from django.db import models
 from api.db.models.user import User
-from api.utils.constant import CURRENCY_CHOICES, PROVIDER_CHOICES, SUBSCRIPTION_STATUS_CHOICES, PAYMENT_STATUS_CHOICES
+from api.utils.constants.choice import CURRENCY_CHOICES, PROVIDER_CHOICES, PAYMENT_STATUS_CHOICES, SUBSCRIPTION_STATUS_CHOICES
 from api.utils.enum.i18n import Currency
 from api.utils.enum.payment import SubscriptionStatus, PaymentStatus
 

--- a/myus/api/db/models/user.py
+++ b/myus/api/db/models/user.py
@@ -3,7 +3,8 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.utils import timezone
 from django_ulid.models import ulid
-from api.utils.enum.user import GenderType, PlanAction, PlanName
+from api.utils.constants.choice import GENDER_CHOICES, PLAN_CHOICES, PLAN_ACTION_CHOICES
+from api.utils.enum.user import PlanName
 from api.utils.functions.file import avatar_upload
 
 
@@ -66,14 +67,13 @@ class User(AbstractBaseUser, PermissionsMixin):
 class Profile(models.Model):
     """Profile"""
     id           = models.BigAutoField(primary_key=True)
-    gender_type  = ((GenderType.MALE, "男性"), (GenderType.FEMALE, "女性"), (GenderType.SECRET, "秘密"))
     message      = "電話番号は090-1234-5678の形式で入力する必要があります。最大15桁まで入力できます"
     phone_no     = RegexValidator(regex=r"\d{2,4}-?\d{2,4}-?\d{3,4}", message=message)
     user         = models.OneToOneField(User, on_delete=models.CASCADE)
     last_name    = models.CharField(max_length=50)
     first_name   = models.CharField(max_length=50)
     birthday     = models.DateField()
-    gender       = models.CharField(choices=gender_type, max_length=6)
+    gender       = models.CharField(choices=GENDER_CHOICES, max_length=6)
     phone        = models.CharField(validators=[phone_no], max_length=15, blank=True)
     country_code = models.CharField(max_length=255, default="JP")
     postal_code  = models.CharField(max_length=255, blank=True)
@@ -127,10 +127,9 @@ class UserNotification(models.Model):
 
 class UserPlan(models.Model):
     """UserPlan"""
-    plans        = [(p, p) for p in PlanName]
     id           = models.BigAutoField(primary_key=True)
     user         = models.OneToOneField(User, on_delete=models.CASCADE, related_name="user_plan")
-    plan         = models.CharField(max_length=30, choices=plans, default=PlanName.FREE)
+    plan         = models.CharField(max_length=30, choices=PLAN_CHOICES, default=PlanName.FREE)
     customer_id  = models.CharField(max_length=255)
     subscription = models.CharField(max_length=255)
     is_paid      = models.BooleanField(default=False)
@@ -147,13 +146,11 @@ class UserPlan(models.Model):
 
 class UserPlanHistory(models.Model):
     """UserPlanHistory"""
-    plans        = [(p, p) for p in PlanName]
-    actions      = [(a, a) for a in PlanAction]
     id           = models.BigAutoField(primary_key=True)
     user         = models.ForeignKey(User, on_delete=models.CASCADE, related_name="user_plan_histories")
-    plan         = models.CharField(max_length=30, choices=plans)
+    plan         = models.CharField(max_length=30, choices=PLAN_CHOICES)
     price        = models.IntegerField()
-    action       = models.CharField(max_length=20, choices=actions)
+    action       = models.CharField(max_length=20, choices=PLAN_ACTION_CHOICES)
     subscription = models.CharField(max_length=255, blank=True)
     created      = models.DateTimeField(auto_now_add=True)
 

--- a/myus/api/utils/constants/choice.py
+++ b/myus/api/utils/constants/choice.py
@@ -1,0 +1,14 @@
+from api.utils.enum.i18n import Currency
+from api.utils.enum.payment import PaymentProvider, SubscriptionStatus, PaymentStatus
+from api.utils.enum.user import GenderType, PlanName, PlanAction
+
+
+GENDER_CHOICES = ((GenderType.MALE, "男性"), (GenderType.FEMALE, "女性"), (GenderType.SECRET, "秘密"))
+ADVERTISE_TYPE_CHOICES = (("all", "全体"), ("one", "個別"))
+
+PLAN_CHOICES = [(p, p) for p in PlanName]
+PLAN_ACTION_CHOICES = [(a, a) for a in PlanAction]
+CURRENCY_CHOICES = [(c, c) for c in Currency]
+PROVIDER_CHOICES = [(p, p) for p in PaymentProvider]
+PAYMENT_STATUS_CHOICES = [(s, s) for s in PaymentStatus]
+SUBSCRIPTION_STATUS_CHOICES = [(s, s) for s in SubscriptionStatus]

--- a/myus/api/utils/constants/media.py
+++ b/myus/api/utils/constants/media.py
@@ -1,15 +1,4 @@
-from api.db.models.comment import Comment
 from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat
-from api.db.models.message import Message
-from api.db.models.users import Follow
-from api.utils.enum.i18n import Currency
-from api.utils.enum.payment import PaymentProvider, SubscriptionStatus, PaymentStatus
-
-
-CURRENCY_CHOICES = [(c, c) for c in Currency]
-PROVIDER_CHOICES = [(p, p) for p in PaymentProvider]
-SUBSCRIPTION_STATUS_CHOICES = [(s, s) for s in SubscriptionStatus]
-PAYMENT_STATUS_CHOICES = [(s, s) for s in PaymentStatus]
 
 
 type MediaModel = Video | Music | Blog | Comic | Picture | Chat
@@ -84,29 +73,4 @@ model_comment_dict = {
     "blog/detail"   : Blog,
     "comic/detail"  : Comic,
     "picture/detail": Picture,
-}
-
-notification_type_no = {
-    "is_video"  : 1,
-    "is_music"  : 2,
-    "is_blog"   : 3,
-    "is_comic"  : 4,
-    "is_picture": 5,
-    "is_chat"   : 6,
-    "is_follow" : 7,
-    "is_like"   : 8,
-    "is_reply"  : 9,
-    "is_views"  : 10,
-}
-
-notification_type_model = {
-    "video"  : Video,
-    "music"  : Music,
-    "blog"   : Blog,
-    "comic"  : Comic,
-    "picture": Picture,
-    "chat"   : Chat,
-    "follow" : Follow,
-    "comment": Comment,
-    "message": Message,
 }

--- a/myus/api/utils/constants/notification.py
+++ b/myus/api/utils/constants/notification.py
@@ -1,0 +1,30 @@
+from api.db.models.comment import Comment
+from api.db.models.media import Video, Music, Blog, Comic, Picture, Chat
+from api.db.models.message import Message
+from api.db.models.users import Follow
+
+
+notification_type_no = {
+    "is_video"  : 1,
+    "is_music"  : 2,
+    "is_blog"   : 3,
+    "is_comic"  : 4,
+    "is_picture": 5,
+    "is_chat"   : 6,
+    "is_follow" : 7,
+    "is_like"   : 8,
+    "is_reply"  : 9,
+    "is_views"  : 10,
+}
+
+notification_type_model = {
+    "video"  : Video,
+    "music"  : Music,
+    "blog"   : Blog,
+    "comic"  : Comic,
+    "picture": Picture,
+    "chat"   : Chat,
+    "follow" : Follow,
+    "comment": Comment,
+    "message": Message,
+}

--- a/myus/app/modules/context_data.py
+++ b/myus/app/modules/context_data.py
@@ -4,7 +4,7 @@ from django.db.models import F, Count, Exists, OuterRef
 from api.db.models import MyPage, SearchTag, UserNotification, Follow, Comment
 from api.utils.plan import PLANS
 from api.db.models import Video, Music, Blog, Comic, Picture, Chat, Advertise
-from api.utils.constant import model_dict, model_media_comment_no_dict
+from api.utils.constants.media import model_dict, model_media_comment_no_dict
 from app.modules.notification import notification_data
 
 

--- a/myus/app/modules/get_form.py
+++ b/myus/app/modules/get_form.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from api.db.models import AccessLog, Notification
-from api.utils.constant import model_dict
+from api.utils.constants.media import model_dict
 from api.utils.enum.notification import NotificationObjectType, NotificationTypeNo
 
 

--- a/myus/app/modules/notification.py
+++ b/myus/app/modules/notification.py
@@ -1,6 +1,6 @@
 from django.db.models import Exists, OuterRef
 from api.db.models import Follow, Notification, UserNotification
-from api.utils.constant import notification_type_no
+from api.utils.constants.notification import notification_type_no
 from api.utils.functions.index import set_attr
 
 

--- a/myus/app/modules/pjax.py
+++ b/myus/app/modules/pjax.py
@@ -4,7 +4,7 @@ from django.db.models import Count, F
 from django.template.loader import render_to_string
 from api.db.models import Advertise, Follow, MyPage, UserNotification
 from api.utils.plan import PLANS
-from api.utils.constant import model_create_pjax, model_dict, model_pjax
+from api.utils.constants.media import model_create_pjax, model_dict, model_pjax
 from app.modules.search import SearchData
 
 

--- a/myus/app/modules/search.py
+++ b/myus/app/modules/search.py
@@ -5,7 +5,7 @@ from operator import and_
 from django.contrib.auth import get_user_model
 from django.db.models import Count, F, Q
 from api.db.models import Music, Video
-from api.utils.constant import model_list
+from api.utils.constants.media import model_list
 from api.utils.filter_data import DeferData
 
 

--- a/myus/app/views.py
+++ b/myus/app/views.py
@@ -22,7 +22,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.html import urlize as urlize_impl
 from django.views.generic import CreateView, DetailView, ListView, TemplateView, UpdateView, View
 from api.db.models import Advertise, Blog, Chat, Comic, ComicPage, Comment, Follow, Music, MyPage, Notification, Picture, Profile, SearchTag, UserNotification, Video
-from api.utils.constant import model_comment_dict, model_like_dict
+from api.utils.constants.media import model_comment_dict, model_like_dict
 from api.utils.enum.notification import NotificationObjectType, NotificationType, NotificationTypeNo
 from api.utils.functions.convert.convert_hls import convert_exe
 from api.utils.functions.user import email_user


### PR DESCRIPTION
## Summary
- `api/utils/constant.py` を `api/utils/constants/` パッケージに分割（`media.py` / `notification.py` / `choice.py`）
- モデル内に散らばっていた `choices` 定義を `constants/choice.py` に集約
- すべての import path を `api.utils.constant` → `api.utils.constants.xxx` に更新

## 変更内容

### `myus/api/utils/constants/` 新設
- `__init__.py`: 新規追加
- `media.py`: 旧 `constant.py` のうちメディアモデル系の辞書（`model_dict`, `model_list`, `model_pjax`, `model_create_pjax`, `model_comment_dict`, `model_like_dict`, `model_media_comment_dict`, `model_media_comment_no_dict` など）を移管
- `notification.py`: `notification_type_no` / `notification_type_model` を分離して配置
- `choice.py`: 各 Django モデルで個別に定義していた `choices` を集約
  - `GENDER_CHOICES` / `ADVERTISE_TYPE_CHOICES`
  - `PLAN_CHOICES` / `PLAN_ACTION_CHOICES`
  - `CURRENCY_CHOICES` / `PROVIDER_CHOICES` / `PAYMENT_STATUS_CHOICES` / `SUBSCRIPTION_STATUS_CHOICES`

### モデル側のリファクタリング
- `db/models/common.py`: `Advertise.choice` を削除し `ADVERTISE_TYPE_CHOICES` を参照
- `db/models/user.py`: `Profile.gender_type` / `UserPlan.plans` / `UserPlanHistory.plans` / `UserPlanHistory.actions` をモデル内定義から `*_CHOICES` 参照へ変更
- `db/models/payment.py`: import 元を `constants.choice` に変更
- `db/models/notification.py`: 未使用の `GenericForeignKey` / `ContentType` import を削除

### import path 更新
- `api/admin.py` / `app/modules/context_data.py` / `get_form.py` / `notification.py` / `pjax.py` / `search.py` / `app/views.py` の import 元を `api.utils.constant` → `api.utils.constants.{media,notification}` に修正