### PR TITLE
【back】WebhookEvent* クラス名を WebhookInbox* にリネーム + 依存 import 更新

### DIFF
--- a/myus/api/src/adapter/external/payment/stripe/_convert.py
+++ b/myus/api/src/adapter/external/payment/stripe/_convert.py
@@ -15,19 +15,19 @@ from stripe.params.checkout import (
 from api.src.adapter.external.payment.stripe._type import stripe_event_type
 from api.src.domain.interface.payment.data import Money
 from api.src.domain.interface.payment.provider.data import CheckoutData, CheckoutFailed, WebhookVerifyFailed
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_inbox.data import WebhookInboxData
 from api.utils.enum.i18n import Locale
 from api.utils.enum.payment import CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
 from api.utils.enum.user import PlanName
 
 
-def convert_stripe_event(event: stripe.Event) -> WebhookEventData | WebhookVerifyFailed:
+def convert_stripe_event(event: stripe.Event) -> WebhookInboxData | WebhookVerifyFailed:
     event_type = stripe_event_type(event.type)
     if event_type is None:
         return WebhookVerifyFailed(error=WebhookVerifyError.UNSUPPORTED_EVENT, message=f"unsupported event_type={event.type}")
 
     external_id: str = getattr(event.data.object, "id", "")
-    return WebhookEventData(
+    return WebhookInboxData(
         id=0,
         provider=PaymentProvider.STRIPE,
         event_id=event.id,

--- a/myus/api/src/adapter/payment.py
+++ b/myus/api/src/adapter/payment.py
@@ -7,7 +7,7 @@ from api.src.domain.interface.payment.data import Money
 from api.src.domain.interface.payment.provider.data import CancelFailed, CancelSuccess, CheckoutCreated, CheckoutData, CheckoutFailed, CustomerData, MarketplaceData, RedirectUrls, WebhookVerified, WebhookVerifyFailed
 from api.src.domain.interface.payment.provider.interface import PaymentInterface
 from api.src.domain.interface.payment.subscription.interface import FilterOption as SubscriptionFilterOption, SortOption as SubscriptionSortOption, SubscriptionInterface
-from api.src.domain.interface.payment.webhook_event.interface import FilterOption, SortOption, WebhookEventInterface
+from api.src.domain.interface.payment.webhook_inbox.interface import FilterOption, SortOption, WebhookInboxInterface
 from api.src.injectors.container import injector
 from api.src.types.schema.common import ErrorOut
 from api.src.types.schema.payment import PaymentCancelOut, PaymentCheckoutIn, PaymentCheckoutOut, PaymentWebhookOut
@@ -84,7 +84,7 @@ class PaymentAPI:
             case WebhookVerified(event=event):
                 log.info("PaymentAPI webhook verified", event_id=event.event_id, event_type=event.event_type.value)
 
-                webhook_event_repo = injector.get(WebhookEventInterface)
+                webhook_event_repo = injector.get(WebhookInboxInterface)
                 existing_ids = webhook_event_repo.get_ids(
                     FilterOption(provider=event.provider.value, event_id=event.event_id),
                     SortOption(),

--- a/myus/api/src/domain/entity/payment/webhook_inbox/_convert.py
+++ b/myus/api/src/domain/entity/payment/webhook_inbox/_convert.py
@@ -1,10 +1,10 @@
 from api.db.models.payment import WebhookEvent
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_inbox.data import WebhookInboxData
 from api.utils.enum.payment import PaymentProvider, WebhookEventType
 
 
-def convert_data(obj: WebhookEvent) -> WebhookEventData:
-    return WebhookEventData(
+def convert_data(obj: WebhookEvent) -> WebhookInboxData:
+    return WebhookInboxData(
         id=obj.id,
         provider=PaymentProvider(obj.provider),
         event_id=obj.event_id,
@@ -14,7 +14,7 @@ def convert_data(obj: WebhookEvent) -> WebhookEventData:
     )
 
 
-def marshal_data(data: WebhookEventData) -> WebhookEvent:
+def marshal_data(data: WebhookInboxData) -> WebhookEvent:
     return WebhookEvent(
         id=data.id if data.id != 0 else None,
         provider=data.provider,

--- a/myus/api/src/domain/entity/payment/webhook_inbox/repository.py
+++ b/myus/api/src/domain/entity/payment/webhook_inbox/repository.py
@@ -1,15 +1,15 @@
 from django.db.models import Q
 from api.db.models.payment import WebhookEvent
 from api.src.domain.entity.index import get_new_ids, sort_ids
-from api.src.domain.entity.payment.webhook_event._convert import convert_data, marshal_data
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
-from api.src.domain.interface.payment.webhook_event.interface import FilterOption, SortOption, WebhookEventInterface
+from api.src.domain.entity.payment.webhook_inbox._convert import convert_data, marshal_data
+from api.src.domain.interface.payment.webhook_inbox.data import WebhookInboxData
+from api.src.domain.interface.payment.webhook_inbox.interface import FilterOption, SortOption, WebhookInboxInterface
 
 
 WEBHOOK_EVENT_FIELDS = ["provider", "event_id", "event_type", "external_id", "occurred_at"]
 
 
-class WebhookEventRepository(WebhookEventInterface):
+class WebhookInboxRepository(WebhookInboxInterface):
     def get_ids(self, filter: FilterOption, sort: SortOption, limit: int | None = 20) -> list[int]:
         q_list: list[Q] = []
         if len(filter.provider) > 0:
@@ -26,7 +26,7 @@ class WebhookEventRepository(WebhookEventInterface):
 
         return list(qs.values_list("id", flat=True))
 
-    def bulk_get(self, ids: list[int]) -> list[WebhookEventData]:
+    def bulk_get(self, ids: list[int]) -> list[WebhookInboxData]:
         if len(ids) == 0:
             return []
 
@@ -34,7 +34,7 @@ class WebhookEventRepository(WebhookEventInterface):
         sorted_objs = sort_ids(objs, ids)
         return [convert_data(obj) for obj in sorted_objs]
 
-    def bulk_save(self, objs: list[WebhookEventData]) -> list[int]:
+    def bulk_save(self, objs: list[WebhookInboxData]) -> list[int]:
         if len(objs) == 0:
             return []
 

--- a/myus/api/src/domain/interface/payment/provider/data.py
+++ b/myus/api/src/domain/interface/payment/provider/data.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from api.src.domain.interface.payment.data import Money
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_inbox.data import WebhookInboxData
 from api.utils.enum.i18n import Locale
 from api.utils.enum.payment import CancelError, CheckoutError, PaymentProvider, PaymentType, WebhookVerifyError
 
@@ -58,7 +58,7 @@ type CheckoutResult = CheckoutCreated | CheckoutFailed
 
 @dataclass(frozen=True, slots=True)
 class WebhookVerified:
-    event: WebhookEventData
+    event: WebhookInboxData
 
 
 @dataclass(frozen=True, slots=True)

--- a/myus/api/src/domain/interface/payment/webhook_inbox/data.py
+++ b/myus/api/src/domain/interface/payment/webhook_inbox/data.py
@@ -4,7 +4,7 @@ from api.utils.enum.payment import PaymentProvider, WebhookEventType
 
 
 @dataclass(frozen=True, slots=True)
-class WebhookEventData:
+class WebhookInboxData:
     id: int
     provider: PaymentProvider
     event_id: str

--- a/myus/api/src/domain/interface/payment/webhook_inbox/interface.py
+++ b/myus/api/src/domain/interface/payment/webhook_inbox/interface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, auto
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_inbox.data import WebhookInboxData
 
 
 class SortType(Enum):
@@ -20,15 +20,15 @@ class SortOption:
     sort_type: SortType = SortType.OCCURRED_AT
 
 
-class WebhookEventInterface(ABC):
+class WebhookInboxInterface(ABC):
     @abstractmethod
     def get_ids(self, filter: FilterOption, sort: SortOption, limit: int | None = 20) -> list[int]:
         ...
 
     @abstractmethod
-    def bulk_get(self, ids: list[int]) -> list[WebhookEventData]:
+    def bulk_get(self, ids: list[int]) -> list[WebhookInboxData]:
         ...
 
     @abstractmethod
-    def bulk_save(self, objs: list[WebhookEventData]) -> list[int]:
+    def bulk_save(self, objs: list[WebhookInboxData]) -> list[int]:
         ...

--- a/myus/api/src/injectors/index.py
+++ b/myus/api/src/injectors/index.py
@@ -2,7 +2,7 @@ from injector import Module, provider
 from api.src.adapter.external.payment.stripe.provider import StripeProvider
 from api.src.domain.entity.payment.subscription.repository import SubscriptionRepository
 from api.src.domain.entity.payment.transaction.repository import TransactionRepository
-from api.src.domain.entity.payment.webhook_event.repository import WebhookEventRepository
+from api.src.domain.entity.payment.webhook_inbox.repository import WebhookInboxRepository
 from api.src.domain.entity.user.repository import UserRepository
 from api.src.domain.entity.category.repository import CategoryRepository
 from api.src.domain.entity.channel.repository import ChannelRepository
@@ -42,7 +42,7 @@ from api.src.domain.interface.notification.interface import NotificationInterfac
 from api.src.domain.interface.payment.provider.interface import PaymentInterface
 from api.src.domain.interface.payment.subscription.interface import SubscriptionInterface
 from api.src.domain.interface.payment.transaction.interface import TransactionInterface
-from api.src.domain.interface.payment.webhook_event.interface import WebhookEventInterface
+from api.src.domain.interface.payment.webhook_inbox.interface import WebhookInboxInterface
 
 
 class UserModule(Module):
@@ -157,5 +157,5 @@ class PaymentModule(Module):
         return TransactionRepository()
 
     @provider
-    def provide_webhook_event_repository(self) -> WebhookEventInterface:
-        return WebhookEventRepository()
+    def provide_webhook_event_repository(self) -> WebhookInboxInterface:
+        return WebhookInboxRepository()

--- a/myus/api/src/usecase/payment.py
+++ b/myus/api/src/usecase/payment.py
@@ -2,12 +2,12 @@ from dataclasses import replace
 from api.modules.logger import log
 from api.src.domain.interface.payment.subscription.interface import FilterOption as SubscriptionFilterOption, SortOption as SubscriptionSortOption, SubscriptionInterface
 from api.src.domain.interface.payment.transaction.interface import FilterOption as TransactionFilterOption, SortOption as TransactionSortOption, TransactionInterface
-from api.src.domain.interface.payment.webhook_event.data import WebhookEventData
+from api.src.domain.interface.payment.webhook_inbox.data import WebhookInboxData
 from api.src.injectors.container import injector
 from api.utils.enum.payment import PaymentStatus, SubscriptionStatus, WebhookEventType
 
 
-def handle_webhook_event(event: WebhookEventData) -> None:
+def handle_webhook_event(event: WebhookInboxData) -> None:
     match event.event_type:
         case WebhookEventType.SUBSCRIPTION_CANCELED:
             update_subscription_canceled(event)
@@ -23,7 +23,7 @@ def handle_webhook_event(event: WebhookEventData) -> None:
             log.info("WebhookEvent SUBSCRIPTION_UPDATED noop", external_id=event.external_id)
 
 
-def update_subscription_canceled(event: WebhookEventData) -> None:
+def update_subscription_canceled(event: WebhookInboxData) -> None:
     repo = injector.get(SubscriptionInterface)
     ids = repo.get_ids(
         SubscriptionFilterOption(provider=event.provider.value, external_id=event.external_id),
@@ -40,7 +40,7 @@ def update_subscription_canceled(event: WebhookEventData) -> None:
     log.info("Subscription canceled", external_id=event.external_id)
 
 
-def update_transaction_status(event: WebhookEventData, status: PaymentStatus, update_paid_at: bool) -> None:
+def update_transaction_status(event: WebhookInboxData, status: PaymentStatus, update_paid_at: bool) -> None:
     repo = injector.get(TransactionInterface)
     ids = repo.get_ids(
         TransactionFilterOption(provider=event.provider.value, external_id=event.external_id),


### PR DESCRIPTION
## Summary
- 前 PR #853（フォルダ rename）の後続。`webhook_inbox/` 配下のクラス名と依存ファイルの import path を更新
- 本 PR をマージすることで Inbox/Outbox 命名整理が完結し、Import 解決可能な状態になる

## 変更内容
### Domain 層のクラス rename
- `WebhookEventInterface` → `WebhookInboxInterface`（interface.py）
- `WebhookEventData` → `WebhookInboxData`（data.py）
- `WebhookEventRepository` → `WebhookInboxRepository`（repository.py）
- `_convert.py` の引数型と戻り値型を更新

### 依存ファイルの import path・型参照更新
- `adapter/payment.py`: import path + `injector.get(WebhookInboxInterface)` の型参照
- `adapter/external/payment/stripe/_convert.py`: import path + `convert_stripe_event` の戻り値型と return 文
- `domain/interface/payment/provider/data.py`: import path + `WebhookVerified.event` の型
- `injectors/index.py`: import path + `provide_webhook_event_repository()` の戻り値型・生成インスタンス
- `usecase/payment.py`: import path + `handle_webhook_event` / `update_subscription_canceled` / `update_transaction_status` の引数型

### scope 外（前回と同じ）
- DB model `WebhookEvent` / table `webhook_event` / migration
- enum `WebhookEventType`
- 関数名 `handle_webhook_event`、`provide_webhook_event_repository`、変数 `webhook_event_repo`、定数 `WEBHOOK_EVENT_FIELDS`