### PR TITLE
【front】Subscription 解約ボタン + 確認ダイアログを追加（POST /api/payment/cancel 連携）

### DIFF
--- a/frontend/src/api/internal/payment.ts
+++ b/frontend/src/api/internal/payment.ts
@@ -1,9 +1,13 @@
 import { apiClient } from 'lib/axios/internal'
 import { ApiOut, apiOut } from 'lib/error'
-import { PaymentCheckoutIn, PaymentCheckoutOut } from 'types/internal/payment'
-import { apiPaymentCheckout } from 'api/uri'
+import { PaymentCancelOut, PaymentCheckoutIn, PaymentCheckoutOut } from 'types/internal/payment'
+import { apiPaymentCancel, apiPaymentCheckout } from 'api/uri'
 import { camelSnake } from 'utils/functions/convertCase'
 
 export const postPaymentCheckout = async (request: PaymentCheckoutIn): Promise<ApiOut<PaymentCheckoutOut>> => {
   return await apiOut(apiClient('json').post(apiPaymentCheckout, camelSnake(request)))
+}
+
+export const postPaymentCancel = async (): Promise<ApiOut<PaymentCancelOut>> => {
+  return await apiOut(apiClient('json').post(apiPaymentCancel))
 }

--- a/frontend/src/api/uri.ts
+++ b/frontend/src/api/uri.ts
@@ -35,6 +35,7 @@ export const apiSettingNotification = base + '/setting/notification'
 
 // Payment
 export const apiPaymentCheckout = base + '/payment/checkout'
+export const apiPaymentCancel = base + '/payment/cancel'
 
 // Channel
 export const apiChannelCreate = base + '/channel'

--- a/frontend/src/components/templates/setting/payment/PlanCard/PlanCard.module.scss
+++ b/frontend/src/components/templates/setting/payment/PlanCard/PlanCard.module.scss
@@ -17,7 +17,7 @@
     background: rgb(245, 250, 255);
   }
 
-  &.disabled {
+  &.current {
     opacity: 0.6;
     cursor: default;
   }

--- a/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
+++ b/frontend/src/components/templates/setting/payment/PlanCard/index.tsx
@@ -14,21 +14,20 @@ interface Props {
   current?: boolean
   showPurchase?: boolean
   disabled?: boolean
-  purchaseDisabled?: boolean
   loading?: boolean
   onClick?: () => void
   onPurchase?: (plan: string) => void
 }
 
 export default function PlanCard(props: Props): React.JSX.Element {
-  const { plan, active, onClick, onPurchase, current = false, showPurchase = true, disabled = false, purchaseDisabled = false, loading = false } = props
+  const { plan, active, onClick, onPurchase, current = false, showPurchase = true, disabled = false, loading = false } = props
   const { name, price, features } = plan
 
-  const handleClick = disabled ? undefined : onClick
+  const handleClick = current ? undefined : onClick
   const handlePurchase = () => onPurchase?.(name)
 
   return (
-    <div className={cx(style.plan, active && style.active, handleClick && style.clickable, disabled && style.disabled)} onClick={handleClick}>
+    <div className={cx(style.plan, active && style.active, handleClick && style.clickable, current && style.current)} onClick={handleClick}>
       <div className={style.name}>
         {name}
         {current && <span className={style.current_label}>現在</span>}
@@ -44,7 +43,7 @@ export default function PlanCard(props: Props): React.JSX.Element {
           </li>
         ))}
       </ul>
-      {showPurchase && name !== 'Free' && <Button color="purple" size="l" name="購入する" disabled={purchaseDisabled} loading={loading} onClick={handlePurchase} />}
+      {showPurchase && name !== 'Free' && <Button color="purple" size="l" name="購入する" disabled={disabled} loading={loading} onClick={handlePurchase} />}
     </div>
   )
 }

--- a/frontend/src/components/templates/setting/payment/change/index.tsx
+++ b/frontend/src/components/templates/setting/payment/change/index.tsx
@@ -35,7 +35,6 @@ export default function PaymentChange(props: Props): React.JSX.Element {
               active={activeName === plan.name}
               onClick={() => setActiveName(plan.name)}
               current={plan.name === currentPlanName}
-              disabled={plan.name === currentPlanName}
               showPurchase={false}
             />
           ))}

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { MypageOut } from 'types/internal/user'
-import { postPaymentCheckout } from 'api/internal/payment'
+import { postPaymentCancel, postPaymentCheckout } from 'api/internal/payment'
 import { FetchError } from 'utils/constants/enum'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
