### PR TITLE
【back】StripeProvider.verify_webhook を実装 + event_type マッピング (_type.py)

### DIFF
--- a/myus/api/src/adapter/external/payment/stripe/_convert.py
+++ b/myus/api/src/adapter/external/payment/stripe/_convert.py
@@ -1,3 +1,5 @@
+import stripe
+from datetime import datetime, timezone
 from typing import assert_never
 from django.conf import settings
 from stripe.params.checkout import (
@@ -10,10 +12,26 @@ from stripe.params.checkout import (
     SessionCreateParamsSubscriptionData,
     SessionCreateParamsSubscriptionDataTransferData,
 )
-from api.src.domain.interface.payment.data import CheckoutData, CheckoutFailed, Money
+from api.src.adapter.external.payment.stripe._type import stripe_event_type
+from api.src.domain.interface.payment.data import CheckoutData, CheckoutFailed, Money, WebhookEventData, WebhookVerifyFailed
 from api.utils.enum.i18n import Locale
-from api.utils.enum.payment import CheckoutError, PaymentType
+from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
 from api.utils.enum.user import PlanName
+
+
+def convert_stripe_event(event: stripe.Event) -> WebhookEventData | WebhookVerifyFailed:
+    event_type = stripe_event_type(event.type)
+    if event_type is None:
+        return WebhookVerifyFailed(error=WebhookVerifyError.UNSUPPORTED_EVENT, message=f"unsupported event_type={event.type}")
+
+    related_external_id: str = getattr(event.data.object, "id", "")
+    return WebhookEventData(
+        provider=PaymentProvider.STRIPE,
+        event_id=event.id,
+        event_type=event_type,
+        related_external_id=related_external_id,
+        occurred_at=datetime.fromtimestamp(event.created, tz=timezone.utc),
+    )
 
 
 def stripe_price_id(product_code: str) -> str:

--- a/myus/api/src/adapter/external/payment/stripe/_type.py
+++ b/myus/api/src/adapter/external/payment/stripe/_type.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from api.utils.enum.payment import WebhookEventType
+
+
+@dataclass(frozen=True, slots=True)
+class StripeEventTypeMap:
+    payment_intent_succeeded: WebhookEventType
+    payment_intent_payment_failed: WebhookEventType
+    customer_subscription_created: WebhookEventType
+    customer_subscription_updated: WebhookEventType
+    customer_subscription_deleted: WebhookEventType
+    charge_refunded: WebhookEventType
+
+
+STRIPE_EVENT_TYPE_MAP = StripeEventTypeMap(
+    payment_intent_succeeded=WebhookEventType.PAYMENT_SUCCEEDED,
+    payment_intent_payment_failed=WebhookEventType.PAYMENT_FAILED,
+    customer_subscription_created=WebhookEventType.SUBSCRIPTION_CREATED,
+    customer_subscription_updated=WebhookEventType.SUBSCRIPTION_UPDATED,
+    customer_subscription_deleted=WebhookEventType.SUBSCRIPTION_CANCELED,
+    charge_refunded=WebhookEventType.REFUND_ISSUED,
+)
+
+
+def stripe_event_type(event_type: str) -> WebhookEventType | None:
+    key = event_type.replace(".", "_")
+    return getattr(STRIPE_EVENT_TYPE_MAP, key, None)

--- a/myus/api/src/adapter/external/payment/stripe/provider.py
+++ b/myus/api/src/adapter/external/payment/stripe/provider.py
@@ -1,10 +1,10 @@
 import stripe
 from django.conf import settings
 from api.modules.logger import log
-from api.src.adapter.external.payment.stripe._convert import convert_stripe_params
-from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerifyResult
+from api.src.adapter.external.payment.stripe._convert import convert_stripe_event, convert_stripe_params
+from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerified, WebhookVerifyFailed, WebhookVerifyResult
 from api.src.domain.interface.payment.interface import PaymentInterface
-from api.utils.enum.payment import CheckoutError, PaymentProvider
+from api.utils.enum.payment import CheckoutError, PaymentProvider, WebhookVerifyError
 
 
 class StripeProvider(PaymentInterface):
@@ -34,4 +34,16 @@ class StripeProvider(PaymentInterface):
         ))
 
     def verify_webhook(self, payload: bytes, signature: str) -> WebhookVerifyResult:
