### PR TITLE
【back】payment/provider を sub-package 化（interface + data 分離）

### DIFF
--- a/myus/api/src/adapter/external/payment/stripe/_convert.py
+++ b/myus/api/src/adapter/external/payment/stripe/_convert.py
@@ -13,7 +13,8 @@ from stripe.params.checkout import (
     SessionCreateParamsSubscriptionDataTransferData,
 )
 from api.src.adapter.external.payment.stripe._type import stripe_event_type
-from api.src.domain.interface.payment.data import CheckoutData, CheckoutFailed, Money, WebhookVerifyFailed
+from api.src.domain.interface.payment.data import Money
+from api.src.domain.interface.payment.provider.data import CheckoutData, CheckoutFailed, WebhookVerifyFailed
 from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
 from api.utils.enum.i18n import Locale
 from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError

--- a/myus/api/src/adapter/external/payment/stripe/provider.py
+++ b/myus/api/src/adapter/external/payment/stripe/provider.py
@@ -2,8 +2,8 @@ import stripe
 from django.conf import settings
 from api.modules.logger import log
 from api.src.adapter.external.payment.stripe._convert import convert_stripe_event, convert_stripe_params
-from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerified, WebhookVerifyFailed, WebhookVerifyResult
-from api.src.domain.interface.payment.interface import PaymentInterface
+from api.src.domain.interface.payment.provider.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerified, WebhookVerifyFailed, WebhookVerifyResult
+from api.src.domain.interface.payment.provider.interface import PaymentInterface
 from api.utils.enum.payment import CheckoutError, PaymentProvider, WebhookVerifyError
 
 

--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -2,8 +2,9 @@ from django.conf import settings
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
-from api.src.domain.interface.payment.data import CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, Money, RedirectUrls, WebhookVerified, WebhookVerifyFailed
-from api.src.domain.interface.payment.interface import PaymentInterface
+from api.src.domain.interface.payment.data import Money
+from api.src.domain.interface.payment.provider.data import CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, RedirectUrls, WebhookVerified, WebhookVerifyFailed
+from api.src.domain.interface.payment.provider.interface import PaymentInterface
 from api.src.domain.interface.payment.webhook_event.interface import FilterOption, SortOption, WebhookEventInterface
 from api.src.injectors.container import injector
 from api.src.types.schema.common import ErrorOut

--- a/myus/api/src/domain/interface/payment/data.py
+++ b/myus/api/src/domain/interface/payment/data.py
@@ -1,64 +1,13 @@
 from dataclasses import dataclass
 from datetime import datetime
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
-from api.utils.enum.i18n import Currency, Locale
-from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentStatus, PaymentType, SubscriptionStatus, WebhookVerifyError
+from api.utils.enum.i18n import Currency
+from api.utils.enum.payment import PaymentProvider, PaymentStatus, SubscriptionStatus
 
 
 @dataclass(frozen=True, slots=True)
 class Money:
     amount: int
     currency: Currency
-
-
-@dataclass(frozen=True, slots=True)
-class MarketplaceData:
-    seller_id: str
-    application_fee: Money
-
-
-@dataclass(frozen=True, slots=True)
-class CustomerData:
-    email: str
-
-
-@dataclass(frozen=True, slots=True)
-class RedirectUrls:
-    success_url: str
-    cancel_url: str
-
-
-@dataclass(frozen=True, slots=True)
-class CheckoutData:
-    product_code: str
-    description: str
-    price: Money
-    payment_type: PaymentType
-    customer: CustomerData
-    redirect: RedirectUrls
-    marketplace: MarketplaceData
-    locale: Locale
-
-
-@dataclass(frozen=True, slots=True)
-class CheckoutSessionData:
-    provider: PaymentProvider
-    external_id: str
-    redirect_url: str
-
-
-@dataclass(frozen=True, slots=True)
-class CheckoutCreated:
-    session: CheckoutSessionData
-
-
-@dataclass(frozen=True, slots=True)
-class CheckoutFailed:
-    error: CheckoutError
-    message: str
-
-
-type CheckoutResult = CheckoutCreated | CheckoutFailed
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,17 +35,3 @@ class PaymentTransactionData:
     price: Money
     status: PaymentStatus
     paid_at: datetime
-
-
-@dataclass(frozen=True, slots=True)
-class WebhookVerified:
-    event: WebhookEventData
-
-
-@dataclass(frozen=True, slots=True)
-class WebhookVerifyFailed:
-    error: WebhookVerifyError
-    message: str
-
-
-type WebhookVerifyResult = WebhookVerified | WebhookVerifyFailed

