### PR TITLE
【front】dangerouslySetInnerHTML に DOMPurify サニタイズを適用

### DIFF
--- a/frontend/src/components/parts/FormatHtml/index.tsx
+++ b/frontend/src/components/parts/FormatHtml/index.tsx
@@ -1,8 +1,10 @@
+import { sanitizeHtml } from 'utils/functions/sanitize'
+
 interface Props {
   content: string
 }
 
 export default function FormatHtml(props: Props): React.JSX.Element {
   const { content } = props
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }} />
 }

--- a/frontend/src/components/widgets/Message/MessageItem/index.tsx
+++ b/frontend/src/components/widgets/Message/MessageItem/index.tsx
@@ -4,6 +4,7 @@ import { ChatMessage } from 'types/internal/message'
 import { UserMe } from 'types/internal/user'
 import cx from 'utils/functions/cx'
 import { formatDatetime } from 'utils/functions/datetime'
+import { sanitizeHtml } from 'utils/functions/sanitize'
 import ActionButton from 'components/parts/Action/Button'
 import { ActionItem } from 'components/parts/Action/List'
 import AvatarLink from 'components/parts/Avatar/Link'
@@ -83,7 +84,7 @@ export default function MessageItem(props: Props): React.JSX.Element {
         {isEdit ? (
           <ChatEditor value={editText} onChange={setEditText} onCancel={handleEditCancel} onSave={handleEditSubmit} />
         ) : (
-          <div className={style.message_text} dangerouslySetInnerHTML={{ __html: message.text }} />
+          <div className={style.message_text} dangerouslySetInnerHTML={{ __html: sanitizeHtml(message.text) }} />
         )}
         {onThread && !isEdit && (
           <div className={style.message_thread_row}>

--- a/frontend/src/components/widgets/Modal/MessageDelete/index.tsx
+++ b/frontend/src/components/widgets/Modal/MessageDelete/index.tsx
@@ -1,5 +1,6 @@
 import { Author } from 'types/internal/user'
 import { formatDatetime } from 'utils/functions/datetime'
+import { sanitizeHtml } from 'utils/functions/sanitize'
 import Avatar from 'components/parts/Avatar'
 import Modal from 'components/parts/Modal'
 import HStack from 'components/parts/Stack/Horizontal'
@@ -38,7 +39,7 @@ export default function MessageDeleteModal(props: Props): React.JSX.Element {
             <span className="mr_4">{author.nickname}</span>
             <time>{formatDatetime(created)}</time>
           </div>
-          <p className={style.text} dangerouslySetInnerHTML={{ __html: text }} />
+          <p className={style.text} dangerouslySetInnerHTML={{ __html: sanitizeHtml(text) }} />
         </div>
       </HStack>
     </Modal>

--- a/frontend/src/utils/functions/sanitize.ts
+++ b/frontend/src/utils/functions/sanitize.ts
@@ -1,0 +1,5 @@
+import DOMPurify from 'isomorphic-dompurify'
+
+export const sanitizeHtml = (html: string): string => {
+  return DOMPurify.sanitize(html)
+}


### PR DESCRIPTION
## Summary
- `dangerouslySetInnerHTML` で HTML を直接描画していた箇所に DOMPurify によるサニタイズを適用し、XSS を防止
- サニタイズ処理を `utils/functions/sanitize.ts` に共通化

## 変更内容
### 新規: `frontend/src/utils/functions/sanitize.ts`
- `isomorphic-dompurify` の `DOMPurify.sanitize` をラップした `sanitizeHtml` 関数を追加

### 適用箇所（3ファイル）
- `components/parts/FormatHtml/index.tsx` — content の描画時にサニタイズ
- `components/widgets/Message/MessageItem/index.tsx` — メッセージ本文の描画時にサニタイズ
- `components/widgets/Modal/MessageDelete/index.tsx` — 削除確認モーダルのメッセージ描画時にサニタイズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)