-        raise NotImplementedError
+        try:
+            event = stripe.Webhook.construct_event(payload, signature, settings.STRIPE_WEBHOOK_SECRET)  # type: ignore[no-untyped-call]
+        except stripe.SignatureVerificationError as e:
+            log.warning("Stripe webhook signature invalid", exc=e)
+            return WebhookVerifyFailed(error=WebhookVerifyError.INVALID_SIGNATURE, message=str(e))
+        except ValueError as e:
+            log.warning("Stripe webhook payload malformed", exc=e)
+            return WebhookVerifyFailed(error=WebhookVerifyError.MALFORMED_PAYLOAD, message=str(e))
+
+        event_data = convert_stripe_event(event)
+        if isinstance(event_data, WebhookVerifyFailed):
+            return event_data
+        return WebhookVerified(event=event_data)

--- a/myus/config/env.py
+++ b/myus/config/env.py
@@ -45,6 +45,7 @@ class Environment:
     # Stripe
     stripe_secret_key: str
     stripe_public_key: str
+    stripe_webhook_secret: str
     stripe_price_id_basic: str
     stripe_price_id_standard: str
     stripe_price_id_premium: str

--- a/myus/config/settings/base.py
+++ b/myus/config/settings/base.py
@@ -184,6 +184,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240  # フォームフィールドの最大数
 # Stripe API keys
 STRIPE_SECRET_KEY = env.stripe_secret_key
 STRIPE_PUBLIC_KEY = env.stripe_public_key
+STRIPE_WEBHOOK_SECRET = env.stripe_webhook_secret
 STRIPE_PRICE_ID_BASIC = env.stripe_price_id_basic
 STRIPE_PRICE_ID_STANDARD = env.stripe_price_id_standard
 STRIPE_PRICE_ID_PREMIUM = env.stripe_price_id_premium


### PR DESCRIPTION
## Summary
- 前 PR (#840) で `NotImplementedError` だった `StripeProvider.verify_webhook` を Stripe `Webhook.construct_event` 経由で実装
- Stripe event_type → 内部 `WebhookEventType` のマッピングを `_type.py` に分離（dataclass + lookup 関数）
- `STRIPE_WEBHOOK_SECRET` を env / settings に追加

## 変更内容

### env / settings
- `myus/config/env.py`: `stripe_webhook_secret: str` を `Environment` に追加
- `myus/config/settings/base.py`: `STRIPE_WEBHOOK_SECRET = env.stripe_webhook_secret` を公開

### `stripe/_type.py`（新規）
Stripe event_type マッピングの**データ定義**を独立ファイルに集約：
- `StripeEventTypeMap` dataclass（`@dataclass(frozen=True, slots=True)`）
- `STRIPE_EVENT_TYPE_MAP` 定数（インスタンス、6種類の event_type をカバー）
  - `payment_intent.succeeded` → `PAYMENT_SUCCEEDED`
  - `payment_intent.payment_failed` → `PAYMENT_FAILED`
  - `customer.subscription.created` → `SUBSCRIPTION_CREATED`
  - `customer.subscription.updated` → `SUBSCRIPTION_UPDATED`
  - `customer.subscription.deleted` → `SUBSCRIPTION_CANCELED`
  - `charge.refunded` → `REFUND_ISSUED`
- `stripe_event_type(event_type)`: dot 表記 → underscore 正規化 → `getattr` で lookup

### `stripe/_convert.py`
- `convert_stripe_event(event: stripe.Event) -> WebhookEventData | WebhookVerifyFailed` を追加
- `event.data.object.id` を `related_external_id` として抽出、`event.created` を UTC datetime に変換
- 未知 event_type は `WebhookVerifyFailed(UNSUPPORTED_EVENT)` を返す

### `stripe/provider.py`
- `verify_webhook(payload, signature)` を実装：
  - `stripe.Webhook.construct_event(payload, signature, STRIPE_WEBHOOK_SECRET)` で署名検証
  - `stripe.SignatureVerificationError` → `WebhookVerifyFailed(INVALID_SIGNATURE)`
  - `ValueError`（payload 不正）→ `WebhookVerifyFailed(MALFORMED_PAYLOAD)`
  - 成功時は `convert_stripe_event` を通して `WebhookVerified(event=...)` を返す
- `construct_event` が Stripe SDK 側で型未付与のため `# type: ignore[no-untyped-call]` を1箇所付与

## 範囲外（後続 PR）
- `WebhookEvent` テーブル（冪等性キー）の追加
- webhook 受信 adapter エンドポイント
- usecase で Subscription / PaymentTransaction の status 更新

## 確認
- `uv run mypy` 本変更ファイル群に新規エラー 0件（既存30件は無関係の pre-existing）
- backend.md ルール準拠（dataclass 使用、import 順は既存スタイル踏襲、ヘルパは `_<purpose>.py` に配置）
- ファイル責務分離: `_type.py`=データ定義 / `_convert.py`=変換 / `provider.py`=外部 API 呼び出し