### PR TITLE
【back】Subscription 解約 API 新設 (POST /api/payment/cancel) + StripeProvider 実装

### DIFF
--- a/myus/api/src/adapter/external/payment/stripe/provider.py
+++ b/myus/api/src/adapter/external/payment/stripe/provider.py
@@ -1,10 +1,11 @@
 import stripe
+from datetime import datetime, timezone
 from django.conf import settings
 from api.modules.logger import log
 from api.src.adapter.external.payment.stripe._convert import convert_stripe_event, convert_stripe_params
-from api.src.domain.interface.payment.provider.data import CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerified, WebhookVerifyFailed, WebhookVerifyResult
+from api.src.domain.interface.payment.provider.data import CancelFailed, CancelResult, CancelSuccess, CheckoutCreated, CheckoutData, CheckoutFailed, CheckoutResult, CheckoutSessionData, WebhookVerified, WebhookVerifyFailed, WebhookVerifyResult
 from api.src.domain.interface.payment.provider.interface import PaymentInterface
-from api.utils.enum.payment import CheckoutError, PaymentProvider, WebhookVerifyError
+from api.utils.enum.payment import CancelError, CheckoutError, PaymentProvider, WebhookVerifyError
 
 
 class StripeProvider(PaymentInterface):
@@ -47,3 +48,23 @@ class StripeProvider(PaymentInterface):
         if isinstance(event_data, WebhookVerifyFailed):
             return event_data
         return WebhookVerified(event=event_data)
+
+    def cancel_subscription(self, external_id: str) -> CancelResult:
+        stripe.api_key = settings.STRIPE_SECRET_KEY
+        try:
+            subscription = stripe.Subscription.modify(external_id, cancel_at_period_end=True)
+        except stripe.InvalidRequestError as e:
+            log.warning("Stripe subscription not found for cancel", external_id=external_id, exc=e)
+            return CancelFailed(error=CancelError.NOT_FOUND, message=str(e))
+        except stripe.APIConnectionError as e:
+            log.error("Stripe network error on cancel", exc=e)
+            return CancelFailed(error=CancelError.NETWORK_ERROR, message=str(e))
+        except stripe.StripeError as e:
+            log.error("Stripe cancel error", exc=e)
+            return CancelFailed(error=CancelError.PROVIDER_REJECTED, message=str(e))
+
+        period_end_ts: int = getattr(subscription, "current_period_end", 0)
+        return CancelSuccess(
+            canceled_at=datetime.now(timezone.utc),
+            period_end=datetime.fromtimestamp(period_end_ts, tz=timezone.utc),
+        )

--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -1,19 +1,21 @@
+from dataclasses import replace
 from django.conf import settings
 from django.http import HttpRequest
 from ninja import Router
 from api.modules.logger import log
 from api.src.domain.interface.payment.data import Money
-from api.src.domain.interface.payment.provider.data import CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, RedirectUrls, WebhookVerified, WebhookVerifyFailed
+from api.src.domain.interface.payment.provider.data import CancelFailed, CancelSuccess, CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, RedirectUrls, WebhookVerified, WebhookVerifyFailed
 from api.src.domain.interface.payment.provider.interface import PaymentInterface
+from api.src.domain.interface.payment.subscription.interface import FilterOption as SubscriptionFilterOption, SortOption as SubscriptionSortOption, SubscriptionInterface
 from api.src.domain.interface.payment.webhook_event.interface import FilterOption, SortOption, WebhookEventInterface
 from api.src.injectors.container import injector
 from api.src.types.schema.common import ErrorOut
-from api.src.types.schema.payment import PaymentCheckoutIn, PaymentCheckoutOut, PaymentWebhookOut
+from api.src.types.schema.payment import PaymentCancelOut, PaymentCheckoutIn, PaymentCheckoutOut, PaymentWebhookOut
 from api.src.usecase.auth import auth_check
 from api.src.usecase.payment import handle_webhook_event
 from api.src.usecase.user import get_user_data
 from api.utils.enum.i18n import Currency, Locale
-from api.utils.enum.payment import PaymentType, WebhookVerifyError
+from api.utils.enum.payment import PaymentProvider, PaymentType, SubscriptionStatus, WebhookVerifyError
 from api.utils.plan import get_plan
 
 
@@ -95,3 +97,36 @@ class PaymentAPI:
                 webhook_event_repo.bulk_save([event])
                 handle_webhook_event(event)
                 return 200, PaymentWebhookOut(message="OK")