--- a/myus/api/src/domain/interface/payment/provider/data.py
+++ b/myus/api/src/domain/interface/payment/provider/data.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from api.src.domain.interface.payment.data import Money
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.utils.enum.i18n import Locale
+from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
+
+
+@dataclass(frozen=True, slots=True)
+class MarketplaceData:
+    seller_id: str
+    application_fee: Money
+
+
+@dataclass(frozen=True, slots=True)
+class CustomerData:
+    email: str
+
+
+@dataclass(frozen=True, slots=True)
+class RedirectUrls:
+    success_url: str
+    cancel_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutData:
+    product_code: str
+    description: str
+    price: Money
+    payment_type: PaymentType
+    customer: CustomerData
+    redirect: RedirectUrls
+    marketplace: MarketplaceData
+    locale: Locale
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutSessionData:
+    provider: PaymentProvider
+    external_id: str
+    redirect_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutCreated:
+    session: CheckoutSessionData
+
+
+@dataclass(frozen=True, slots=True)
+class CheckoutFailed:
+    error: CheckoutError
+    message: str
+
+
+type CheckoutResult = CheckoutCreated | CheckoutFailed
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookVerified:
+    event: WebhookEventData
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookVerifyFailed:
+    error: WebhookVerifyError
+    message: str
+
+
+type WebhookVerifyResult = WebhookVerified | WebhookVerifyFailed

--- a/myus/api/src/domain/interface/payment/provider/interface.py
+++ b/myus/api/src/domain/interface/payment/provider/interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.payment.data import CheckoutData, CheckoutResult, WebhookVerifyResult
+from api.src.domain.interface.payment.provider.data import CheckoutData, CheckoutResult, WebhookVerifyResult
 
 
 class PaymentInterface(ABC):

--- a/myus/api/src/injectors/index.py
+++ b/myus/api/src/injectors/index.py
@@ -37,7 +37,7 @@ from api.src.domain.interface.hashtag.interface import HashtagInterface
 from api.src.domain.interface.ng_word.interface import NgWordInterface
 from api.src.domain.interface.search_tag.interface import SearchTagInterface
 from api.src.domain.interface.notification.interface import NotificationInterface
-from api.src.domain.interface.payment.interface import PaymentInterface
+from api.src.domain.interface.payment.provider.interface import PaymentInterface
 from api.src.domain.interface.payment.webhook_event.interface import WebhookEventInterface
 
 


### PR DESCRIPTION
## Summary
- `domain/interface/payment/interface.py`（フラット）と `payment/data.py` から Provider 関連を抜き出し、`payment/provider/` sub-package に整理
- ロジック変更ゼロの純粋な構造変更（mypy / DI 検証済み）
- PR #846 (`webhook_event` sub-package 化) に続く段階的 refactor の **第 2 段**

## 背景
`media/{video,music,...}/{interface, data}` パターンに揃えるための段階的 refactor。`payment/` 配下に Provider Interface（外部 API 抽象）と複数 Repository Interface（DB CRUD）が混在しており、ファイル名規約の歪みを解消する。

進捗：
- ✅ PR #846: `webhook_event` sub-package 化
- ✅ **PR 本件**: `provider` sub-package 化
- ⏭ 後続: Subscription / Transaction Repository の追加（既存 DB モデル向け）
- ⏭ 後続: webhook usecase の追加

## 変更内容

### 新規ファイル
- `domain/interface/payment/provider/__init__.py`（パッケージ化）
- `domain/interface/payment/provider/data.py`
  - `MarketplaceData` / `CustomerData` / `RedirectUrls`
  - `CheckoutData` / `CheckoutSessionData` / `CheckoutCreated` / `CheckoutFailed` / `CheckoutResult`
  - `WebhookVerified` / `WebhookVerifyFailed` / `WebhookVerifyResult`
  - `Money` は親パッケージから import、`WebhookEventData` は `webhook_event/data.py` から import

### Rename
- `domain/interface/payment/interface.py` → `domain/interface/payment/provider/interface.py`
  - `PaymentInterface` 抽象クラス
  - import 元を `payment.data` → `payment.provider.data` に更新

### 修正
- `domain/interface/payment/data.py`
  - Provider 関連の dataclass（Checkout* / WebhookVerify* / Marketplace / Customer / Redirect）をすべて削除
  - 残置：`Money` / `SubscriptionData` / `PaymentTransactionData`（後続 PR で各 sub-package へ移行予定）
- `adapter/external/payment/stripe/provider.py`: `PaymentInterface` / `Checkout*` / `WebhookVerified` / `WebhookVerifyFailed` / `WebhookVerifyResult` の import path を `provider.*` に更新
- `adapter/external/payment/stripe/_convert.py`: `CheckoutData` / `CheckoutFailed` / `WebhookVerifyFailed` を `provider.data` から import、`Money` のみ親 `payment.data` から
- `adapter/payment.py`: 同様に `Checkout*` / `Customer` / `Marketplace` / `Redirect` / `WebhookVerified/Failed` / `PaymentInterface` を `provider.*` 経由
- `injectors/index.py`: `PaymentInterface` の import path 更新

## 確認
- ✅ `uv run mypy` 本変更ファイル群に新規エラー 0件
- ✅ `injector.get(PaymentInterface)` → `StripeProvider` 解決
- ✅ `injector.get(WebhookEventInterface)` → `WebhookEventRepository`（既存パス、影響なし）

## 範囲外（後続 PR）
- `payment/data.py` から `SubscriptionData` / `PaymentTransactionData` を `subscription/data.py` / `transaction/data.py` に移行（新規 Repository 追加 PR と同時）
- webhook usecase / adapter wiring