+import Modal from 'components/parts/Modal'
 import CurrentBanner from './CurrentBanner'
 import style from './Payment.module.scss'
 import PlanCard from './PlanCard'
@@ -20,6 +21,8 @@ export default function Payment(props: Props): React.JSX.Element {
   const router = useRouter()
   const { toast, handleToast } = useToast()
   const [loadingPlan, setLoadingPlan] = useState<string>('')
+  const [cancelOpen, setCancelOpen] = useState<boolean>(false)
+  const [cancelLoading, setCancelLoading] = useState<boolean>(false)
 
   const currentPlan = mypage.plan
   const purchasable = plans.filter((plan) => plan.name !== 'Free')
@@ -38,6 +41,23 @@ export default function Payment(props: Props): React.JSX.Element {
     window.location.href = ret.value.url
   }
 
+  const handleCancelOpen = () => setCancelOpen(true)
+  const handleCancelClose = () => setCancelOpen(false)
+
+  const handleCancelSubmit = async () => {
+    setCancelLoading(true)
+    const ret = await postPaymentCancel()
+    setCancelLoading(false)
+    if (ret.isErr()) {
+      handleToast(ret.error.message ?? FetchError.Post, true)
+      return
+    }
+    setCancelOpen(false)
+    const periodEnd = new Date(ret.value.periodEnd).toLocaleDateString('ja-JP')
+    handleToast(`解約予約完了。${periodEnd} まで利用可能です`, false)
+    router.reload()
+  }
+
   return (
     <Main metaTitle="料金プラン" toast={toast}>
       <div className={style.payment}>
@@ -52,9 +72,23 @@ export default function Payment(props: Props): React.JSX.Element {
         {isPaid && (
           <div className={style.actions}>
             <Button color="green" name="プランを変更" onClick={handleChange} />
+            <Button color="red" name="解約する" onClick={handleCancelOpen} />
           </div>
         )}
       </div>
+
+      <Modal
+        open={cancelOpen}
+        onClose={handleCancelClose}
+        title="解約の確認"
+        actions={[
+          { name: 'キャンセル', color: 'white', onClick: handleCancelClose, disabled: cancelLoading },
+          { name: '解約する', color: 'red', onClick: handleCancelSubmit, loading: cancelLoading },
+        ]}
+      >
+        <p>本当に解約しますか？</p>
+        <p>解約後は次回更新日まで現在のプランをご利用いただけます。</p>
+      </Modal>
     </Main>
   )
 }

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -21,8 +21,8 @@ export default function Payment(props: Props): React.JSX.Element {
   const router = useRouter()
   const { toast, handleToast } = useToast()
   const [loadingPlan, setLoadingPlan] = useState<string>('')
-  const [cancelOpen, setCancelOpen] = useState<boolean>(false)
-  const [cancelLoading, setCancelLoading] = useState<boolean>(false)
+  const [isCancelOpen, setIsCancelOpen] = useState<boolean>(false)
+  const [isCancelLoading, setIsCancelLoading] = useState<boolean>(false)
 
   const currentPlan = mypage.plan
   const purchasable = plans.filter((plan) => plan.name !== 'Free')
@@ -41,18 +41,18 @@ export default function Payment(props: Props): React.JSX.Element {
     window.location.href = ret.value.url
   }
 
-  const handleCancelOpen = () => setCancelOpen(true)
-  const handleCancelClose = () => setCancelOpen(false)
+  const handleCancelOpen = () => setIsCancelOpen(true)
+  const handleCancelClose = () => setIsCancelOpen(false)
 
   const handleCancelSubmit = async () => {
-    setCancelLoading(true)
+    setIsCancelLoading(true)
     const ret = await postPaymentCancel()
-    setCancelLoading(false)
+    setIsCancelLoading(false)
     if (ret.isErr()) {
       handleToast(ret.error.message ?? FetchError.Post, true)
       return
     }
-    setCancelOpen(false)
+    setIsCancelOpen(false)
     const periodEnd = new Date(ret.value.periodEnd).toLocaleDateString('ja-JP')
     handleToast(`解約予約完了。${periodEnd} まで利用可能です`, false)
     router.reload()
@@ -78,12 +78,12 @@ export default function Payment(props: Props): React.JSX.Element {
       </div>
 
       <Modal
-        open={cancelOpen}
+        open={isCancelOpen}
         onClose={handleCancelClose}
         title="解約の確認"
         actions={[
-          { name: 'キャンセル', color: 'white', onClick: handleCancelClose, disabled: cancelLoading },
-          { name: '解約する', color: 'red', onClick: handleCancelSubmit, loading: cancelLoading },
+          { name: 'キャンセル', color: 'white', onClick: handleCancelClose, disabled: isCancelLoading },
+          { name: '解約する', color: 'red', onClick: handleCancelSubmit, loading: isCancelLoading },
         ]}
       >
         <p>本当に解約しますか？</p>

--- a/frontend/src/components/templates/setting/payment/index.tsx
+++ b/frontend/src/components/templates/setting/payment/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { MypageOut } from 'types/internal/user'
 import { postPaymentCancel, postPaymentCheckout } from 'api/internal/payment'
 import { FetchError } from 'utils/constants/enum'
+import { useLoading } from 'components/hooks/useLoading'
 import { useToast } from 'components/hooks/useToast'
 import Main from 'components/layout/Main'
 import Button from 'components/parts/Button'
@@ -19,10 +20,10 @@ interface Props {
 export default function Payment(props: Props): React.JSX.Element {
   const { mypage } = props
   const router = useRouter()
+  const { loading, handleLoading } = useLoading()
   const { toast, handleToast } = useToast()
-  const [loadingPlan, setLoadingPlan] = useState<string>('')
-  const [isCancelOpen, setIsCancelOpen] = useState<boolean>(false)
-  const [isCancelLoading, setIsCancelLoading] = useState<boolean>(false)
+  const [isModal, setIsModal] = useState<boolean>(false)
+  const [selectedPlan, setSelectedPlan] = useState<string>('')
 
   const currentPlan = mypage.plan
   const purchasable = plans.filter((plan) => plan.name !== 'Free')
@@ -31,28 +32,27 @@ export default function Payment(props: Props): React.JSX.Element {
   const handleChange = () => router.push('/setting/payment/change')
 
   const handlePurchase = async (plan: string) => {
-    setLoadingPlan(plan)
+    setSelectedPlan(plan)
     const ret = await postPaymentCheckout({ plan })
     if (ret.isErr()) {
-      setLoadingPlan('')
+      setSelectedPlan('')
       handleToast(ret.error.message ?? FetchError.Post, true)
       return
     }
     window.location.href = ret.value.url
   }
 
-  const handleCancelOpen = () => setIsCancelOpen(true)
-  const handleCancelClose = () => setIsCancelOpen(false)
+  const handleModal = () => setIsModal(!isModal)
 
   const handleCancelSubmit = async () => {
-    setIsCancelLoading(true)
+    handleLoading(true)
     const ret = await postPaymentCancel()
-    setIsCancelLoading(false)
+    handleLoading(false)
     if (ret.isErr()) {
       handleToast(ret.error.message ?? FetchError.Post, true)
       return
     }
-    setIsCancelOpen(false)
+    setIsModal(false)
     const periodEnd = new Date(ret.value.periodEnd).toLocaleDateString('ja-JP')
     handleToast(`解約予約完了。${periodEnd} まで利用可能です`, false)
     router.reload()
@@ -65,25 +65,25 @@ export default function Payment(props: Props): React.JSX.Element {
 
         <div className={style.plans}>
           {purchasable.map((plan) => (
-            <PlanCard key={plan.name} plan={plan} active={currentPlan === plan.name} purchaseDisabled={isPaid} loading={loadingPlan === plan.name} onPurchase={handlePurchase} />
+            <PlanCard key={plan.name} plan={plan} active={currentPlan === plan.name} disabled={isPaid} loading={selectedPlan === plan.name} onPurchase={handlePurchase} />
           ))}
         </div>
 
         {isPaid && (
           <div className={style.actions}>
             <Button color="green" name="プランを変更" onClick={handleChange} />
-            <Button color="red" name="解約する" onClick={handleCancelOpen} />
+            <Button color="red" name="解約する" onClick={handleModal} />
           </div>
         )}
       </div>
 
       <Modal
-        open={isCancelOpen}
-        onClose={handleCancelClose}
+        open={isModal}
+        onClose={handleModal}
         title="解約の確認"
         actions={[
-          { name: 'キャンセル', color: 'white', onClick: handleCancelClose, disabled: isCancelLoading },
-          { name: '解約する', color: 'red', onClick: handleCancelSubmit, loading: isCancelLoading },
+          { name: 'キャンセル', color: 'white', onClick: handleModal, disabled: loading },
+          { name: '解約する', color: 'red', onClick: handleCancelSubmit, loading },
         ]}
       >
         <p>本当に解約しますか？</p>

--- a/frontend/src/types/internal/payment.d.ts
+++ b/frontend/src/types/internal/payment.d.ts
@@ -5,3 +5,8 @@ export interface PaymentCheckoutIn {
 export interface PaymentCheckoutOut {
   url: string
 }
+
+export interface PaymentCancelOut {
+  canceledAt: string
+  periodEnd: string
+}


### PR DESCRIPTION
## Summary
- 料金プランページに「解約する」ボタンと確認ダイアログ（Modal）を追加
- PR #851 (BE) で実装した `POST /api/payment/cancel` を呼び出して subscription を予約解約
- ロードマップ PR #6 の FE 部分

## 背景
PR #851 で「予約解約（period_end まで利用可能）」のサーバ API が完成。本 PR はユーザーがその API を叩く UI を提供。`/setting/payment` で `isPaid` のとき「プランを変更」と並べて「解約する」ボタンを表示し、確認ダイアログ経由で実行する。

## 変更内容

### `frontend/src/api/uri.ts`
- `apiPaymentCancel = base + '/payment/cancel'` 追加

### `frontend/src/types/internal/payment.d.ts`
- `PaymentCancelOut { canceledAt: string; periodEnd: string }` 追加（BE の `PaymentCancelOut` と一致、camelCase で受信）

### `frontend/src/api/internal/payment.ts`
- `postPaymentCancel(): Promise<ApiOut<PaymentCancelOut>>` 追加（body 不要、auth Cookie のみで認証）

### `frontend/src/components/templates/setting/payment/index.tsx`
- 状態追加：`cancelOpen: boolean`、`cancelLoading: boolean`
- ハンドラ追加：`handleCancelOpen` / `handleCancelClose` / `handleCancelSubmit`
- `isPaid` 時のアクション領域に「解約する」（red）ボタン追加
- Modal で確認ダイアログ：
  - タイトル「解約の確認」
  - 本文「本当に解約しますか？解約後は次回更新日まで現在のプランをご利用いただけます。」
  - アクション：「キャンセル」（white）/「解約する」（red, loading 制御あり）
- 成功時：Modal を閉じ、`periodEnd` を日本ロケールで表示したトースト出力 →`router.reload()` で SSR 再取得

## UX フロー
```
1. /setting/payment（isPaid=true）
2. 「解約する」ボタンクリック → Modal 開く
3. 「解約する」確定 → loading=true → API 呼び出し
4. 成功 → Modal 閉じ → "解約予約完了。YYYY/MM/DD まで利用可能です" トースト → ページリロード
5. 失敗 → エラートースト（Modal は開いたまま、再試行可能）
```

## 範囲外（後続 PR）
- 解約予約状態の **明示的な UI 表示**（`canceled_at` 値を mypage から取得して「解約予約済み（YYYY/MM/DD で終了）」のバナー表示）
- 解約取り消し（uncancel）API + UI
- 即時解約オプション

現状は `canceled_at` を表示する場所がないため、ユーザーは「解約予約完了」のトーストを見たあと、再度アクセスしても解約予約済みであることに気づきにくい。後続 PR でバナー表示を入れる必要あり。

## 確認
- ✅ `npm run lint` エラー 0件（既存 9 warnings は無関係）
- ✅ TypeScript エラー 0件

## 動作確認のお願い
- アクティブなサブスクのあるユーザーで `/setting/payment` を開く
- 「解約する」ボタンクリック → Modal 表示
- 「キャンセル」→ Modal が閉じる、API 呼び出しなし
- 「解約する」→ loading 表示 → 完了後トースト + リロード
- BE 側で Stripe Dashboard に "Will cancel on YYYY-MM-DD" 反映確認
- DB の Subscription.canceled_at / current_period_end が更新確認