### PR TITLE
【back】Webhook 検証ドメイン層を追加（enum / data / Interface）

### DIFF
--- a/myus/api/src/adapter/external/payment/stripe/provider.py
+++ b/myus/api/src/adapter/external/payment/stripe/provider.py
@@ -2,7 +2,7 @@ import stripe
 from django.conf import settings
 from api.modules.logger import log
 from api.src.adapter.external.payment.stripe._convert import convert_stripe_params
-from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData
+from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerifyResult
 from api.src.domain.interface.payment.interface import PaymentInterface
 from api.utils.enum.payment import CheckoutError, PaymentProvider
 
@@ -32,3 +32,6 @@ class StripeProvider(PaymentInterface):
             external_id=session.id,
             redirect_url=session.url,
         ))
+
+    def verify_webhook(self, payload: bytes, signature: str) -> WebhookVerifyResult:
+        raise NotImplementedError

--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from api.utils.enum.i18n import Currency, Locale
-from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentStatus, PaymentType, SubscriptionStatus
+from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentStatus, PaymentType, SubscriptionStatus, WebhookEventType, WebhookVerifyError
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,3 +85,26 @@ class PaymentTransactionData:
     price: Money
     status: PaymentStatus
     paid_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookEventData:
+    provider: PaymentProvider
+    event_id: str
+    event_type: WebhookEventType
+    related_external_id: str
+    occurred_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookVerified:
+    event: WebhookEventData
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookVerifyFailed:
+    error: WebhookVerifyError
+    message: str
+
+
+type WebhookVerifyResult = WebhookVerified | WebhookVerifyFailed

--- a/myus/api/src/domain/interface/payment/interface.py
+++ b/myus/api/src/domain/interface/payment/interface.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.payment.data import CheckoutData, CheckoutResult
+from api.src.domain.interface.payment.data import CheckoutData, CheckoutResult, WebhookVerifyResult
 
 
 class PaymentInterface(ABC):
     @abstractmethod
     def create_checkout(self, input: CheckoutData) -> CheckoutResult:
+        ...
+
+    @abstractmethod
+    def verify_webhook(self, payload: bytes, signature: str) -> WebhookVerifyResult:
         ...

--- a/myus/api/utils/enum/payment.py
+++ b/myus/api/utils/enum/payment.py
@@ -32,3 +32,18 @@ class PaymentStatus(str, Enum):
     FAILED = "Failed"
     REFUNDED = "Refunded"
     CANCELED = "Canceled"
+
+
+class WebhookEventType(str, Enum):
+    PAYMENT_SUCCEEDED = "PaymentSucceeded"
+    PAYMENT_FAILED = "PaymentFailed"
+    SUBSCRIPTION_CREATED = "SubscriptionCreated"
+    SUBSCRIPTION_UPDATED = "SubscriptionUpdated"
+    SUBSCRIPTION_CANCELED = "SubscriptionCanceled"
+    REFUND_ISSUED = "RefundIssued"
+
+
+class WebhookVerifyError(str, Enum):
+    INVALID_SIGNATURE = "InvalidSignature"
+    MALFORMED_PAYLOAD = "MalformedPayload"
+    UNSUPPORTED_EVENT = "UnsupportedEvent"


### PR DESCRIPTION
## Summary
- Webhook 検証用の enum (`WebhookEventType` / `WebhookVerifyError`) を追加
- ドメイン層に `WebhookEventData` / `WebhookVerified` / `WebhookVerifyFailed` を新設し、`WebhookVerifyResult` sum type を定義
- `PaymentInterface.verify_webhook(payload, signature) -> WebhookVerifyResult` を抽象メソッドとして追加（ロードマップ PR #5 の第1段）

## 変更内容

### `myus/api/utils/enum/payment.py`
- `WebhookEventType`: `PAYMENT_SUCCEEDED` / `PAYMENT_FAILED` / `SUBSCRIPTION_CREATED` / `SUBSCRIPTION_UPDATED` / `SUBSCRIPTION_CANCELED` / `REFUND_ISSUED`
- `WebhookVerifyError`: `INVALID_SIGNATURE` / `MALFORMED_PAYLOAD` / `UNSUPPORTED_EVENT`

### `myus/api/src/domain/interface/payment/data.py`
- `WebhookEventData`: `provider` / `event_id` / `event_type` / `related_external_id` / `occurred_at`
- `WebhookVerified`: 検証成功時に `WebhookEventData` を包む
- `WebhookVerifyFailed`: `WebhookVerifyError` + メッセージ
- `type WebhookVerifyResult = WebhookVerified | WebhookVerifyFailed`
- いずれも `@dataclass(frozen=True, slots=True)`、フィールド初期値なし（domain interface ルール準拠）

### `myus/api/src/domain/interface/payment/interface.py`
- `PaymentInterface` に `verify_webhook(payload: bytes, signature: str) -> WebhookVerifyResult` を `@abstractmethod` で追加

### `myus/api/src/adapter/external/payment/stripe/provider.py`
- `verify_webhook` を `raise NotImplementedError` のスタブで実装（`@abstractmethod` 追加に伴う `StripeProvider` のインスタンス化維持目的）
- 実体は後続 PR で実装する（Stripe `Webhook.construct_event` 経由）

## 範囲外（後続 PR で対応）
- `StripeProvider.verify_webhook` の実装
- `WebhookEvent` テーブル（冪等性キー）の追加
- webhook 受信 adapter エンドポイント
- usecase で Subscription / PaymentTransaction の status 更新

## 確認
- `uv run mypy` 本変更ファイルに新規エラー 0件（既存30件は無関係の pre-existing）
- 既存テストへの影響なし（インターフェースに `verify_webhook` を追加したが `StripeProvider` のスタブで instantiability を維持）