### PR TITLE
【back】Subscription / PaymentTransaction の index 名を短縮

### DIFF
--- a/myus/api/db/models/payment.py
+++ b/myus/api/db/models/payment.py
@@ -30,8 +30,8 @@ class Subscription(models.Model):
         db_table = "subscription"
         verbose_name_plural = "001 Subscription"
         indexes = [
-            models.Index(fields=["customer", "status"], name="subscription_customer_status_idx"),
-            models.Index(fields=["provider", "external_id"], name="subscription_external_idx"),
+            models.Index(fields=["customer", "status"], name="customer_status_idx"),
+            models.Index(fields=["provider", "external_id"], name="provider_external_idx"),
         ]
 
 
@@ -54,8 +54,8 @@ class PaymentTransaction(models.Model):
         db_table = "payment_transaction"
         verbose_name_plural = "001 PaymentTransaction"
         indexes = [
-            models.Index(fields=["customer", "-paid_at"], name="payment_tx_customer_paid_idx"),
-            models.Index(fields=["provider", "external_id"], name="payment_tx_external_idx"),
+            models.Index(fields=["customer", "-paid_at"], name="customer_paid_idx"),
+            models.Index(fields=["provider", "external_id"], name="pt_external_idx"),
         ]
 
 


### PR DESCRIPTION
## Summary
- `Subscription` / `PaymentTransaction` の index 名を短縮し、Django E034（index 名 30 文字制限）対応 + 命名の冗長性を解消

## 変更内容

### `myus/api/db/models/payment.py`

**`Subscription` の indexes**
| 旧名 | 新名 | 文字数 |
|------|------|--------|
| `subscription_customer_status_idx` | `customer_status_idx` | 32 → 19（E034 違反を解消） |
| `subscription_external_idx` | `provider_external_idx` | 25 → 21 |

**`PaymentTransaction` の indexes**
| 旧名 | 新名 | 文字数 |
|------|------|--------|
| `payment_tx_customer_paid_idx` | `customer_paid_idx` | 28 → 17 |
| `payment_tx_external_idx` | `pt_external_idx` | 23 → 15 |

## 背景
- Django の `models.E034` で index 名は **最大 30 文字** の制約あり
- 既存の `subscription_customer_status_idx` は 32 文字で `manage.py migrate --check` 時に warning（あるいは error）対象
- 他の index も「テーブル名プレフィックス」を冗長として削除し、`fields` から意味が読み取れるシンプルな命名に統一

## 確認
- `uv run python manage.py check` で E034 エラー消滅
- `uv run python manage.py sqlmigrate db <migration>` で SQL の `CREATE INDEX` 文が新名で生成されること
- migration ファイル自体は gitignore 対象のため PR には含まれない（デプロイ時に再生成）