### PR TITLE
【back】WebhookEvent モデル新設 + Repository Interface 追加

### DIFF
--- a/myus/api/db/models/payment.py
+++ b/myus/api/db/models/payment.py
@@ -1,7 +1,7 @@
 import datetime
 from django.db import models
 from api.db.models.user import User
-from api.utils.constants.choice import CURRENCY_CHOICES, PROVIDER_CHOICES, PAYMENT_STATUS_CHOICES, SUBSCRIPTION_STATUS_CHOICES
+from api.utils.constants.choice import CURRENCY_CHOICES, PROVIDER_CHOICES, PAYMENT_STATUS_CHOICES, SUBSCRIPTION_STATUS_CHOICES, WEBHOOK_EVENT_TYPE_CHOICES
 from api.utils.enum.i18n import Currency
 from api.utils.enum.payment import SubscriptionStatus, PaymentStatus
 
@@ -56,4 +56,28 @@ class PaymentTransaction(models.Model):
         indexes = [
             models.Index(fields=["customer", "-paid_at"], name="payment_tx_customer_paid_idx"),
             models.Index(fields=["provider", "external_id"], name="payment_tx_external_idx"),
+        ]
+
+
+class WebhookEvent(models.Model):
+    """WebhookEvent"""
+    id          = models.BigAutoField(primary_key=True)
+    provider    = models.CharField(max_length=20, choices=PROVIDER_CHOICES)
+    event_id    = models.CharField(max_length=255)
+    event_type  = models.CharField(max_length=30, choices=WEBHOOK_EVENT_TYPE_CHOICES)
+    external_id = models.CharField(max_length=255)
+    occurred_at = models.DateTimeField(default=DATETIME_MIN)
+    created     = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.provider}:{self.event_id}:{self.event_type}"
+
+    class Meta:
+        db_table = "webhook_event"
+        verbose_name_plural = "001 WebhookEvent"
+        constraints = [
+            models.UniqueConstraint(fields=["provider", "event_id"], name="webhook_event_provider_event_id_uniq"),
+        ]
+        indexes = [
+            models.Index(fields=["external_id"], name="webhook_event_external_idx"),
         ]

--- a/myus/api/src/adapter/external/payment/stripe/_convert.py
+++ b/myus/api/src/adapter/external/payment/stripe/_convert.py
@@ -24,12 +24,13 @@ def convert_stripe_event(event: stripe.Event) -> WebhookEventData | WebhookVerif
     if event_type is None:
         return WebhookVerifyFailed(error=WebhookVerifyError.UNSUPPORTED_EVENT, message=f"unsupported event_type={event.type}")
 
-    related_external_id: str = getattr(event.data.object, "id", "")
+    external_id: str = getattr(event.data.object, "id", "")
     return WebhookEventData(
+        id=0,
         provider=PaymentProvider.STRIPE,
         event_id=event.id,
         event_type=event_type,
-        related_external_id=related_external_id,
+        external_id=external_id,
         occurred_at=datetime.fromtimestamp(event.created, tz=timezone.utc),
     )
 

--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -89,10 +89,11 @@ class PaymentTransactionData:
 
 @dataclass(frozen=True, slots=True)
 class WebhookEventData:
+    id: int
     provider: PaymentProvider
     event_id: str
     event_type: WebhookEventType
-    related_external_id: str
+    external_id: str
     occurred_at: datetime
 
 

--- a/myus/api/src/domain/interface/payment/webhook_event.py
+++ b/myus/api/src/domain/interface/payment/webhook_event.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum, auto
+from api.src.domain.interface.payment.data import WebhookEventData
+
+
+class SortType(Enum):
+    OCCURRED_AT = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class FilterOption:
+    provider: str = ""
+    event_id: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SortOption:
+    is_asc: bool = True
+    sort_type: SortType = SortType.OCCURRED_AT
+
+
+class WebhookEventInterface(ABC):
+    @abstractmethod
+    def get_ids(self, filter: FilterOption, sort: SortOption, limit: int | None = 20) -> list[int]:
+        ...
+
+    @abstractmethod
+    def bulk_get(self, ids: list[int]) -> list[WebhookEventData]:
+        ...