+
+    @staticmethod
+    @router.post("/cancel", response={200: PaymentCancelOut, 401: ErrorOut, 404: ErrorOut, 500: ErrorOut})
+    def cancel(request: HttpRequest):
+        user_id = auth_check(request)
+        if user_id is None:
+            return 401, ErrorOut(message="Unauthorized")
+
+        sub_repo = injector.get(SubscriptionInterface)
+        ids = sub_repo.get_ids(
+            SubscriptionFilterOption(customer_user_id=user_id, provider=PaymentProvider.STRIPE.value),
+            SubscriptionSortOption(is_asc=False),
+            limit=1,
+        )
+        if len(ids) == 0:
+            return 404, ErrorOut(message="アクティブなサブスクリプションが見つかりません")
+
+        subs = sub_repo.bulk_get(ids)
+        subscription = subs[0]
+        if subscription.status != SubscriptionStatus.ACTIVE:
+            return 404, ErrorOut(message="アクティブなサブスクリプションが見つかりません")
+
+        payment = injector.get(PaymentInterface)
+        result = payment.cancel_subscription(subscription.external_id)
+        match result:
+            case CancelSuccess(canceled_at=canceled_at, period_end=period_end):
+                updated = replace(subscription, canceled_at=canceled_at, current_period_end=period_end)
+                sub_repo.bulk_save([updated])
+                log.info("PaymentAPI cancel succeeded", user_id=user_id, external_id=subscription.external_id)
+                return 200, PaymentCancelOut(canceled_at=canceled_at, period_end=period_end)
+            case CancelFailed(error=error, message=message):
+                log.error("Payment cancel failed", error=error.value, message=message)
+                return 500, ErrorOut(message="解約処理に失敗しました")

--- a/myus/api/src/domain/interface/payment/provider/data.py
+++ b/myus/api/src/domain/interface/payment/provider/data.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from datetime import datetime
 from api.src.domain.interface.payment.data import Money
 from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
 from api.utils.enum.i18n import Locale
-from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
+from api.utils.enum.payment import CancelError, CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,3 +68,18 @@ class WebhookVerifyFailed:
 
 
 type WebhookVerifyResult = WebhookVerified | WebhookVerifyFailed
+
+
+@dataclass(frozen=True, slots=True)
+class CancelSuccess:
+    canceled_at: datetime
+    period_end: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class CancelFailed:
+    error: CancelError
+    message: str
+
+
+type CancelResult = CancelSuccess | CancelFailed

--- a/myus/api/src/domain/interface/payment/provider/interface.py
+++ b/myus/api/src/domain/interface/payment/provider/interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from api.src.domain.interface.payment.provider.data import CheckoutData, CheckoutResult, WebhookVerifyResult
+from api.src.domain.interface.payment.provider.data import CancelResult, CheckoutData, CheckoutResult, WebhookVerifyResult
 
 
 class PaymentInterface(ABC):
@@ -9,4 +9,8 @@ class PaymentInterface(ABC):
 
     @abstractmethod
     def verify_webhook(self, payload: bytes, signature: str) -> WebhookVerifyResult:
+        ...
+
+    @abstractmethod
+    def cancel_subscription(self, external_id: str) -> CancelResult:
         ...

--- a/myus/api/src/types/schema/payment.py
+++ b/myus/api/src/types/schema/payment.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 
@@ -11,3 +12,8 @@ class PaymentCheckoutOut(BaseModel):
 
 class PaymentWebhookOut(BaseModel):
     message: str
+
+
+class PaymentCancelOut(BaseModel):
+    canceled_at: datetime
+    period_end: datetime

--- a/myus/api/utils/enum/payment.py
+++ b/myus/api/utils/enum/payment.py
@@ -17,6 +17,12 @@ class CheckoutError(str, Enum):
     NETWORK_ERROR = "NetworkError"
 
 
+class CancelError(str, Enum):
+    NOT_FOUND = "NotFound"
+    PROVIDER_REJECTED = "ProviderRejected"
+    NETWORK_ERROR = "NetworkError"
+
+
 class SubscriptionStatus(str, Enum):
     ACTIVE = "Active"
     PAST_DUE = "PastDue"


