### PR TITLE
【back】webhook usecase 実装（Subscription / Transaction status 更新）+ adapter 接続

### DIFF
--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -10,6 +10,7 @@ from api.src.injectors.container import injector
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.payment import PaymentCheckoutIn, PaymentCheckoutOut, PaymentWebhookOut
 from api.src.usecase.auth import auth_check
+from api.src.usecase.payment import handle_webhook_event
 from api.src.usecase.user import get_user_data
 from api.utils.enum.i18n import Currency, Locale
 from api.utils.enum.payment import PaymentType, WebhookVerifyError
@@ -92,4 +93,5 @@ class PaymentAPI:
                     return 200, PaymentWebhookOut(message="Already processed")
 
                 webhook_event_repo.bulk_save([event])
+                handle_webhook_event(event)
                 return 200, PaymentWebhookOut(message="OK")

--- a/myus/api/src/usecase/payment.py
+++ b/myus/api/src/usecase/payment.py
@@ -1,0 +1,58 @@
+from dataclasses import replace
+from api.modules.logger import log
+from api.src.domain.interface.payment.subscription.interface import FilterOption as SubscriptionFilterOption, SortOption as SubscriptionSortOption, SubscriptionInterface
+from api.src.domain.interface.payment.transaction.interface import FilterOption as TransactionFilterOption, SortOption as TransactionSortOption, TransactionInterface
+from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.injectors.container import injector
+from api.utils.enum.payment import PaymentStatus, SubscriptionStatus, WebhookEventType
+
+
+def handle_webhook_event(event: WebhookEventData) -> None:
+    match event.event_type:
+        case WebhookEventType.SUBSCRIPTION_CANCELED:
+            update_subscription_canceled(event)
+        case WebhookEventType.PAYMENT_SUCCEEDED:
+            update_transaction_status(event, PaymentStatus.CAPTURED, update_paid_at=True)
+        case WebhookEventType.PAYMENT_FAILED:
+            update_transaction_status(event, PaymentStatus.FAILED, update_paid_at=False)
+        case WebhookEventType.REFUND_ISSUED:
+            update_transaction_status(event, PaymentStatus.REFUNDED, update_paid_at=False)
+        case WebhookEventType.SUBSCRIPTION_CREATED:
+            log.info("WebhookEvent SUBSCRIPTION_CREATED noop", external_id=event.external_id)
+        case WebhookEventType.SUBSCRIPTION_UPDATED:
+            log.info("WebhookEvent SUBSCRIPTION_UPDATED noop", external_id=event.external_id)
+
+
+def update_subscription_canceled(event: WebhookEventData) -> None:
+    repo = injector.get(SubscriptionInterface)
+    ids = repo.get_ids(
+        SubscriptionFilterOption(provider=event.provider.value, external_id=event.external_id),
+        SubscriptionSortOption(),
+        limit=1,
+    )
+    if len(ids) == 0:
+        log.warning("Subscription not found for cancel", external_id=event.external_id)
+        return
+
+    subs = repo.bulk_get(ids)
+    updated = replace(subs[0], status=SubscriptionStatus.CANCELED, canceled_at=event.occurred_at)
+    repo.bulk_save([updated])
+    log.info("Subscription canceled", external_id=event.external_id)
+
+
+def update_transaction_status(event: WebhookEventData, status: PaymentStatus, update_paid_at: bool) -> None:
+    repo = injector.get(TransactionInterface)
+    ids = repo.get_ids(
+        TransactionFilterOption(provider=event.provider.value, external_id=event.external_id),
+        TransactionSortOption(),
+        limit=1,
+    )
+    if len(ids) == 0:
+        log.warning("Transaction not found for status update", external_id=event.external_id, status=status.value)
+        return
+
+    transactions = repo.bulk_get(ids)
+    transaction = transactions[0]
+    updated = replace(transaction, status=status, paid_at=event.occurred_at) if update_paid_at else replace(transaction, status=status)
+    repo.bulk_save([updated])
+    log.info("Transaction status updated", external_id=event.external_id, status=status.value)


### PR DESCRIPTION
## Summary
- `usecase/payment.py` を新設し、`handle_webhook_event(event)` で Stripe webhook を受けて Subscription / Transaction の status を更新
- `adapter/payment.py` の webhook エンドポイントから usecase を呼び出し
- **ロードマップ PR #5（webhook 受信エンドポイント）の最終段**：これで「Stripe → webhook 検証 → WebhookEvent 記録 → Subscription/Transaction status 反映」のサイクルが閉じる

## 背景
PR #840〜#849 までで以下を整備：
- 決済ドメイン抽象（PR #840 / #841 で WebhookEvent / verify_webhook）
- Webhook 受信エンドポイント（PR #844、現状 200 OK 返却のみ）
- Repository 群（PR #843 WebhookEvent / #848 Subscription / #849 Transaction）
- sub-package 構造（PR #846 / #847）

**本 PR**: 上記基盤を使って **webhook 受信時に DB の status を更新する usecase** を実装。

## 変更内容

### `myus/api/src/usecase/payment.py`（新規）

`handle_webhook_event(event: WebhookEventData)` を新設し、event_type ごとに分岐：

| event_type | 処理 | 更新対象 |
|------------|------|----------|
| `SUBSCRIPTION_CANCELED` | `update_subscription_canceled` | `Subscription.status` → `CANCELED`、`canceled_at` → `event.occurred_at` |
| `PAYMENT_SUCCEEDED` | `update_transaction_status(CAPTURED, update_paid_at=True)` | `Transaction.status` → `CAPTURED`、`paid_at` 更新 |
| `PAYMENT_FAILED` | `update_transaction_status(FAILED, update_paid_at=False)` | `Transaction.status` → `FAILED`（`paid_at` は変更なし） |
| `REFUND_ISSUED` | `update_transaction_status(REFUNDED, update_paid_at=False)` | `Transaction.status` → `REFUNDED` |
| `SUBSCRIPTION_CREATED` | log のみ（noop） | （次 PR 候補：Stripe API から customer_id / period 取得が必要） |
| `SUBSCRIPTION_UPDATED` | log のみ（noop） | （次 PR 候補：period_end 等の取得が必要） |

各更新関数の実装：
1. `injector.get(SubscriptionInterface)` または `TransactionInterface` 取得
2. `get_ids(FilterOption(provider, external_id), SortOption(), limit=1)` で対象 1 件検索
3. 該当なしなら `log.warning` で skip
4. `bulk_get` → `dataclasses.replace` で immutable update → `bulk_save([updated])`
5. 成功時 `log.info`

### `myus/api/src/adapter/payment.py`
- `from api.src.usecase.payment import handle_webhook_event` 追加
- `webhook_event_repo.bulk_save([event])` 直後に `handle_webhook_event(event)` を呼び出し

## 範囲外（後続 PR）
- `SUBSCRIPTION_CREATED` / `SUBSCRIPTION_UPDATED` の完全実装（Stripe API 経由で customer_id / period 取得が必要）
- 初回 Transaction レコード生成（checkout 完了時の Stripe `payment_intent` から作成）
- ユーザー向け解約 API（ロードマップ PR #6）

## 確認
- ✅ `uv run mypy` 本変更ファイルに新規エラー 0件
- ✅ `from api.src.usecase.payment import handle_webhook_event` の import 確認（Django setup 後）
- ✅ DI 経由で SubscriptionInterface / TransactionInterface が解決

## ロードマップ PR #5 の完結
これで「決済ドメイン抽象 + Stripe 実装 + Webhook 受信 + 冪等性 + status 反映」が一通り揃いました。