--- a/myus/api/utils/constants/choice.py
+++ b/myus/api/utils/constants/choice.py
@@ -1,5 +1,5 @@
 from api.utils.enum.i18n import Currency
-from api.utils.enum.payment import PaymentProvider, SubscriptionStatus, PaymentStatus
+from api.utils.enum.payment import PaymentProvider, SubscriptionStatus, PaymentStatus, WebhookEventType
 from api.utils.enum.user import GenderType, PlanName, PlanAction
 
 
@@ -12,3 +12,4 @@ CURRENCY_CHOICES = [(c, c) for c in Currency]
 PROVIDER_CHOICES = [(p, p) for p in PaymentProvider]
 PAYMENT_STATUS_CHOICES = [(s, s) for s in PaymentStatus]
 SUBSCRIPTION_STATUS_CHOICES = [(s, s) for s in SubscriptionStatus]
+WEBHOOK_EVENT_TYPE_CHOICES = [(t, t) for t in WebhookEventType]


### PR DESCRIPTION
## Summary
- Stripe webhook の冪等性キーを保持する `WebhookEvent` テーブルを新設（`provider` + `event_id` で UNIQUE）
- `WebhookEventInterface` (Repository) を `domain/interface/payment/webhook_event.py` に追加（`get_ids` / `bulk_get` のみ）
- `WebhookEventData` を `Record` 系廃止して単一 dataclass に統合し、`related_external_id` を `external_id` にリネーム

## 変更内容

### `myus/api/utils/constants/choice.py`
- `WEBHOOK_EVENT_TYPE_CHOICES = [(t, t) for t in WebhookEventType]` を追加
- import に `WebhookEventType` を追加

### `myus/api/db/models/payment.py`
- `WebhookEvent` モデルを新設
  - フィールド: `provider` / `event_id` / `event_type` / `external_id` / `occurred_at` / `created`
  - **冪等性 UNIQUE**: `UniqueConstraint(fields=["provider", "event_id"], name="webhook_event_provider_event_id_uniq")`
  - **クエリ最適化 INDEX**: `Index(fields=["external_id"], name="webhook_event_external_idx")`
  - `db_table = "webhook_event"` / `verbose_name_plural = "001 WebhookEvent"`

### `myus/api/src/domain/interface/payment/data.py`
- `WebhookEventData` の先頭に `id: int` を追加（`SubscriptionData` 等と同じ pattern、新規時は `id=0` セントネル）
- フィールド `related_external_id` を `external_id` にリネーム
- 一時的に検討した `WebhookEventRecord` は廃止し、`Data` 1 型に統合

### `myus/api/src/domain/interface/payment/webhook_event.py`（新規）
- `WebhookEventInterface` (ABC) を新設
  - `get_ids(filter, sort, limit) -> list[int]`
  - `bulk_get(ids) -> list[WebhookEventData]`
- `FilterOption(provider="", event_id="")` / `SortOption(is_asc, sort_type)` / `SortType.OCCURRED_AT`
- `bulk_save` は usecase で必要になった時点で追加（backend.md 「使う分だけ既存の形で書く」準拠）

### `myus/api/src/adapter/external/payment/stripe/_convert.py`
- `convert_stripe_event` で `WebhookEventData(id=0, ...)` を構築するよう更新
- フィールド名リネームに合わせて `external_id=...` を渡す

## 範囲外（後続 PR）
- Repository 実装 (`domain/entity/payment/webhook_event/`)
- webhook 受信 adapter エンドポイント
- usecase（Subscription / PaymentTransaction status 更新）

## 確認
- `uv run python manage.py sqlmigrate db 0015_webhook_event` で SQL 確認済み（UNIQUE / INDEX とも正しく生成）
- `uv run python manage.py check` でエラー 0件
- `uv run mypy` 本変更ファイルに新規エラー 0件（既存30件は無関係の pre-existing）
- migration `0015_webhook_event.py` は `myus/api/db/migrations` が **gitignore 対象** なので PR には含まれない（デプロイ時に再生成）