### PR DESCRIPTION
## Summary
- `PaymentInterface.cancel_subscription(external_id)` を新設し、`StripeProvider` で実装
- `POST /api/payment/cancel` エンドポイントを `PaymentAPI` に追加（auth check + Subscription 検索 + Stripe 解約 + DB 反映）
- **解約は period_end までは利用可能** な「予約解約」方式（`stripe.Subscription.modify(cancel_at_period_end=True)`）
- ロードマップ PR #6 の BE 部分。FE 連携は次 PR

## 背景
PR #5 完結後、ユーザー操作で Subscription を解約する API を提供。一般 SaaS の慣習に従い「**月末まで利用可能 → 月末に自動 CANCELED**」のフローを採用。

```
ユーザー解約 → cancel_at_period_end=true
↓
DB: canceled_at = now() （解約予約フラグとして記録）
↓
period_end 到達
↓
Stripe webhook (subscription.deleted)
↓
DB: status = CANCELED（既存 webhook usecase が処理）
```

## 変更内容

### `myus/api/utils/enum/payment.py`
- `CancelError` enum 新設：`NOT_FOUND` / `PROVIDER_REJECTED` / `NETWORK_ERROR`

### `myus/api/src/domain/interface/payment/provider/data.py`
- `CancelSuccess(canceled_at: datetime, period_end: datetime)` 新設
- `CancelFailed(error: CancelError, message: str)` 新設
- `type CancelResult = CancelSuccess | CancelFailed`
- `datetime` import 追加

### `myus/api/src/domain/interface/payment/provider/interface.py`
- `PaymentInterface.cancel_subscription(external_id: str) -> CancelResult` を `@abstractmethod` で追加

### `myus/api/src/adapter/external/payment/stripe/provider.py`
- `StripeProvider.cancel_subscription` を実装
  - `stripe.Subscription.modify(external_id, cancel_at_period_end=True)` で解約予約
  - 例外マッピング：`InvalidRequestError` → `NOT_FOUND`、`APIConnectionError` → `NETWORK_ERROR`、`StripeError` → `PROVIDER_REJECTED`
  - `period_end` は `getattr(subscription, "current_period_end", 0)` で取得（Stripe SDK の型に top-level 属性が無いため）
  - `canceled_at` は `datetime.now(timezone.utc)` で取得

### `myus/api/src/types/schema/payment.py`
- `PaymentCancelOut(canceled_at: datetime, period_end: datetime)` 追加

### `myus/api/src/adapter/payment.py`
- `POST /cancel` エンドポイント新設
  1. `auth_check(request)` で `user_id` 取得（401 if 未認証）
  2. `SubscriptionInterface.get_ids(FilterOption(customer_user_id, provider=STRIPE), SortOption(is_asc=False), limit=1)` で最新サブスク取得
  3. 該当なし or `status != ACTIVE` → 404
  4. `payment.cancel_subscription(external_id)` 呼び出し
  5. `CancelSuccess` → DB の `canceled_at` / `current_period_end` を更新して 200 返却
  6. `CancelFailed` → 500 でエラー
- 必要 import 追加：`replace` / `CancelFailed` / `CancelSuccess` / `SubscriptionInterface` / `PaymentCancelOut` / `PaymentProvider` / `SubscriptionStatus`

## HTTP ステータス設計
| ケース | ステータス | レスポンス |
|--------|----------|-----------|
| 解約予約成功 | 200 | `{canceled_at, period_end}` |
| 未認証 | 401 | "Unauthorized" |
| アクティブサブスクなし | 404 | "アクティブなサブスクリプションが見つかりません" |
| Stripe 通信/拒否エラー | 500 | "解約処理に失敗しました" |

## 範囲外（後続 PR）
- FE 解約ボタン + 確認ダイアログ（次 PR）
- 解約取り消し API（`stripe.Subscription.modify(cancel_at_period_end=False)`）
- 即時解約オプション（`stripe.Subscription.cancel()`）

## 確認
- ✅ `uv run mypy` エラー 0件
- ✅ `PaymentAPI` の 3 エンドポイント登録確認：`POST /checkout` / `POST /webhook` / `POST /cancel`
- ✅ DI: `PaymentInterface` / `SubscriptionInterface` 解決

## 動作確認のお願い
- Stripe CLI で webhook を listen
- 開発環境で `POST /api/payment/cancel` を auth 付きで呼ぶ → 200 で `canceled_at` / `period_end` が返ること
- DB の Subscription レコードに `canceled_at` が記録されること
- Stripe Dashboard で対象 subscription が「cancel scheduled」状態になっていること