### PR TITLE
【back】Stripe webhook 受信エンドポイント新設 (POST /api/payment/webhook)

### DIFF
--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -2,15 +2,16 @@ from django.conf import settings
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
-from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, Money, RedirectUrls
+from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, Money, RedirectUrls, WebhookVerified, WebhookVerifyFailed
 from api.src.domain.interface.payment.interface import PaymentInterface
+from api.src.domain.interface.payment.webhook_event import FilterOption, SortOption, WebhookEventInterface
 from api.src.injectors.container import injector
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.payment import PaymentCheckoutIn, PaymentCheckoutOut
+from api.src.types.schema.payment import PaymentCheckoutIn, PaymentCheckoutOut, PaymentWebhookOut
 from api.src.usecase.auth import auth_check
 from api.src.usecase.user import get_user_data
 from api.utils.enum.i18n import Currency, Locale
-from api.utils.enum.payment import PaymentType
+from api.utils.enum.payment import PaymentType, WebhookVerifyError
 from api.utils.plan import get_plan
 
 
@@ -59,3 +60,35 @@ class PaymentAPI:
             case CheckoutFailed(error=error, message=message):
                 log.error("Payment checkout failed", error=error.value, message=message)
                 return 500, ErrorOut(message="決済セッションの作成に失敗しました!")
+
+    @staticmethod
+    @router.post("/webhook", response={200: PaymentWebhookOut, 400: ErrorOut})
+    def webhook(request: HttpRequest):
+        payload = request.body
+        signature = request.META.get("HTTP_STRIPE_SIGNATURE", "")
+
+        payment = injector.get(PaymentInterface)
+        verify_result = payment.verify_webhook(payload, signature)
+
+        match verify_result:
+            case WebhookVerifyFailed(error=WebhookVerifyError.UNSUPPORTED_EVENT, message=message):
+                log.info("PaymentAPI webhook unsupported event", message=message)
+                return 200, PaymentWebhookOut(message="Unsupported event type")
+            case WebhookVerifyFailed(error=error, message=message):
+                log.warning("PaymentAPI webhook verify failed", error=error.value, message=message)
+                return 400, ErrorOut(message="Invalid webhook")
+            case WebhookVerified(event=event):
+                log.info("PaymentAPI webhook verified", event_id=event.event_id, event_type=event.event_type.value)
+
+                webhook_event_repo = injector.get(WebhookEventInterface)
+                existing_ids = webhook_event_repo.get_ids(
+                    FilterOption(provider=event.provider.value, event_id=event.event_id),
+                    SortOption(),
+                    limit=1,
+                )
+                if len(existing_ids) > 0:
+                    log.info("PaymentAPI webhook already processed", event_id=event.event_id)
+                    return 200, PaymentWebhookOut(message="Already processed")
+
+                webhook_event_repo.bulk_save([event])
+                return 200, PaymentWebhookOut(message="OK")

--- a/myus/api/src/types/schema/payment.py
+++ b/myus/api/src/types/schema/payment.py
@@ -7,3 +7,7 @@ class PaymentCheckoutIn(BaseModel):
 
 class PaymentCheckoutOut(BaseModel):
     url: str
+
+
+class PaymentWebhookOut(BaseModel):
+    message: str


### PR DESCRIPTION
## Summary
- `POST /api/payment/webhook` エンドポイントを `PaymentAPI` に追加
- 署名検証 + 冪等性チェック + `WebhookEvent` 記録までを実装
- ロードマップ PR #5 のうち adapter 部分を完結

## 変更内容

### `myus/api/src/types/schema/payment.py`
- `PaymentWebhookOut(message: str)` を追加（webhook 応答用 schema）

### `myus/api/src/adapter/payment.py`
新規 import:
- `WebhookVerified` / `WebhookVerifyFailed` from `payment.data`
- `FilterOption` / `SortOption` / `WebhookEventInterface` from `payment.webhook_event`
- `PaymentWebhookOut` from `schema.payment`
- `WebhookVerifyError` from `enum.payment`

`PaymentAPI.webhook` メソッド（`POST /webhook`）：
1. `request.body` (bytes) + `Stripe-Signature` header を取得
2. `payment.verify_webhook(payload, signature)` で署名検証
3. `match-case` 分岐：
   - `WebhookVerifyFailed(UNSUPPORTED_EVENT)` → **200** "Unsupported event type"（Stripe retry 防止）
   - 他の `WebhookVerifyFailed` → **400** "Invalid webhook"（INVALID_SIGNATURE / MALFORMED_PAYLOAD）
   - `WebhookVerified(event)`:
     - `WebhookEventInterface.get_ids` で冪等性チェック（`provider` + `event_id`）
     - 既存 → **200** "Already processed"
     - 新規 → `bulk_save([event])` → **200** "OK"

### HTTP ステータス設計
| ケース | ステータス | Stripe Retry 防止 | 備考 |
|--------|----------|------------------|------|
| 検証成功・新規保存 | 200 | ✓ | 通常パス |
| 検証成功・既処理 | 200 | ✓ | 冪等性保護 |
| 未対応 event_type | 200 | ✓ | 将来対応想定 |
| 署名不正 | 400 | ✓ | 永続エラー |
| payload 不正 | 400 | ✓ | 永続エラー |

## 範囲外（後続 PR）
- usecase: Subscription / PaymentTransaction の status 更新（現状は受信記録のみ）
- WebhookEvent → ドメインモデルへの反映バッチ / リプレイ機能

## 確認
- `uv run mypy` 本変更ファイルに新規エラー 0件
- Django setup 後に `PaymentAPI` のルートを確認: `POST /checkout` と `POST /webhook` の 2 エンドポイントが正しく登録される
- backend.md ルール準拠（match-case 使用、ログは f-string ではなく kwargs、`==`/`is None` 判定の使い分け）

## 動作確認手順
```bash
# Stripe CLI で webhook を forward
stripe listen --forward-to localhost:8000/api/payment/webhook

# 別ターミナルで event を発火
stripe trigger payment_intent.succeeded
```
期待動作:
- 1 回目: 200 "OK"（DB に保存）
- 2 回目（同じ event_id）: 200 "Already processed"
- `stripe trigger account.updated` 等の未対応 event: 200 "Unsupported event type"