### PR TITLE
【back】payment/webhook_event を sub-package 化（interface + data 分離）

### DIFF
--- a/myus/api/src/adapter/external/payment/stripe/_convert.py
+++ b/myus/api/src/adapter/external/payment/stripe/_convert.py
@@ -13,7 +13,8 @@ from stripe.params.checkout import (
     SessionCreateParamsSubscriptionDataTransferData,
 )
 from api.src.adapter.external.payment.stripe._type import stripe_event_type
-from api.src.domain.interface.payment.data import CheckoutData, CheckoutFailed, Money, WebhookEventData, WebhookVerifyFailed
+from api.src.domain.interface.payment.data import CheckoutData, CheckoutFailed, Money, WebhookVerifyFailed
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
 from api.utils.enum.i18n import Locale
 from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
 from api.utils.enum.user import PlanName

--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -4,7 +4,7 @@ from ninja import Router
 from api.modules.logger import log
 from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, Money, RedirectUrls, WebhookVerified, WebhookVerifyFailed
 from api.src.domain.interface.payment.interface import PaymentInterface
-from api.src.domain.interface.payment.webhook_event import FilterOption, SortOption, WebhookEventInterface
+from api.src.domain.interface.payment.webhook_event.interface import FilterOption, SortOption, WebhookEventInterface
 from api.src.injectors.container import injector
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.payment import PaymentCheckoutIn, PaymentCheckoutOut, PaymentWebhookOut

--- a/myus/api/src/domain/entity/payment/webhook_event/_convert.py
+++ b/myus/api/src/domain/entity/payment/webhook_event/_convert.py
@@ -1,5 +1,5 @@
 from api.db.models.payment import WebhookEvent
-from api.src.domain.interface.payment.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
 from api.utils.enum.payment import PaymentProvider, WebhookEventType
 
 

--- a/myus/api/src/domain/entity/payment/webhook_event/repository.py
+++ b/myus/api/src/domain/entity/payment/webhook_event/repository.py
@@ -2,8 +2,8 @@ from django.db.models import Q
 from api.db.models.payment import WebhookEvent
 from api.src.domain.entity.index import get_new_ids, sort_ids
 from api.src.domain.entity.payment.webhook_event._convert import convert_data, marshal_data
-from api.src.domain.interface.payment.data import WebhookEventData
-from api.src.domain.interface.payment.webhook_event import FilterOption, SortOption, WebhookEventInterface
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_event.interface import FilterOption, SortOption, WebhookEventInterface
 
 
 WEBHOOK_EVENT_FIELDS = ["provider", "event_id", "event_type", "external_id", "occurred_at"]

--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from datetime import datetime
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
 from api.utils.enum.i18n import Currency, Locale
-from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentStatus, PaymentType, SubscriptionStatus, WebhookEventType, WebhookVerifyError
+from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentStatus, PaymentType, SubscriptionStatus, WebhookVerifyError
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,16 +86,6 @@ class PaymentTransactionData:
     price: Money
     status: PaymentStatus
     paid_at: datetime
-
-
-@dataclass(frozen=True, slots=True)
-class WebhookEventData:
-    id: int
-    provider: PaymentProvider
-    event_id: str
-    event_type: WebhookEventType
-    external_id: str
-    occurred_at: datetime
 
 
 @dataclass(frozen=True, slots=True)

--- a/myus/api/src/domain/interface/payment/webhook_event/data.py
+++ b/myus/api/src/domain/interface/payment/webhook_event/data.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from datetime import datetime
+from api.utils.enum.payment import PaymentProvider, WebhookEventType
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookEventData:
+    id: int
+    provider: PaymentProvider
+    event_id: str
+    event_type: WebhookEventType
+    external_id: str
+    occurred_at: datetime

--- a/myus/api/src/domain/interface/payment/webhook_event/interface.py
+++ b/myus/api/src/domain/interface/payment/webhook_event/interface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, auto
-from api.src.domain.interface.payment.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
 
 
 class SortType(Enum):

--- a/myus/api/src/injectors/index.py
+++ b/myus/api/src/injectors/index.py
@@ -38,7 +38,7 @@ from api.src.domain.interface.ng_word.interface import NgWordInterface
 from api.src.domain.interface.search_tag.interface import SearchTagInterface
 from api.src.domain.interface.notification.interface import NotificationInterface
 from api.src.domain.interface.payment.interface import PaymentInterface
-from api.src.domain.interface.payment.webhook_event import WebhookEventInterface
+from api.src.domain.interface.payment.webhook_event.interface import WebhookEventInterface
 
 
 class UserModule(Module):


### PR DESCRIPTION
## Summary
- `domain/interface/payment/webhook_event.py`（フラット）を `payment/webhook_event/` sub-package に分割し、Repository interface と `WebhookEventData` を別ファイルに整理
- 構造の意図：`payment/{provider, subscription, transaction, webhook_event}/...` のネスト型統一に向けた段階的 refactor の **第 1 段**
- ロジック変更ゼロの純粋な構造変更（mypy / DI 検証済み）

## 背景
`domain/interface/payment/` 配下に Provider Interface（外部 API 抽象）と複数 Repository Interface（DB CRUD）が混在しており、`interface.py` が **payment では Provider、他ドメインでは Repository** を意味する用語の歪みが生じていた。`media/{video,music,...}/{interface, data}` パターンに揃えるため、`webhook_event` を先に sub-package 化。

後続 PR：
- PR B（次）: `payment/interface.py` → `payment/provider/{interface, data}` への分割
- PR C 以降: `payment/{subscription, transaction}/` の新規 Repository 追加

## 変更内容

### 新規ファイル
- `domain/interface/payment/webhook_event/__init__.py`（パッケージ化のための空ファイル）
- `domain/interface/payment/webhook_event/data.py`
  - `WebhookEventData` を `payment/data.py` から移動

### Rename
- `domain/interface/payment/webhook_event.py` → `domain/interface/payment/webhook_event/interface.py`
  - 中身は `WebhookEventInterface` / `FilterOption` / `SortOption` / `SortType.OCCURRED_AT`
  - import 元を `payment.data` → `payment.webhook_event.data` に更新

### 修正
- `domain/interface/payment/data.py`
  - `WebhookEventData` を削除（`webhook_event/data.py` に移動）
  - `WebhookVerified.event: WebhookEventData` のため `payment.webhook_event.data` から import を追加
- `adapter/external/payment/stripe/_convert.py`: `WebhookEventData` の import path 更新
- `adapter/payment.py`: `WebhookEventInterface` / `FilterOption` / `SortOption` の import path 更新
- `domain/entity/payment/webhook_event/_convert.py`: `WebhookEventData` の import path 更新
- `domain/entity/payment/webhook_event/repository.py`: `WebhookEventData` / `WebhookEventInterface` の import path 更新
- `injectors/index.py`: `WebhookEventInterface` の import path 更新

## 確認
- ✅ `uv run mypy` 本変更ファイル群に新規エラー 0件
- ✅ `injector.get(WebhookEventInterface)` → `WebhookEventRepository` を Django setup 後に確認
- ✅ `injector.get(PaymentInterface)` → `StripeProvider`（旧 path のまま、影響なし）

## 範囲外（後続 PR）
- Provider 抽象の sub-package 化（`payment/provider/...`）
- Subscription / Transaction Repository の追加
- webhook usecase の追加